### PR TITLE
fix(APP-3754): Prevent vote timer from continuing past 0 on SppStageStatus

### DIFF
--- a/src/plugins/sppPlugin/components/sppStageStatus/sppStageStatus.tsx
+++ b/src/plugins/sppPlugin/components/sppStageStatus/sppStageStatus.tsx
@@ -67,6 +67,7 @@ export const SppStageStatus: React.FC<ISppStageStatusProps> = (props) => {
 
     const displayMinAdvanceTime = useDynamicValue({
         callback: () => minAdvanceTime != null && DateTime.now() < minAdvanceTime,
+        enabled: minAdvanceTime != null && displayAdvanceButton,
     });
     const displayMaxAdvanceTime =
         maxAdvanceTime != null && maxAdvanceTime.diffNow('days').days < 90 && !isStageAdvanced;

--- a/src/plugins/sppPlugin/components/sppVotingTerminal/sppVotingTerminalStage.tsx
+++ b/src/plugins/sppPlugin/components/sppVotingTerminal/sppVotingTerminalStage.tsx
@@ -88,7 +88,13 @@ export const SppVotingTerminalStage: React.FC<IProposalVotingTerminalStageProps>
                         </ProposalVoting.BodySummaryListItem>
                     ))}
                 </ProposalVoting.BodySummaryList>
-                {isTimelockStage && <SppVotingTerminalStageTimelock stage={stage} proposal={proposal} />}
+                {isTimelockStage && (
+                    <SppVotingTerminalStageTimelock
+                        stage={stage}
+                        proposal={proposal}
+                        stageStatus={processedStageStatus}
+                    />
+                )}
                 <SppVotingTerminalBodySummaryFooter proposal={proposal} stage={stage} />
             </ProposalVoting.BodySummary>
             {stage.plugins.map((plugin) => (

--- a/src/plugins/sppPlugin/components/sppVotingTerminal/sppVotingTerminalStageTimelock.tsx
+++ b/src/plugins/sppPlugin/components/sppVotingTerminal/sppVotingTerminalStageTimelock.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { CardEmptyState, DateFormat, formatterUtils } from '@aragon/gov-ui-kit';
+import { CardEmptyState, DateFormat, formatterUtils, ProposalVotingStatus } from '@aragon/gov-ui-kit';
 import type { ISppProposal, ISppStage } from '../../types';
 import { sppStageUtils } from '../../utils/sppStageUtils';
 
@@ -12,11 +12,16 @@ export interface ISppVotingTerminalStageTimelockProps {
      * Parent Proposal of the stage.
      */
     proposal: ISppProposal;
+    /**
+     * Status of the stage
+     */
+    stageStatus: ProposalVotingStatus;
 }
 
-const getTimelockInfo = (stage: ISppStage, proposal: ISppProposal) => {
-    const isTimelockActive = stage.stageIndex === proposal.stageIndex;
-    const isTimelockComplete = stage.stageIndex < proposal.stageIndex;
+const getTimelockInfo = (stage: ISppStage, proposal: ISppProposal, stageStatus: ProposalVotingStatus) => {
+    const isTimelockExpired = stageStatus === ProposalVotingStatus.EXPIRED;
+    const isTimelockActive = !isTimelockExpired && stage.stageIndex === proposal.stageIndex;
+    const isTimelockComplete = isTimelockExpired || stage.stageIndex < proposal.stageIndex;
 
     const timelockCompletedDate =
         formatterUtils.formatDate(sppStageUtils.getStageEndDate(proposal, stage), {
@@ -51,11 +56,11 @@ const getTimelockInfo = (stage: ISppStage, proposal: ISppProposal) => {
 };
 
 export const SppVotingTerminalStageTimelock: React.FC<ISppVotingTerminalStageTimelockProps> = (props) => {
-    const { stage, proposal } = props;
+    const { stage, proposal, stageStatus } = props;
 
     const { t } = useTranslations();
 
-    const { heading, description, date } = getTimelockInfo(stage, proposal);
+    const { heading, description, date } = getTimelockInfo(stage, proposal, stageStatus);
 
     return (
         <CardEmptyState


### PR DESCRIPTION
# Description

Fix issue with advance button not becoming enabled when the timer got to 0, instead the timer would count up from 0 until the page was refreshed.

In other setups we are using the status to determine the advance button, so when status changes the advance becomes available. However in timelock stage the status doesn't change, so we need another way to trigger the re-rendering and calculation of what to display.

This change may become redundant once we introduce the new stage and differentiate between accepted and advanceable, but seeing as though we are not sure when that will happen I think we can use this.


Task: [APP-3754](https://aragonassociation.atlassian.net/browse/APP-3754)

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have tested my code locally.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have selected the correct base branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules.


[APP-3754]: https://aragonassociation.atlassian.net/browse/APP-3754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ