### PR TITLE
Fix plugin name in plugin info

### DIFF
--- a/src/shared/hooks/useDaoPluginInfo/useDaoPluginInfo.ts
+++ b/src/shared/hooks/useDaoPluginInfo/useDaoPluginInfo.ts
@@ -46,7 +46,7 @@ export const useDaoPluginInfo = (params: IUseDaoPluginInfoParams): IDefinitionSe
     const { id: chainId } = networkDefinitions[dao.network];
     const pluginCreationLink = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: transactionHash, chainId });
 
-    const name = daoUtils.getPluginName(plugin.meta);
+    const name = daoUtils.parsePluginSubdomain(plugin.meta.subdomain);
     const pluginLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: address, chainId });
 
     return [


### PR DESCRIPTION
## Description
- use plugin subdomain instead of metadata name in `useDaoPluginInfo`

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project