### PR TITLE
Fix verify smart contract dialog focus

### DIFF
--- a/src/modules/governance/dialogs/verifySmartContractDialog/verifySmartContractDialog.tsx
+++ b/src/modules/governance/dialogs/verifySmartContractDialog/verifySmartContractDialog.tsx
@@ -136,6 +136,7 @@ export const VerifySmartContractDialog: React.FC<IVerifySmartContractDialogProps
             <Dialog.Content description={t('app.governance.verifySmartContractDialog.description')}>
                 <form className="flex flex-col gap-3 py-2" onSubmit={handleSubmit(handleFormSubmit)} id={formId}>
                     <AddressInput
+                        autoFocus
                         placeholder={t('app.finance.transferAssetForm.receiver.placeholder')}
                         value={addressInput}
                         onChange={setAddressInput}
@@ -151,18 +152,19 @@ export const VerifySmartContractDialog: React.FC<IVerifySmartContractDialogProps
                     )}
                 </form>
             </Dialog.Content>
-            <Dialog.Footer
-                primaryAction={{
-                    label: t(`app.governance.verifySmartContractDialog.action.${buttonLabel}`),
-                    type: 'submit',
-                    isLoading: isLoadingAbi,
-                    form: formId,
-                }}
-                secondaryAction={{
-                    label: t('app.governance.verifySmartContractDialog.action.cancel'),
-                    onClick: () => close(),
-                }}
-            />
+                <Dialog.Footer
+                    primaryAction={{
+                        label: t(`app.governance.verifySmartContractDialog.action.${buttonLabel}`),
+                        type: 'submit',
+                        isLoading: isLoadingAbi,
+                        form: formId,
+                    }}
+                    secondaryAction={{
+                        label: t('app.governance.verifySmartContractDialog.action.cancel'),
+                        type: 'button',
+                        onClick: () => close(),
+                    }}
+                />
         </>
     );
 };


### PR DESCRIPTION
## Summary
- focus address input in verify smart contract dialog
- ensure cancel button closes dialog without validating form

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*