### PR TITLE
Update token setup validations

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -1406,6 +1406,9 @@
             },
             "helpText": "The percentage of tokens that vote 'Yes' in support of a proposal, out of all tokens that have voted, must be greater than this value.",
             "label": "Support threshold",
+            "error": {
+              "max": "Support threshold can't be 100%"
+            },
             "tag": {
               "no": "No",
               "yes": "Yes"
@@ -1432,7 +1435,8 @@
               },
               "address": {
                 "label": "Address",
-                "placeholder": "ENS or 0x…"
+                "placeholder": "ENS or 0x…",
+                "duplicate": "Address has already been added"
               },
               "tokens": {
                 "label": "Tokens"
@@ -1444,8 +1448,7 @@
             },
             "symbol": {
               "helpText": "This is the abbreviated ticker of the token. For example: UNI",
-              "label": "Token symbol",
-              "onlyLetters": "Only letters are allowed."
+              "label": "Token symbol"
             }
           },
           "importToken": {

--- a/src/plugins/tokenPlugin/components/tokenSetupGovernance/fields/minParticipationField/minParticipationField.tsx
+++ b/src/plugins/tokenPlugin/components/tokenSetupGovernance/fields/minParticipationField/minParticipationField.tsx
@@ -16,7 +16,7 @@ export interface IMinParticipationFieldProps {
     token: ITokenSetupGovernanceProps['membershipSettings']['token'];
 }
 
-const defaultMinParticipation = 1;
+const defaultMinParticipation = 0;
 
 export const MinParticipationField: React.FC<IMinParticipationFieldProps> = (props) => {
     const { formPrefix, token } = props;
@@ -40,7 +40,7 @@ export const MinParticipationField: React.FC<IMinParticipationFieldProps> = (pro
             label={t('app.plugins.token.tokenSetupGovernance.minParticipation.label')}
             helpText={t('app.plugins.token.tokenSetupGovernance.minParticipation.helpText')}
             valueLabel={`${formattedAmount} ${symbol}`}
-            min={1}
+            min={0}
             total={100}
             defaultValue={defaultMinParticipation}
             prefix="≥"

--- a/src/plugins/tokenPlugin/components/tokenSetupGovernance/fields/supportThresholdField/supportThresholdField.tsx
+++ b/src/plugins/tokenPlugin/components/tokenSetupGovernance/fields/supportThresholdField/supportThresholdField.tsx
@@ -42,6 +42,7 @@ export const SupportThresholdField: React.FC<ISupportThresholdFieldProps> = (pro
             valueLabel={`> ${value.toString()} %`}
             min={1}
             total={100}
+            validate={(v) => v < 100 || t('app.plugins.token.tokenSetupGovernance.supportThreshold.error.max')}
             prefix=">"
             suffix="%"
             alert={alert}

--- a/src/plugins/tokenPlugin/components/tokenSetupMembership/components/tokenSetupMembershipCreateToken/tokenSetupMembershipCreateToken.tsx
+++ b/src/plugins/tokenPlugin/components/tokenSetupMembership/components/tokenSetupMembershipCreateToken/tokenSetupMembershipCreateToken.tsx
@@ -2,7 +2,7 @@ import type { ITokenSetupMembershipForm } from '@/plugins/tokenPlugin/components
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useFormField } from '@/shared/hooks/useFormField';
 import { Button, IconType, InputContainer, InputText } from '@aragon/gov-ui-kit';
-import { useEffect } from 'react';
+import { useEffect, type ChangeEvent } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { parseUnits } from 'viem';
 import { defaultTokenAddress, defaultTokenDecimals } from '../../constants/tokenDefaults';
@@ -45,17 +45,24 @@ export const TokenSetupMembershipCreateToken: React.FC<ITokenSetupMembershipCrea
         rules: { required: true },
     });
 
-    const symbolField = useFormField<ITokenSetupMembershipForm['token'], 'symbol'>('symbol', {
+    const {
+        onChange: onSymbolChange,
+        ...symbolFieldProps
+    } = useFormField<ITokenSetupMembershipForm['token'], 'symbol'>('symbol', {
         label: t('app.plugins.token.tokenSetupMembership.createToken.symbol.label'),
         defaultValue: '',
         trimOnBlur: true,
         fieldPrefix: tokenFormPrefix,
         rules: {
             required: true,
-            validate: (value) =>
-                /^[A-Za-z]+$/.test(value) || t('app.plugins.token.tokenSetupMembership.createToken.symbol.onlyLetters'),
+            pattern: /^[A-Z0-9]+$/,
         },
     });
+
+    const handleSymbolChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const processed = event.target.value.toUpperCase().replace(/[^A-Z0-9]/g, '');
+        onSymbolChange(processed);
+    };
 
     const membersFieldName = `${formPrefix}.members`;
     const {
@@ -91,7 +98,8 @@ export const TokenSetupMembershipCreateToken: React.FC<ITokenSetupMembershipCrea
             <InputText
                 helpText={t('app.plugins.token.tokenSetupMembership.createToken.symbol.helpText')}
                 maxLength={symbolMaxLength}
-                {...symbolField}
+                onChange={handleSymbolChange}
+                {...symbolFieldProps}
             />
             <InputContainer
                 helpText={t('app.plugins.token.tokenSetupMembership.createToken.distribute.helpText')}

--- a/src/shared/components/forms/numberProgressInput/numberProgressInput.api.tsx
+++ b/src/shared/components/forms/numberProgressInput/numberProgressInput.api.tsx
@@ -1,4 +1,5 @@
 import type { IAlertInlineProps, IInputNumberProps, ITagProps } from '@aragon/gov-ui-kit';
+import type { Validate } from 'react-hook-form';
 
 export interface INumberProgressInputProps extends Omit<IInputNumberProps, 'value' | 'alert'> {
     /**
@@ -31,6 +32,21 @@ export interface INumberProgressInputProps extends Omit<IInputNumberProps, 'valu
     thresholdIndicator?: number;
     /**
      * Optional tags to be displayed to the left and right of the progress component. The first tag will be displayed to the left and the second to the right.
-     */
+    */
     tags?: [ITagProps, ITagProps];
+
+    /**
+     * Maximum value allowed for the input.
+     */
+    max?: number;
+
+    /**
+     * Minimum value allowed for the input.
+     */
+    min?: number;
+
+    /**
+     * Custom validation function for the input value.
+     */
+    validate?: Validate<number | undefined, Record<string, number | undefined>>;
 }

--- a/src/shared/components/forms/numberProgressInput/numberProgressInput.tsx
+++ b/src/shared/components/forms/numberProgressInput/numberProgressInput.tsx
@@ -19,6 +19,9 @@ export const NumberProgressInput: React.FC<INumberProgressInputProps> = (props) 
         suffix,
         thresholdIndicator,
         tags,
+        validate,
+        max,
+        min,
         ...otherProps
     } = props;
 
@@ -34,7 +37,7 @@ export const NumberProgressInput: React.FC<INumberProgressInputProps> = (props) 
         ...numberField
     } = useFormField<Record<string, number | undefined>, typeof fieldName>(fieldName, {
         label,
-        rules: { required: true, max: total },
+        rules: { required: true, max: max ?? total, min, validate },
         defaultValue,
     });
 
@@ -59,7 +62,8 @@ export const NumberProgressInput: React.FC<INumberProgressInputProps> = (props) 
                     <InputNumber
                         value={value}
                         className="w-full md:max-w-40"
-                        max={total}
+                        max={max ?? total}
+                        min={min}
                         onChange={(value) => onChange(Number(value))}
                         prefix={prefix}
                         suffix={suffix}


### PR DESCRIPTION
## Summary
- enforce uppercase alphanumeric token symbols
- wrap token amount input on mobile
- prevent duplicate token mint recipients
- disallow support threshold of 100%
- allow 0% minimum participation
- extend `NumberProgressInput` validation
- add translations for new validation messages
- fix symbol field handler and validation types

## Testing
- `yarn type-check` *(fails: Couldn't find the node_modules state file)*