### PR TITLE
feat: add 'All Proposals' tab

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -811,6 +811,9 @@
           "title": "Proposals"
         }
       },
+      "allProposalsTab": {
+        "label": "All Proposals"
+      },
       "efpCard": {
         "cta": "View on EFP",
         "followers": "Followers",

--- a/src/modules/governance/components/daoProposalList/daoProposalListContainer.test.tsx
+++ b/src/modules/governance/components/daoProposalList/daoProposalListContainer.test.tsx
@@ -36,4 +36,17 @@ describe('<DaoProposalListContainer /> component', () => {
         expect(pluginComponent.dataset.slotid).toEqual(GovernanceSlotId.GOVERNANCE_DAO_PROPOSAL_LIST);
         expect(pluginComponent.dataset.plugins).toEqual(plugins[0].id);
     });
+
+    it('adds an all proposals tab when multiple process plugins are available', () => {
+        const plugins = [
+            generateTabComponentPlugin({ id: 'token', meta: generateDaoPlugin() }),
+            generateTabComponentPlugin({ id: 'multisig', meta: generateDaoPlugin() }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+
+        render(createTestComponent());
+
+        const pluginComponent = screen.getByTestId('plugin-component-mock');
+        expect(pluginComponent.dataset.plugins).toEqual('all');
+    });
 });

--- a/src/modules/governance/components/daoProposalList/daoProposalListContainer.tsx
+++ b/src/modules/governance/components/daoProposalList/daoProposalListContainer.tsx
@@ -3,6 +3,7 @@
 import type { IDaoPlugin } from '@/shared/api/daoService';
 import { type IPluginTabComponentProps, PluginTabComponent } from '@/shared/components/pluginTabComponent';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
+import { useTranslations } from '@/shared/components/translationsProvider';
 import { PluginType } from '@/shared/types';
 import type { NestedOmit } from '@/shared/types/nestedOmit';
 import type { ReactNode } from 'react';
@@ -29,8 +30,10 @@ export interface IDaoProposalListContainerProps
 export const DaoProposalListContainer: React.FC<IDaoProposalListContainerProps> = (props) => {
     const { initialParams, ...otherProps } = props;
 
+    const { t } = useTranslations();
+
     const processPlugins = useDaoPlugins({ daoId: initialParams.queryParams.daoId, type: PluginType.PROCESS });
-    const processedPlugins = processPlugins?.map((plugin) => {
+    let processedPlugins = processPlugins?.map((plugin) => {
         const pluginInitialParams = {
             ...initialParams,
             queryParams: { ...initialParams.queryParams, pluginAddress: plugin.meta.address },
@@ -38,6 +41,23 @@ export const DaoProposalListContainer: React.FC<IDaoProposalListContainerProps> 
 
         return { ...plugin, props: { initialParams: pluginInitialParams, plugin: plugin.meta } };
     });
+
+    if (processPlugins && processPlugins.length > 1) {
+        const { pluginAddress: _ignored, ...queryParams } =
+            (initialParams.queryParams as IGetProposalListParams['queryParams'] & {
+                pluginAddress?: string;
+            });
+
+        const allInitialParams = { ...initialParams, queryParams };
+        const allTabPlugin = {
+            id: 'all',
+            uniqueId: `all-${initialParams.queryParams.daoId}`,
+            label: t('app.governance.allProposalsTab.label'),
+            meta: {} as IDaoPlugin,
+            props: { initialParams: allInitialParams, plugin: {} as IDaoPlugin },
+        };
+        processedPlugins = [allTabPlugin, ...(processedPlugins ?? [])];
+    }
 
     return (
         <PluginTabComponent

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.test.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.test.tsx
@@ -68,6 +68,18 @@ describe('<DaoProposalsPageClient /> component', () => {
         expect(screen.getByTestId('plugin-info-mock')).toBeInTheDocument();
     });
 
+    it('hides the plugin info when multiple process plugins exist', () => {
+        const plugins = [
+            generateTabComponentPlugin({ meta: generateDaoPlugin() }),
+            generateTabComponentPlugin({ meta: generateDaoPlugin() }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+
+        render(createTestComponent());
+
+        expect(screen.queryByTestId('plugin-info-mock')).not.toBeInTheDocument();
+    });
+
     it('renders the create proposal button with the correct link and label', () => {
         const pluginAddress = '0x082729';
         const initialParams = { queryParams: { daoId: 'test-dao-id', pluginAddress } };

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.tsx
@@ -8,6 +8,7 @@ import { useDialogContext } from '@/shared/components/dialogProvider';
 import { Page } from '@/shared/components/page';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
+import type { ITabComponentPlugin } from '@/shared/components/pluginTabComponent';
 import { PluginType } from '@/shared/types';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { useRouter } from 'next/navigation';
@@ -34,7 +35,19 @@ export const DaoProposalsPageClient: React.FC<IDaoProposalsPageClientProps> = (p
 
     const { data: dao } = useDao({ urlParams: { id: daoId } });
     const processPlugins = useDaoPlugins({ daoId, type: PluginType.PROCESS })!;
-    const [selectedPlugin, setSelectedPlugin] = useState(processPlugins[0]);
+
+    let defaultPlugin: ITabComponentPlugin<IDaoPlugin> = processPlugins[0];
+    if (processPlugins.length > 1) {
+        defaultPlugin = {
+            id: 'all',
+            uniqueId: `all-${daoId}`,
+            label: t('app.governance.allProposalsTab.label'),
+            meta: {} as IDaoPlugin,
+            props: {},
+        };
+    }
+
+    const [selectedPlugin, setSelectedPlugin] = useState(defaultPlugin);
 
     const buildProposalUrl = (plugin: IDaoPlugin): __next_route_internal_types__.DynamicRoutes =>
         daoUtils.getDaoUrl(dao, `create/${plugin.address}/proposal`)!;
@@ -82,15 +95,17 @@ export const DaoProposalsPageClient: React.FC<IDaoProposalsPageClientProps> = (p
                     onValueChange={setSelectedPlugin}
                 />
             </Page.Main>
-            <Page.Aside>
-                <Page.AsideCard title={`${selectedPlugin.label} (${selectedPlugin.meta.slug.toUpperCase()})`}>
-                    <DaoPluginInfo
-                        plugin={selectedPlugin.meta}
-                        daoId={initialParams.queryParams.daoId}
-                        type={PluginType.PROCESS}
-                    />
-                </Page.AsideCard>
-            </Page.Aside>
+            {selectedPlugin.id !== 'all' && (
+                <Page.Aside>
+                    <Page.AsideCard title={`${selectedPlugin.label} (${selectedPlugin.meta.slug.toUpperCase()})`}>
+                        <DaoPluginInfo
+                            plugin={selectedPlugin.meta}
+                            daoId={initialParams.queryParams.daoId}
+                            type={PluginType.PROCESS}
+                        />
+                    </Page.AsideCard>
+                </Page.Aside>
+            )}
         </>
     );
 };


### PR DESCRIPTION
## Summary
- show an "All Proposals" tab when there are multiple processes
- translate label for the new tab
- test that the all proposals tab is added
- default the proposals page to the "All Proposals" tab
- omit plugin info sidebar when the all tab is selected

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*