### PR TITLE
feat (APP-3657): Trigger E2E tests on correct branch

### DIFF
--- a/.github/workflows/app-e2e-dispatch.yml
+++ b/.github/workflows/app-e2e-dispatch.yml
@@ -14,7 +14,6 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      # Step 1: Load secrets
       - name: Load secrets
         id: load-secrets
         uses: 1password/load-secrets-action@v2.0.0
@@ -24,11 +23,9 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION_BACKUPS_TEMP }}
           GH_APP_QA: op://apikeys_production/gh-app-qa/credential
 
-      # Step 2: Extract branch name
       - name: Extract branch name
         run: echo "BRANCH=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
 
-      # Step 3: Trigger E2E tests in app-qa repository
       - name: Trigger E2E tests in app-qa repository
         env:
           GH_APP_QA: ${{ steps.load-secrets.outputs.GH_APP_QA }}


### PR DESCRIPTION
# Description

E2E tests are now triggered on correct branch/ commit, see image below and [here](https://github.com/aragon/app-qa/actions/runs/11934145960/job/33262657075).

Image
<img width="1590" alt="image" src="https://github.com/user-attachments/assets/82cada58-543d-4387-a1ea-ad2ac1178393">


Task: [APP-3657](https://aragonassociation.atlassian.net/browse/APP-3657)

## Type of Change

<!--- Please delete the options that are not relevant. -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

-   [x] I have tested my code locally.
-   [ ] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] I have selected the correct base branch.
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] Any dependent changes have been merged and published in downstream modules.


[APP-3657]: https://aragonassociation.atlassian.net/browse/APP-3657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ