### PR TITLE
Add all proposals tab

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -809,6 +809,9 @@
         "main": {
           "action": "Proposal",
           "title": "Proposals"
+        },
+        "tabs": {
+          "ALL": "All Proposals"
         }
       },
       "efpCard": {

--- a/src/modules/governance/api/governanceService/governanceService.api.ts
+++ b/src/modules/governance/api/governanceService/governanceService.api.ts
@@ -1,7 +1,7 @@
-import type { IPaginatedRequest } from '@/shared/api/aragonBackendService';
+import type { IPaginatedRequest, IOrderedRequest } from '@/shared/api/aragonBackendService';
 import type { IRequestQueryParams, IRequestUrlParams, IRequestUrlQueryParams } from '@/shared/api/httpService';
 
-export interface IGetProposalListQueryParams extends IPaginatedRequest {
+export interface IGetProposalListQueryParams extends IPaginatedRequest, IOrderedRequest {
     /**
      * ID of the Dao to fetch the proposals from.
      */

--- a/src/modules/governance/components/daoProposalList/daoProposalListContainer.test.tsx
+++ b/src/modules/governance/components/daoProposalList/daoProposalListContainer.test.tsx
@@ -36,4 +36,15 @@ describe('<DaoProposalListContainer /> component', () => {
         expect(pluginComponent.dataset.slotid).toEqual(GovernanceSlotId.GOVERNANCE_DAO_PROPOSAL_LIST);
         expect(pluginComponent.dataset.plugins).toEqual(plugins[0].id);
     });
+
+    it('includes the all proposals tab when more than one process plugin exists', () => {
+        const plugins = [
+            generateTabComponentPlugin({ id: 'token', meta: generateDaoPlugin() }),
+            generateTabComponentPlugin({ id: 'multisig', meta: generateDaoPlugin() }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+        render(createTestComponent());
+        const pluginComponent = screen.getByTestId('plugin-component-mock');
+        expect(pluginComponent.dataset.plugins).toEqual('all-proposals');
+    });
 });

--- a/src/modules/governance/components/daoProposalList/daoProposalListContainer.tsx
+++ b/src/modules/governance/components/daoProposalList/daoProposalListContainer.tsx
@@ -3,6 +3,7 @@
 import type { IDaoPlugin } from '@/shared/api/daoService';
 import { type IPluginTabComponentProps, PluginTabComponent } from '@/shared/components/pluginTabComponent';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
+import { useTranslations } from '@/shared/components/translationsProvider';
 import { PluginType } from '@/shared/types';
 import type { NestedOmit } from '@/shared/types/nestedOmit';
 import type { ReactNode } from 'react';
@@ -29,6 +30,8 @@ export interface IDaoProposalListContainerProps
 export const DaoProposalListContainer: React.FC<IDaoProposalListContainerProps> = (props) => {
     const { initialParams, ...otherProps } = props;
 
+    const { t } = useTranslations();
+
     const processPlugins = useDaoPlugins({ daoId: initialParams.queryParams.daoId, type: PluginType.PROCESS });
     const processedPlugins = processPlugins?.map((plugin) => {
         const pluginInitialParams = {
@@ -39,10 +42,26 @@ export const DaoProposalListContainer: React.FC<IDaoProposalListContainerProps> 
         return { ...plugin, props: { initialParams: pluginInitialParams, plugin: plugin.meta } };
     });
 
+    const allProposalsPlugin = processPlugins && processPlugins.length > 1
+        ? [{
+              id: 'all-proposals',
+              uniqueId: 'all-proposals',
+              label: t('app.governance.daoProposalsPage.tabs.ALL'),
+              meta: {} as IDaoPlugin,
+              props: {
+                  initialParams: {
+                      ...initialParams,
+                      queryParams: { ...initialParams.queryParams, pluginAddress: '' },
+                  },
+                  plugin: {} as IDaoPlugin,
+              },
+          }, ...processedPlugins]
+        : processedPlugins;
+
     return (
         <PluginTabComponent
             slotId={GovernanceSlotId.GOVERNANCE_DAO_PROPOSAL_LIST}
-            plugins={processedPlugins}
+            plugins={allProposalsPlugin}
             Fallback={DaoProposalListDefault}
             {...otherProps}
         />

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.test.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.test.tsx
@@ -1,6 +1,7 @@
 import { daoOptions, Network } from '@/shared/api/daoService';
 import { generateDao, generateDaoPlugin } from '@/shared/testUtils';
 import { PluginType } from '@/shared/types';
+import { OrderDirection } from '@/shared/api/aragonBackendService';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import type * as ReactQuery from '@tanstack/react-query';
 import { QueryClient } from '@tanstack/react-query';
@@ -71,6 +72,8 @@ describe('<DaoProposalsPage /> component', () => {
             daoId: expectedDaoId,
             pageSize: daoProposalsCount,
             pluginAddress: bodyPlugin.address,
+            sort: 'blockTimestamp',
+            order: OrderDirection.DESC,
         };
         expect(prefetchInfiniteQuerySpy.mock.calls[0][0].queryKey).toEqual(
             proposalListOptions({ queryParams: memberListParams }).queryKey,

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.tsx
@@ -3,6 +3,7 @@ import { Page } from '@/shared/components/page';
 import { PluginType, type IDaoPageParams } from '@/shared/types';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { QueryClient } from '@tanstack/react-query';
+import { OrderDirection } from '@/shared/api/aragonBackendService';
 import { proposalListOptions } from '../../api/governanceService';
 import { DaoProposalsPageClient } from './daoProposalsPageClient';
 
@@ -28,7 +29,13 @@ export const DaoProposalsPage: React.FC<IDaoProposalsPageProps> = async (props) 
 
     const { address: processPluginAddress } = daoUtils.getDaoPlugins(dao, { type: PluginType.PROCESS })![0];
 
-    const proposalListQueryParams = { daoId, pageSize: daoProposalsCount, pluginAddress: processPluginAddress };
+    const proposalListQueryParams = {
+        daoId,
+        pageSize: daoProposalsCount,
+        pluginAddress: processPluginAddress,
+        sort: 'blockTimestamp',
+        order: OrderDirection.DESC,
+    };
     const proposalListParams = { queryParams: proposalListQueryParams };
     await queryClient.prefetchInfiniteQuery(proposalListOptions(proposalListParams));
 

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.test.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.test.tsx
@@ -86,4 +86,16 @@ describe('<DaoProposalsPageClient /> component', () => {
         expect(createProposalButton).toHaveAttribute('href', testCreateProposalUrl);
         expect(getDaoUrlSpy.mock.calls[0][1]).toEqual(`create/${pluginAddress}/proposal`);
     });
+
+    it('hides the plugin info when the all proposals tab is selected', () => {
+        const plugins = [
+            generateTabComponentPlugin({ meta: generateDaoPlugin() }),
+            generateTabComponentPlugin({ meta: generateDaoPlugin() }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+
+        render(createTestComponent());
+
+        expect(screen.queryByTestId('plugin-info-mock')).not.toBeInTheDocument();
+    });
 });

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.tsx
@@ -34,11 +34,23 @@ export const DaoProposalsPageClient: React.FC<IDaoProposalsPageClientProps> = (p
 
     const { data: dao } = useDao({ urlParams: { id: daoId } });
     const processPlugins = useDaoPlugins({ daoId, type: PluginType.PROCESS })!;
-    const [selectedPlugin, setSelectedPlugin] = useState(processPlugins[0]);
+    const allPlugins =
+        processPlugins.length > 1
+            ? [
+                  {
+                      id: 'all-proposals',
+                      uniqueId: 'all-proposals',
+                      label: t('app.governance.daoProposalsPage.tabs.ALL'),
+                      meta: {} as IDaoPlugin,
+                  },
+                  ...processPlugins,
+              ]
+            : processPlugins;
+    const [selectedPlugin, setSelectedPlugin] = useState(allPlugins[0]);
 
     const buildProposalUrl = (plugin: IDaoPlugin): __next_route_internal_types__.DynamicRoutes =>
         daoUtils.getDaoUrl(dao, `create/${plugin.address}/proposal`)!;
-    const createProposalUrl = buildProposalUrl(selectedPlugin.meta);
+    const createProposalUrl = buildProposalUrl(processPlugins[0].meta);
 
     const handlePermissionGuardSuccess = (plugin?: IDaoPlugin) =>
         router.push(buildProposalUrl(plugin ?? selectedPlugin.meta));
@@ -47,7 +59,7 @@ export const DaoProposalsPageClient: React.FC<IDaoProposalsPageClientProps> = (p
         permissionNamespace: 'proposal',
         slotId: GovernanceSlotId.GOVERNANCE_PERMISSION_CHECK_PROPOSAL_CREATION,
         onSuccess: handlePermissionGuardSuccess,
-        plugin: selectedPlugin.meta,
+        plugin: selectedPlugin.id === 'all-proposals' ? processPlugins[0].meta : selectedPlugin.meta,
         daoId,
     });
 
@@ -83,13 +95,15 @@ export const DaoProposalsPageClient: React.FC<IDaoProposalsPageClientProps> = (p
                 />
             </Page.Main>
             <Page.Aside>
-                <Page.AsideCard title={`${selectedPlugin.label} (${selectedPlugin.meta.slug.toUpperCase()})`}>
-                    <DaoPluginInfo
-                        plugin={selectedPlugin.meta}
-                        daoId={initialParams.queryParams.daoId}
-                        type={PluginType.PROCESS}
-                    />
-                </Page.AsideCard>
+                {selectedPlugin.id !== 'all-proposals' && (
+                    <Page.AsideCard title={`${selectedPlugin.label} (${selectedPlugin.meta.slug.toUpperCase()})`}>
+                        <DaoPluginInfo
+                            plugin={selectedPlugin.meta}
+                            daoId={initialParams.queryParams.daoId}
+                            type={PluginType.PROCESS}
+                        />
+                    </Page.AsideCard>
+                )}
             </Page.Aside>
         </>
     );


### PR DESCRIPTION
## Summary
- show an "All Proposals" tab when multiple governance processes exist
- sort proposal lists by creation timestamp
- skip plugin info when "All Proposals" is selected
- add tests for the new behaviour

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*