### PR TITLE
fix(APP-4195): Sort member DAOs by blockTimestamp

### DIFF
--- a/.changeset/tender-carrots-drive.md
+++ b/.changeset/tender-carrots-drive.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app-next': patch
+---
+
+Update member DAOs sorting to be sorted by the blockTimestamp

--- a/src/modules/explore/components/exploreDao/exploreDao.tsx
+++ b/src/modules/explore/components/exploreDao/exploreDao.tsx
@@ -35,7 +35,9 @@ export const ExploreDaos: React.FC<IExploreDaosProps> = (props) => {
 
     const daoListParams = daoFilter === 'all' ? initialParams : undefined;
     const daoListMemberParams =
-        daoFilter === 'member' ? { urlParams: { address: address! }, queryParams: { sort: 'blockNumber' } } : undefined;
+        daoFilter === 'member'
+            ? { urlParams: { address: address! }, queryParams: { sort: 'blockTimestamp' } }
+            : undefined;
 
     return (
         <div className="flex grow flex-col gap-3">


### PR DESCRIPTION
# Description

Update member DAOs sorting on Explore page to be sorted by the blockTimestamp.

Member DAOs were already sorted by `blockNumber`, which is different on different chains, so basically only DAOs on the same chain were sorted.

Updated logic to use `blockTimestamp`.

Task: [APP-4195](https://aragonassociation.atlassian.net/browse/APP-4195)

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [x] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [x] Confirmed that changes follow the code style guidelines of this project


[APP-4195]: https://aragonassociation.atlassian.net/browse/APP-4195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ