### PR TITLE
fix(APP-3626): Fix calculation of max-advance parameter for SPP stages

### DIFF
--- a/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.test.ts
+++ b/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.test.ts
@@ -401,6 +401,19 @@ describe('SppStageUtils', () => {
             expect(sppStageUtils.getStageStatus(proposal, stage)).toBe(ProposalStatus.EXPIRED);
         });
 
+        it('returns accepted when stage has ended, approval is reached, max advance date has passed and stage has already been advanced', () => {
+            const now = '2023-01-01T12:00:00.000Z';
+            const endDate = DateTime.fromISO(now).minus({ days: 3 });
+            const maxAdvance = DateTime.fromISO(now).minus({ days: 1 });
+            const stage = generateSppStage({ stageIndex: 1 });
+            const proposal = generateSppProposal({ stageIndex: 2, settings: { stages: [stage] } });
+            getStageEndDateSpy.mockReturnValue(endDate);
+            getStageMaxAdvanceSpy.mockReturnValue(maxAdvance);
+            isApprovalReachedSpy.mockReturnValue(true);
+            timeUtils.setTime(now);
+            expect(sppStageUtils.getStageStatus(proposal, stage)).toBe(ProposalStatus.ACCEPTED);
+        });
+
         it('returns accepted when stage has ended, approval is reached, max advance date has passed but proposal has no actions and stage is last stage', () => {
             const now = '2023-01-01T12:00:00.000Z';
             const endDate = DateTime.fromISO(now).minus({ days: 3 });

--- a/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.ts
+++ b/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.ts
@@ -40,13 +40,14 @@ class SppStageUtils {
             return canAdvance ? ProposalVotingStatus.ACCEPTED : ProposalVotingStatus.ACTIVE;
         }
 
-        if (approvalReached) {
-            const isExpired = maxAdvanceDate != null && now > maxAdvanceDate && !isSignalingProposal;
-
-            return isExpired ? ProposalVotingStatus.EXPIRED : ProposalVotingStatus.ACCEPTED;
+        if (!approvalReached) {
+            return ProposalVotingStatus.REJECTED;
         }
 
-        return ProposalVotingStatus.REJECTED;
+        const isExpired =
+            maxAdvanceDate != null && now > maxAdvanceDate && !isSignalingProposal && stageIndex === currentStageIndex;
+
+        return isExpired ? ProposalVotingStatus.EXPIRED : ProposalVotingStatus.ACCEPTED;
     };
 
     isStagedUnreached = (proposal: ISppProposal, currentStageIndex: number): boolean => {


### PR DESCRIPTION
# Description

- Max-advance should be calculated based on the `lastStageTransition`, meaning the proposal start-date (see https://github.com/aragon/staged-proposal-processor-plugin/blob/develop/src/StagedProposalProcessor.sol#L673)
- Mark stages as ACCEPTED if mad-advance has passed but stage has already been advanced (`currentStageIndex > stage.stageIndex`)

Task: [APP-3626](https://aragonassociation.atlassian.net/browse/APP-3626)

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have tested my code locally.
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] I have selected the correct base branch.
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] Any dependent changes have been merged and published in downstream modules.


[APP-3626]: https://aragonassociation.atlassian.net/browse/APP-3626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ