### PR TITLE
fix(APP-4010): Force scroll to top when switching steps of a wizard

### DIFF
--- a/src/shared/components/wizards/wizard/wizardStep/wizardStep.tsx
+++ b/src/shared/components/wizards/wizard/wizardStep/wizardStep.tsx
@@ -1,4 +1,3 @@
-import { appUtils } from '@/shared/utils/appUtils';
 import classNames from 'classnames';
 import { useEffect, type ComponentProps } from 'react';
 import { useWizardContext, type IWizardStepperStep } from '../wizardProvider';
@@ -25,7 +24,7 @@ export const WizardStep: React.FC<IWizardStepProps> = (props) => {
 
     useEffect(() => {
         if (activeStep === id) {
-            appUtils.scrollToTop();
+            window.scrollTo(0, 0);
         }
     }, [activeStep, id]);
 

--- a/src/shared/utils/appUtils/appUtils.ts
+++ b/src/shared/utils/appUtils/appUtils.ts
@@ -1,7 +1,0 @@
-class AppUtils {
-    scrollToTop() {
-        window.scrollTo(0, 0);
-    }
-}
-
-export const appUtils = new AppUtils();

--- a/src/shared/utils/appUtils/index.ts
+++ b/src/shared/utils/appUtils/index.ts
@@ -1,1 +1,0 @@
-export { appUtils } from './appUtils';


### PR DESCRIPTION
# Description

Fix opening wizard steps in the middle of the page by implementing scroll to top when switching steps of a wizard.

Task: [APP-4010](https://aragonassociation.atlassian.net/browse/APP-4010)

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing


[APP-4010]: https://aragonassociation.atlassian.net/browse/APP-4010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ