### PR TITLE
fix: refine token hook

### DIFF
--- a/src/plugins/tokenPlugin/components/tokenSetupMembership/hooks/useToken/useToken.test.ts
+++ b/src/plugins/tokenPlugin/components/tokenSetupMembership/hooks/useToken/useToken.test.ts
@@ -11,27 +11,41 @@ describe('useToken hook', () => {
 
     it('returns token data when successful', () => {
         const mockReturn = { name: 'MockToken', symbol: 'MTK', decimals: 18, totalSupply: '100000000' };
-        const mockData = [mockReturn.name, mockReturn.symbol, mockReturn.decimals, mockReturn.totalSupply];
 
-        useReadContractsSpy.mockReturnValue({
-            data: mockData,
-            isError: null,
-            isLoading: false,
-        } as unknown as wagmi.UseReadContractsReturnType);
+        useReadContractsSpy
+            .mockReturnValueOnce({
+                isError: false,
+                isLoading: false,
+            } as unknown as wagmi.UseReadContractsReturnType)
+            .mockReturnValueOnce({
+                data: [
+                    { status: 'success', result: mockReturn.name },
+                    { status: 'success', result: mockReturn.symbol },
+                    { status: 'success', result: mockReturn.decimals },
+                    { status: 'success', result: mockReturn.totalSupply },
+                ],
+                isError: false,
+                isLoading: false,
+            } as unknown as wagmi.UseReadContractsReturnType);
 
         const { result } = renderHook(() => useToken({ address: '0x111', chainId: 1 }));
 
         expect(result.current.token).toEqual(mockReturn);
-        expect(result.current.isError).toBeNull();
+        expect(result.current.isError).toBe(false);
         expect(result.current.isLoading).toBe(false);
     });
 
     it('returns null data and error when errored', () => {
-        useReadContractsSpy.mockReturnValue({
-            data: [],
-            isError: true,
-            isLoading: false,
-        } as unknown as wagmi.UseReadContractsReturnType);
+        useReadContractsSpy
+            .mockReturnValueOnce({
+                isError: true,
+                isLoading: false,
+            } as unknown as wagmi.UseReadContractsReturnType)
+            .mockReturnValueOnce({
+                data: [],
+                isError: false,
+                isLoading: false,
+            } as unknown as wagmi.UseReadContractsReturnType);
 
         const { result } = renderHook(() => useToken({ address: '0x000', chainId: 42 }));
 
@@ -41,16 +55,21 @@ describe('useToken hook', () => {
     });
 
     it('returns null data when loading', () => {
-        useReadContractsSpy.mockReturnValue({
-            data: undefined,
-            isError: null,
-            isLoading: true,
-        } as unknown as wagmi.UseReadContractsReturnType);
+        useReadContractsSpy
+            .mockReturnValueOnce({
+                isError: false,
+                isLoading: true,
+            } as unknown as wagmi.UseReadContractsReturnType)
+            .mockReturnValueOnce({
+                data: undefined,
+                isError: false,
+                isLoading: false,
+            } as unknown as wagmi.UseReadContractsReturnType);
 
         const { result } = renderHook(() => useToken({ address: '0x123', chainId: 1 }));
 
         expect(result.current.token).toBeNull();
-        expect(result.current.isError).toBeNull();
+        expect(result.current.isError).toBe(false);
         expect(result.current.isLoading).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- make dummy address configurable
- guard token hook against missing metadata
- update token hook tests

## Testing
- `yarn prettify`
- `yarn lint` *(fails: Unsafe argument type errors)*
- `npx jest src/plugins/tokenPlugin/components/tokenSetupMembership/hooks/useToken/useToken.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_683a0b6bf928832eb3a4a4279e68d008