### PR TITLE
chore: Add Arbitrum to chains, fix BigInt nullish error

### DIFF
--- a/src/modules/application/constants/wagmi.ts
+++ b/src/modules/application/constants/wagmi.ts
@@ -1,11 +1,12 @@
 import { createConfig, http } from 'wagmi';
-import { mainnet, polygon, sepolia } from 'wagmi/chains';
+import { arbitrum, mainnet, polygon, sepolia } from 'wagmi/chains';
 
 export const wagmiConfig = createConfig({
-    chains: [mainnet, sepolia, polygon],
+    chains: [mainnet, sepolia, polygon, arbitrum],
     transports: {
         [mainnet.id]: http(),
         [sepolia.id]: http(),
         [polygon.id]: http(),
+        [arbitrum.id]: http(),
     },
 });

--- a/src/plugins/tokenPlugin/components/tokenMemberList/tokenMemberListItem.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/tokenMemberListItem.tsx
@@ -13,7 +13,7 @@ export const TokenMemberListItem: React.FC<ITokenMemberListItemProps> = (props) 
     const { member } = props;
 
     // TODO: use DAO token decimals (APP-3323)
-    const parsedVotingPower = formatEther(BigInt(member.votingPower));
+    const parsedVotingPower = member?.votingPower != null ? formatEther(BigInt(member.votingPower)) : undefined;
 
     return (
         <MemberDataListItem.Structure


### PR DESCRIPTION
# Description

DAO Explorer is returning Arbitrum DAOs so added the chain so that we can fetch block explorer and other details without error. Also improved handling for null or undefined when use BigInt on voting power.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have tested my code locally.
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] I have selected the correct base branch.
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] Any dependent changes have been merged and published in downstream modules.
