### PR TITLE
fix(APP-3676): Correctly retrieve proposal-id from event logs

### DIFF
--- a/src/modules/governance/dialogs/publishProposalDialog/proposalAbi.ts
+++ b/src/modules/governance/dialogs/publishProposalDialog/proposalAbi.ts
@@ -1,0 +1,46 @@
+export const proposalAbi = [
+    {
+        type: 'event',
+        anonymous: false,
+        inputs: [
+            {
+                name: 'proposalId',
+                internalType: 'uint256',
+                type: 'uint256',
+                indexed: true,
+            },
+            {
+                name: 'creator',
+                internalType: 'address',
+                type: 'address',
+                indexed: true,
+            },
+            {
+                name: 'startDate',
+                internalType: 'uint64',
+                type: 'uint64',
+                indexed: false,
+            },
+            { name: 'endDate', internalType: 'uint64', type: 'uint64', indexed: false },
+            { name: 'metadata', internalType: 'bytes', type: 'bytes', indexed: false },
+            {
+                name: 'actions',
+                internalType: 'struct IDAO.Action[]',
+                type: 'tuple[]',
+                components: [
+                    { name: 'to', internalType: 'address', type: 'address' },
+                    { name: 'value', internalType: 'uint256', type: 'uint256' },
+                    { name: 'data', internalType: 'bytes', type: 'bytes' },
+                ],
+                indexed: false,
+            },
+            {
+                name: 'allowFailureMap',
+                internalType: 'uint256',
+                type: 'uint256',
+                indexed: false,
+            },
+        ],
+        name: 'ProposalCreated',
+    },
+] as const;

--- a/src/modules/governance/dialogs/publishProposalDialog/publishProposalDialogUtils.tsx
+++ b/src/modules/governance/dialogs/publishProposalDialog/publishProposalDialogUtils.tsx
@@ -2,7 +2,7 @@ import type { IDaoPlugin } from '@/shared/api/daoService';
 import type { TransactionDialogPrepareReturn } from '@/shared/components/transactionDialog';
 import { pluginRegistryUtils } from '@/shared/utils/pluginRegistryUtils';
 import { transactionUtils } from '@/shared/utils/transactionUtils';
-import { decodeAbiParameters, type Hex, type TransactionReceipt } from 'viem';
+import { parseEventLogs, type Hex, type TransactionReceipt } from 'viem';
 import type { IProposalAction } from '../../api/governanceService';
 import type {
     ICreateProposalFormData,
@@ -11,6 +11,7 @@ import type {
 } from '../../components/createProposalForm';
 import { GovernanceSlotId } from '../../constants/moduleSlots';
 import type { IBuildCreateProposalDataParams } from '../../types';
+import { proposalAbi } from './proposalAbi';
 
 export interface IBuildTransactionParams {
     /**
@@ -68,13 +69,10 @@ class PublishProposalDialogUtils {
     };
 
     getProposalId = (receipt: TransactionReceipt) => {
-        const proposalIdTopic = receipt.logs[0].topics[1]!;
-        const decodedParams = decodeAbiParameters(
-            [{ name: 'proposalId', internalType: 'uint256', type: 'uint256', indexed: true }],
-            proposalIdTopic,
-        );
+        const { logs } = receipt;
 
-        const decodedProposalId = decodedParams[0].toString();
+        const [proposalCreatedLog] = parseEventLogs({ abi: proposalAbi, eventName: 'ProposalCreated', logs });
+        const decodedProposalId = proposalCreatedLog.args.proposalId.toString();
 
         return decodedProposalId;
     };


### PR DESCRIPTION
# Description

- Properly decode create-proposal event logs and retrieve proposal-created event with new proposal id. This is needed as the admin plugin emits the `executed` event first (see https://sepolia.etherscan.io/tx/0x0c54893f35920ce497653db7fa295872acd702e6010889922986acda84a29935#eventlog)

Task: [APP-3676](https://aragonassociation.atlassian.net/browse/APP-3676)

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have tested my code locally.
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] I have selected the correct base branch.
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] Any dependent changes have been merged and published in downstream modules.


[APP-3676]: https://aragonassociation.atlassian.net/browse/APP-3676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ