### PR TITLE
WIP feat(APP-4106): Implement useToken hook

### DIFF
--- a/.changeset/public-areas-divide.md
+++ b/.changeset/public-areas-divide.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app-next': patch
+---
+
+Implement useToken hook

--- a/src/plugins/tokenPlugin/hooks/useToken/index.ts
+++ b/src/plugins/tokenPlugin/hooks/useToken/index.ts
@@ -1,0 +1,1 @@
+export { useToken } from './useToken';

--- a/src/plugins/tokenPlugin/hooks/useToken/useToken.test.ts
+++ b/src/plugins/tokenPlugin/hooks/useToken/useToken.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from '@testing-library/react';
+import type { Hash } from 'viem';
+import * as wagmi from 'wagmi';
+import { useToken } from './useToken';
+
+describe('useToken hook', () => {
+    const useReadContractsSpy = jest.spyOn(wagmi, 'useReadContracts');
+
+    afterEach(() => {
+        useReadContractsSpy.mockReset();
+    });
+
+    it('returns token data when successful', () => {
+        const mockReturn = {
+            decimals: 18,
+            name: 'MockToken',
+            symbol: 'MTK',
+            totalSupply: '1000000000000000000',
+        };
+
+        const mockData: [number, string, string, string] = [
+            mockReturn.decimals,
+            mockReturn.name,
+            mockReturn.symbol,
+            mockReturn.totalSupply,
+        ];
+
+        const mockAddress: Hash = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+        useReadContractsSpy.mockReturnValue({
+            data: mockData,
+            error: null,
+            isLoading: false,
+        } as unknown as wagmi.UseReadContractsReturnType<[number, string, string, string], false, unknown>);
+
+        const { result } = renderHook(() => useToken({ address: mockAddress, chainId: 1 }));
+
+        expect(result.current.data).toEqual(mockReturn);
+        expect(result.current.error).toBeNull();
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('returns null data and error when errored', () => {
+        const error = new Error('Something went wrong');
+        const mockAddress: Hash = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+        useReadContractsSpy.mockReturnValue({
+            data: [] as [],
+            error,
+            isLoading: false,
+        } as unknown as wagmi.UseReadContractsReturnType<[], false, unknown>);
+
+        const { result } = renderHook(() => useToken({ address: mockAddress, chainId: 10 }));
+
+        expect(result.current.data).toBeNull();
+        expect(result.current.error).toBe(error);
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('returns null data when loading', () => {
+        const mockAddress: Hash = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
+
+        useReadContractsSpy.mockReturnValue({
+            data: undefined,
+            error: null,
+            isLoading: true,
+        } as unknown as wagmi.UseReadContractsReturnType<[number, string, string, bigint], false, unknown>);
+
+        const { result } = renderHook(() => useToken({ address: mockAddress }));
+
+        expect(result.current.data).toBeNull();
+        expect(result.current.error).toBeNull();
+        expect(result.current.isLoading).toBe(true);
+    });
+});

--- a/src/plugins/tokenPlugin/hooks/useToken/useToken.ts
+++ b/src/plugins/tokenPlugin/hooks/useToken/useToken.ts
@@ -1,0 +1,97 @@
+import type { IToken } from '@/modules/finance/api/financeService';
+
+import { useMemo } from 'react';
+
+import { erc20Abi, type Hash } from 'viem';
+
+import { useReadContracts } from 'wagmi';
+
+import type { ReadContractsErrorType } from 'wagmi/actions';
+
+export interface IUseTokenParams {
+    /**
+
+     * Address of the token contract.
+
+     */
+
+    address: Hash;
+
+    /**
+
+     * Chain ID of the token contract.
+
+     */
+
+    chainId?: number;
+}
+
+export interface IUseTokenReturn extends Pick<IToken, 'decimals' | 'name' | 'symbol' | 'totalSupply'> {}
+
+export interface UseTokenResult {
+    /**
+
+     * Token data result.
+
+     */
+
+    data: IUseTokenReturn | null;
+
+    /**
+
+     * Possible error result.
+
+     */
+
+    error: ReadContractsErrorType | null;
+
+    /**
+
+     * Whether the token data is loading.
+
+     */
+
+    isLoading: boolean;
+}
+
+export const useToken = (params: IUseTokenParams): UseTokenResult => {
+    const { address, chainId = 1 } = params;
+
+    const { data, error, isLoading } = useReadContracts({
+        allowFailure: false,
+
+        contracts: [
+            { chainId, address, abi: erc20Abi, functionName: 'decimals' },
+
+            { chainId, address, abi: erc20Abi, functionName: 'name' },
+
+            { chainId, address, abi: erc20Abi, functionName: 'symbol' },
+
+            { chainId, address, abi: erc20Abi, functionName: 'totalSupply' },
+        ],
+    }) as {
+        data: [number, string, string, bigint] | undefined;
+
+        error: ReadContractsErrorType | null;
+
+        isLoading: boolean;
+    };
+
+    const token = useMemo(() => {
+        if (!data || error) {
+            return null;
+        }
+
+        const [decimals, name, symbol, totalSupply] = data;
+
+        return { name, symbol, decimals, totalSupply: totalSupply.toString() };
+    }, [data, error]);
+
+    return {
+        data: token,
+
+        error,
+
+        isLoading,
+    };
+};


### PR DESCRIPTION
# Description

Implements useToken hook based on readContracts work around from [wagmi useToken deprecation advisory](https://wagmi.sh/react/guides/migrate-from-v1-to-v2#deprecated-usetoken).

Task: [APP-4106](https://aragonassociation.atlassian.net/browse/APP-4106)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing


[APP-4106]: https://aragonassociation.atlassian.net/browse/APP-4106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ