### PR TITLE
fix: default to all proposals when multiple processes

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -811,6 +811,9 @@
           "title": "Proposals"
         }
       },
+      "allProposalsTab": {
+        "label": "All Proposals"
+      },
       "efpCard": {
         "cta": "View on EFP",
         "followers": "Followers",

--- a/src/modules/governance/components/daoProposalList/daoProposalListContainer.test.tsx
+++ b/src/modules/governance/components/daoProposalList/daoProposalListContainer.test.tsx
@@ -36,4 +36,17 @@ describe('<DaoProposalListContainer /> component', () => {
         expect(pluginComponent.dataset.slotid).toEqual(GovernanceSlotId.GOVERNANCE_DAO_PROPOSAL_LIST);
         expect(pluginComponent.dataset.plugins).toEqual(plugins[0].id);
     });
+
+    it('adds an all proposals tab when multiple process plugins are available', () => {
+        const plugins = [
+            generateTabComponentPlugin({ id: 'token', meta: generateDaoPlugin() }),
+            generateTabComponentPlugin({ id: 'multisig', meta: generateDaoPlugin() }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+
+        render(createTestComponent());
+
+        const pluginComponent = screen.getByTestId('plugin-component-mock');
+        expect(pluginComponent.dataset.plugins).toEqual('all');
+    });
 });

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.test.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.test.tsx
@@ -77,6 +77,22 @@ describe('<DaoProposalsPage /> component', () => {
         );
     });
 
+    it('prefetches all proposals when multiple process plugins exist', async () => {
+        const dao = generateDao();
+        const plugins = [generateDaoPlugin({ address: '0x123' }), generateDaoPlugin({ address: '0x456' })];
+        fetchQuerySpy.mockResolvedValue(dao);
+        getDaoPluginsSpy.mockReturnValue(plugins);
+        const expectedDaoId = 'test-dao-id';
+        resolveDaoIdSpy.mockResolvedValue(expectedDaoId);
+
+        render(await createTestComponent());
+
+        const expectedParams = { daoId: expectedDaoId, pageSize: daoProposalsCount };
+        expect(prefetchInfiniteQuerySpy.mock.calls[0][0].queryKey).toEqual(
+            proposalListOptions({ queryParams: expectedParams }).queryKey,
+        );
+    });
+
     it('renders the page client component', async () => {
         render(await createTestComponent());
         expect(screen.getByTestId('page-client-mock')).toBeInTheDocument();

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.tsx
@@ -26,9 +26,12 @@ export const DaoProposalsPage: React.FC<IDaoProposalsPageProps> = async (props) 
     const daoParams = { urlParams: daoUrlParams };
     const dao = await queryClient.fetchQuery(daoOptions(daoParams));
 
-    const { address: processPluginAddress } = daoUtils.getDaoPlugins(dao, { type: PluginType.PROCESS })![0];
+    const processPlugins = daoUtils.getDaoPlugins(dao, { type: PluginType.PROCESS })!;
+    const processPluginAddress = processPlugins.length === 1 ? processPlugins[0].address : undefined;
 
-    const proposalListQueryParams = { daoId, pageSize: daoProposalsCount, pluginAddress: processPluginAddress };
+    const proposalListQueryParams = processPluginAddress
+        ? { daoId, pageSize: daoProposalsCount, pluginAddress: processPluginAddress }
+        : { daoId, pageSize: daoProposalsCount };
     const proposalListParams = { queryParams: proposalListQueryParams };
     await queryClient.prefetchInfiniteQuery(proposalListOptions(proposalListParams));
 

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.test.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.test.tsx
@@ -86,4 +86,16 @@ describe('<DaoProposalsPageClient /> component', () => {
         expect(createProposalButton).toHaveAttribute('href', testCreateProposalUrl);
         expect(getDaoUrlSpy.mock.calls[0][1]).toEqual(`create/${pluginAddress}/proposal`);
     });
+
+    it('hides the plugin info aside when multiple process plugins exist', () => {
+        const plugins = [
+            generateTabComponentPlugin({ id: 'token', meta: generateDaoPlugin() }),
+            generateTabComponentPlugin({ id: 'multisig', meta: generateDaoPlugin() }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+
+        render(createTestComponent());
+
+        expect(screen.queryByTestId('plugin-info-mock')).not.toBeInTheDocument();
+    });
 });

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPageClient.tsx
@@ -34,7 +34,21 @@ export const DaoProposalsPageClient: React.FC<IDaoProposalsPageClientProps> = (p
 
     const { data: dao } = useDao({ urlParams: { id: daoId } });
     const processPlugins = useDaoPlugins({ daoId, type: PluginType.PROCESS })!;
-    const [selectedPlugin, setSelectedPlugin] = useState(processPlugins[0]);
+
+    const hasMultipleProcesses = processPlugins.length > 1;
+    const allTabPlugin = hasMultipleProcesses
+        ? {
+              id: 'all',
+              uniqueId: `all-${daoId}`,
+              label: t('app.governance.allProposalsTab.label'),
+              meta: {} as IDaoPlugin,
+              props: {},
+          }
+        : undefined;
+
+    const [selectedPlugin, setSelectedPlugin] = useState(
+        hasMultipleProcesses ? allTabPlugin! : processPlugins[0],
+    );
 
     const buildProposalUrl = (plugin: IDaoPlugin): __next_route_internal_types__.DynamicRoutes =>
         daoUtils.getDaoUrl(dao, `create/${plugin.address}/proposal`)!;
@@ -82,15 +96,17 @@ export const DaoProposalsPageClient: React.FC<IDaoProposalsPageClientProps> = (p
                     onValueChange={setSelectedPlugin}
                 />
             </Page.Main>
-            <Page.Aside>
-                <Page.AsideCard title={`${selectedPlugin.label} (${selectedPlugin.meta.slug.toUpperCase()})`}>
-                    <DaoPluginInfo
-                        plugin={selectedPlugin.meta}
-                        daoId={initialParams.queryParams.daoId}
-                        type={PluginType.PROCESS}
-                    />
-                </Page.AsideCard>
-            </Page.Aside>
+            {selectedPlugin.meta.slug && (
+                <Page.Aside>
+                    <Page.AsideCard title={`${selectedPlugin.label} (${selectedPlugin.meta.slug.toUpperCase()})`}>
+                        <DaoPluginInfo
+                            plugin={selectedPlugin.meta}
+                            daoId={initialParams.queryParams.daoId}
+                            type={PluginType.PROCESS}
+                        />
+                    </Page.AsideCard>
+                </Page.Aside>
+            )}
         </>
     );
 };


### PR DESCRIPTION
## Summary
- include an "All Proposals" tab when multiple governance processes exist
- prefetch all proposals when there are several process plugins
- start on the "All Proposals" tab in the proposals page
- hide plugin info sidebar when no plugin is selected
- update tests for multiple process plugins

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*