### PR TITLE
feat: add 'All Proposals' tab

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -811,6 +811,9 @@
           "title": "Proposals"
         }
       },
+      "allProposalsTab": {
+        "label": "All Proposals"
+      },
       "efpCard": {
         "cta": "View on EFP",
         "followers": "Followers",

--- a/src/modules/governance/components/daoProposalList/daoProposalListContainer.test.tsx
+++ b/src/modules/governance/components/daoProposalList/daoProposalListContainer.test.tsx
@@ -36,4 +36,17 @@ describe('<DaoProposalListContainer /> component', () => {
         expect(pluginComponent.dataset.slotid).toEqual(GovernanceSlotId.GOVERNANCE_DAO_PROPOSAL_LIST);
         expect(pluginComponent.dataset.plugins).toEqual(plugins[0].id);
     });
+
+    it('adds an all proposals tab when multiple process plugins are available', () => {
+        const plugins = [
+            generateTabComponentPlugin({ id: 'token', meta: generateDaoPlugin() }),
+            generateTabComponentPlugin({ id: 'multisig', meta: generateDaoPlugin() }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+
+        render(createTestComponent());
+
+        const pluginComponent = screen.getByTestId('plugin-component-mock');
+        expect(pluginComponent.dataset.plugins).toEqual('all');
+    });
 });

--- a/src/modules/governance/components/daoProposalList/daoProposalListContainer.tsx
+++ b/src/modules/governance/components/daoProposalList/daoProposalListContainer.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import type { IDaoPlugin } from '@/shared/api/daoService';
-import { type IPluginTabComponentProps, PluginTabComponent } from '@/shared/components/pluginTabComponent';
+import { type IPluginTabComponentProps, type ITabComponentPlugin, PluginTabComponent } from '@/shared/components/pluginTabComponent';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
+import { useTranslations } from '@/shared/components/translationsProvider';
 import { PluginType } from '@/shared/types';
 import type { NestedOmit } from '@/shared/types/nestedOmit';
 import type { ReactNode } from 'react';
@@ -29,8 +30,10 @@ export interface IDaoProposalListContainerProps
 export const DaoProposalListContainer: React.FC<IDaoProposalListContainerProps> = (props) => {
     const { initialParams, ...otherProps } = props;
 
+    const { t } = useTranslations();
+
     const processPlugins = useDaoPlugins({ daoId: initialParams.queryParams.daoId, type: PluginType.PROCESS });
-    const processedPlugins = processPlugins?.map((plugin) => {
+    let processedPlugins = processPlugins?.map((plugin) => {
         const pluginInitialParams = {
             ...initialParams,
             queryParams: { ...initialParams.queryParams, pluginAddress: plugin.meta.address },
@@ -38,6 +41,17 @@ export const DaoProposalListContainer: React.FC<IDaoProposalListContainerProps> 
 
         return { ...plugin, props: { initialParams: pluginInitialParams, plugin: plugin.meta } };
     });
+
+    if (processPlugins && processPlugins.length > 1) {
+        const allTabPlugin = {
+            id: 'all',
+            uniqueId: `all-${initialParams.queryParams.daoId}`,
+            label: t('app.governance.allProposalsTab.label'),
+            meta: {} as IDaoPlugin,
+            props: { initialParams: initialParams as IGetProposalListParams, plugin: {} as IDaoPlugin },
+        } as ITabComponentPlugin<IDaoPlugin>;
+        processedPlugins = [allTabPlugin, ...(processedPlugins ?? [])];
+    }
 
     return (
         <PluginTabComponent

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.test.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.test.tsx
@@ -77,6 +77,22 @@ describe('<DaoProposalsPage /> component', () => {
         );
     });
 
+    it('prefetches all DAO proposals when multiple process plugins exist', async () => {
+        const dao = generateDao();
+        const plugins = [generateDaoPlugin({ address: '0x1' }), generateDaoPlugin({ address: '0x2' })];
+        fetchQuerySpy.mockResolvedValue(dao);
+        getDaoPluginsSpy.mockReturnValue(plugins);
+        const expectedDaoId = 'test-dao-id';
+        resolveDaoIdSpy.mockResolvedValue(expectedDaoId);
+
+        render(await createTestComponent());
+
+        const queryParams = { daoId: expectedDaoId, pageSize: daoProposalsCount };
+        expect(prefetchInfiniteQuerySpy.mock.calls[0][0].queryKey).toEqual(
+            proposalListOptions({ queryParams }).queryKey,
+        );
+    });
+
     it('renders the page client component', async () => {
         render(await createTestComponent());
         expect(screen.getByTestId('page-client-mock')).toBeInTheDocument();

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.tsx
@@ -3,7 +3,7 @@ import { Page } from '@/shared/components/page';
 import { PluginType, type IDaoPageParams } from '@/shared/types';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { QueryClient } from '@tanstack/react-query';
-import { proposalListOptions } from '../../api/governanceService';
+import { proposalListOptions, type IGetProposalListParams } from '../../api/governanceService';
 import { DaoProposalsPageClient } from './daoProposalsPageClient';
 
 export interface IDaoProposalsPageProps {
@@ -26,10 +26,14 @@ export const DaoProposalsPage: React.FC<IDaoProposalsPageProps> = async (props) 
     const daoParams = { urlParams: daoUrlParams };
     const dao = await queryClient.fetchQuery(daoOptions(daoParams));
 
-    const { address: processPluginAddress } = daoUtils.getDaoPlugins(dao, { type: PluginType.PROCESS })![0];
+    const processPlugins = daoUtils.getDaoPlugins(dao, { type: PluginType.PROCESS })!;
 
-    const proposalListQueryParams = { daoId, pageSize: daoProposalsCount, pluginAddress: processPluginAddress };
-    const proposalListParams = { queryParams: proposalListQueryParams };
+    const proposalListQueryParams =
+        processPlugins.length > 1
+            ? { daoId, pageSize: daoProposalsCount }
+            : { daoId, pageSize: daoProposalsCount, pluginAddress: processPlugins[0].address };
+
+    const proposalListParams = { queryParams: proposalListQueryParams } as unknown as IGetProposalListParams;
     await queryClient.prefetchInfiniteQuery(proposalListOptions(proposalListParams));
 
     return (

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.test.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.test.tsx
@@ -86,4 +86,16 @@ describe('<DaoProposalsPageClient /> component', () => {
         expect(createProposalButton).toHaveAttribute('href', testCreateProposalUrl);
         expect(getDaoUrlSpy.mock.calls[0][1]).toEqual(`create/${pluginAddress}/proposal`);
     });
+
+    it('hides plugin info when multiple plugins exist', () => {
+        const plugins = [
+            generateTabComponentPlugin({ meta: generateDaoPlugin() }),
+            generateTabComponentPlugin({ meta: generateDaoPlugin() }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+
+        render(createTestComponent());
+
+        expect(screen.queryByTestId('plugin-info-mock')).not.toBeInTheDocument();
+    });
 });

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.tsx
@@ -9,6 +9,7 @@ import { Page } from '@/shared/components/page';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
 import { PluginType } from '@/shared/types';
+import type { ITabComponentPlugin } from '@/shared/components/pluginTabComponent';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -34,7 +35,18 @@ export const DaoProposalsPageClient: React.FC<IDaoProposalsPageClientProps> = (p
 
     const { data: dao } = useDao({ urlParams: { id: daoId } });
     const processPlugins = useDaoPlugins({ daoId, type: PluginType.PROCESS })!;
-    const [selectedPlugin, setSelectedPlugin] = useState(processPlugins[0]);
+
+    let defaultPlugin = processPlugins[0];
+    if (processPlugins.length > 1) {
+        defaultPlugin = {
+            id: 'all',
+            uniqueId: `all-${daoId}`,
+            label: t('app.governance.allProposalsTab.label'),
+            meta: {} as IDaoPlugin,
+            props: {} as never,
+        } as ITabComponentPlugin<IDaoPlugin>;
+    }
+    const [selectedPlugin, setSelectedPlugin] = useState(defaultPlugin);
 
     const buildProposalUrl = (plugin: IDaoPlugin): __next_route_internal_types__.DynamicRoutes =>
         daoUtils.getDaoUrl(dao, `create/${plugin.address}/proposal`)!;
@@ -82,15 +94,17 @@ export const DaoProposalsPageClient: React.FC<IDaoProposalsPageClientProps> = (p
                     onValueChange={setSelectedPlugin}
                 />
             </Page.Main>
-            <Page.Aside>
-                <Page.AsideCard title={`${selectedPlugin.label} (${selectedPlugin.meta.slug.toUpperCase()})`}>
-                    <DaoPluginInfo
-                        plugin={selectedPlugin.meta}
-                        daoId={initialParams.queryParams.daoId}
-                        type={PluginType.PROCESS}
-                    />
-                </Page.AsideCard>
-            </Page.Aside>
+            {selectedPlugin.id !== 'all' && (
+                <Page.Aside>
+                    <Page.AsideCard title={`${selectedPlugin.label} (${selectedPlugin.meta.slug.toUpperCase()})`}>
+                        <DaoPluginInfo
+                            plugin={selectedPlugin.meta}
+                            daoId={initialParams.queryParams.daoId}
+                            type={PluginType.PROCESS}
+                        />
+                    </Page.AsideCard>
+                </Page.Aside>
+            )}
         </>
     );
 };


### PR DESCRIPTION
## Summary
- show an "All Proposals" tab when there are multiple processes
- default to the All Proposals tab on page load
- hide plugin info sidebar for the All Proposals tab
- prefetch all proposals when multiple process plugins exist
- tests cover the new behavior

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*