### PR TITLE
fix: Fix normalisation of plugin-specific actions within SPP context

### DIFF
--- a/src/modules/governance/utils/proposalActionUtils/proposalActionUtils.ts
+++ b/src/modules/governance/utils/proposalActionUtils/proposalActionUtils.ts
@@ -20,18 +20,16 @@ import type { INormalizeActionsParams } from '../../types';
 
 class ProposalActionUtils {
     normalizeActions = (proposal: IProposal, dao: IDao): IGukProposalAction[] => {
-        const normalizedActions = dao.plugins.reduce<IProposalAction[]>((current, plugin) => {
-            const normalizeFunction = pluginRegistryUtils.getSlotFunction<INormalizeActionsParams, IProposalAction[]>({
-                slotId: GovernanceSlotId.GOVERNANCE_PLUGIN_NORMALIZE_ACTIONS,
-                pluginId: plugin.subdomain,
-            });
+        const normalizeFunction = pluginRegistryUtils.getSlotFunction<INormalizeActionsParams, IProposalAction[]>({
+            slotId: GovernanceSlotId.GOVERNANCE_PLUGIN_NORMALIZE_ACTIONS,
+            pluginId: proposal.pluginSubdomain,
+        });
 
-            return normalizeFunction != null
-                ? normalizeFunction({ actions: current, daoId: dao.id, settings: proposal.settings })
-                : current;
-        }, proposal.actions);
+        const pluginNormalizedActions =
+            normalizeFunction?.({ actions: proposal.actions, daoId: dao.id, settings: proposal.settings }) ??
+            proposal.actions;
 
-        return normalizedActions.map((action) => {
+        return pluginNormalizedActions.map((action) => {
             if (this.isWithdrawTokenAction(action)) {
                 return this.normalizeTransferAction(action);
             } else if (this.isUpdateMetadataAction(action)) {

--- a/src/plugins/sppPlugin/hooks/useSppNormalizeActions/index.ts
+++ b/src/plugins/sppPlugin/hooks/useSppNormalizeActions/index.ts
@@ -1,0 +1,1 @@
+export { useSppNormalizeActions, type IUseSppNormalizeActionsParams } from './useMultisigNormalizeActions';

--- a/src/plugins/sppPlugin/hooks/useSppNormalizeActions/useMultisigNormalizeActions.tsx
+++ b/src/plugins/sppPlugin/hooks/useSppNormalizeActions/useMultisigNormalizeActions.tsx
@@ -1,0 +1,25 @@
+import { type IProposalAction } from '@/modules/governance/api/governanceService';
+import { GovernanceSlotId } from '@/modules/governance/constants/moduleSlots';
+import type { INormalizeActionsParams } from '@/modules/governance/types';
+import { pluginRegistryUtils } from '@/shared/utils/pluginRegistryUtils';
+import type { ISppPluginSettings } from '../../types';
+
+export interface IUseSppNormalizeActionsParams extends INormalizeActionsParams<ISppPluginSettings> {}
+
+export const useSppNormalizeActions = (params: IUseSppNormalizeActionsParams) => {
+    const { actions, settings, daoId } = params;
+
+    const sppPlugins = settings.stages.flatMap((stage) => stage.plugins);
+    const normalizedActions = sppPlugins.reduce<IProposalAction[]>((current, plugin) => {
+        const normalizeFunction = pluginRegistryUtils.getSlotFunction<INormalizeActionsParams, IProposalAction[]>({
+            slotId: GovernanceSlotId.GOVERNANCE_PLUGIN_NORMALIZE_ACTIONS,
+            pluginId: plugin.subdomain,
+        });
+
+        return normalizeFunction != null
+            ? normalizeFunction({ actions: current, daoId, settings: plugin.settings })
+            : current;
+    }, actions);
+
+    return normalizedActions;
+};

--- a/src/plugins/sppPlugin/index.ts
+++ b/src/plugins/sppPlugin/index.ts
@@ -6,6 +6,7 @@ import { SppGovernanceInfo } from './components/sppGovernanceInfo';
 import { SppVotingTerminal } from './components/sppVotingTerminal';
 import { plugin } from './constants/plugin';
 import { useSppGovernanceSettings } from './hooks/useSppGovernanceSettings';
+import { useSppNormalizeActions } from './hooks/useSppNormalizeActions';
 import { sppProposalUtils } from './utils/sppProposalUtils';
 import { sppTransactionUtils } from './utils/sppTransactionUtils';
 
@@ -34,6 +35,11 @@ export const initialiseSppPlugin = () => {
             slotId: GovernanceSlotId.GOVERNANCE_BUILD_CREATE_PROPOSAL_DATA,
             pluginId: plugin.id,
             function: sppTransactionUtils.buildCreateProposalData,
+        })
+        .registerSlotFunction({
+            slotId: GovernanceSlotId.GOVERNANCE_PLUGIN_NORMALIZE_ACTIONS,
+            pluginId: plugin.id,
+            function: useSppNormalizeActions,
         })
 
         // Settings module slots


### PR DESCRIPTION
# Description

- As mentioned on Discord, this will currently display the current settings of the plugins instead of the historical one, waiting for backend to set correct settings. But at least this solution fixes the crash and properly encapsulates the spp-specific action-normalisation logic.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have tested my code locally.
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] I have selected the correct base branch.
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] Any dependent changes have been merged and published in downstream modules.
