### PR TITLE
fix: Remove <Link> from Member Details first activity timestamp

### DIFF
--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
@@ -175,9 +175,7 @@ export const DaoMemberDetailsPageClient: React.FC<IDaoMemberDetailsPageClientPro
                             <DefinitionList.Item
                                 term={t('app.governance.daoMemberDetailsPage.aside.details.firstActivity')}
                             >
-                                <Link iconRight={IconType.LINK_EXTERNAL} href={addressUrl} target="_blank">
-                                    {formattedFirstActivity}
-                                </Link>
+                                {formattedFirstActivity}
                             </DefinitionList.Item>
                         </DefinitionList.Container>
                     </Page.Section>


### PR DESCRIPTION
# Description

Removes the link wrapper from firstActivity which created link out even on fallback for unknown timestamp.

Task: [APP-3405](https://aragonassociation.atlassian.net/browse/APP-3405)

## Type of Change

<!--- Please delete the options that are not relevant. -->

-   [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

-   [x] I have tested my code locally.
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] I have selected the correct base branch.
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] Any dependent changes have been merged and published in downstream modules.


[APP-3405]: https://aragonassociation.atlassian.net/browse/APP-3405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ