### PR TITLE
fix: Fix warnings on NextJs Image component and duplicate React keys on DAO transactions page

### DIFF
--- a/src/modules/finance/components/transactionList/transactionList.tsx
+++ b/src/modules/finance/components/transactionList/transactionList.tsx
@@ -46,11 +46,14 @@ export const TransactionList: React.FC<ITransactionListProps> = (props) => {
                 errorState={errorState}
                 SkeletonElement={TransactionDataListItem.Skeleton}
             >
-                {transactionList?.map((transaction) => (
+                {transactionList?.map((transaction, index) => (
                     <TransactionDataListItem.Structure
+                        // Multiple transactions can have the same transaction hash
+                        // (e.g. one deposit and one withdraw on the same proposal)
+                        key={`${transaction.transactionHash}-${index.toString()}`}
                         chainId={networkDefinitions[transaction.network].chainId}
                         hash={transaction.transactionHash}
-                        key={transaction.transactionHash}
+                        target="_blank"
                         date={transaction.blockTimestamp * 1000}
                         type={transactionTypeToDataListType[transaction.type]}
                         status={TransactionStatus.SUCCESS}

--- a/src/shared/components/image/image.tsx
+++ b/src/shared/components/image/image.tsx
@@ -18,7 +18,12 @@ export interface IImageProps extends Omit<ComponentProps<'img'>, 'width' | 'heig
 }
 
 export const Image: React.FC<IImageProps> = (props) => {
-    const { src = '', alt = 'image', fill = true, ...otherProps } = props;
+    const { src = '', alt = 'image', fill = true, sizes, ...otherProps } = props;
 
-    return <NextImage src={src} fill={fill} alt={alt} {...otherProps} />;
+    // Set a default value to '50vw' for the sizes property (default value required by the Image component from NextJs)
+    // when fill is set to true and sizes property is not set. We currently uses fill set to true for gov-ui-kit images
+    // and these never exceed 50vw.
+    const processedSizes = sizes ?? (fill ? '50vw' : undefined);
+
+    return <NextImage src={src} fill={fill} alt={alt} sizes={processedSizes} {...otherProps} />;
 };


### PR DESCRIPTION
# Description

- Set default `sizes` property for NextJs Image component when `sizes` is not set and `fill` is true;
- Fix duplicate keys warning on TransactionList component

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have tested my code locally.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have selected the correct base branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules.
