### PR TITLE
fix(APP-4416): Fix formatting of min participation setting value for token-voting plugin

### DIFF
--- a/.changeset/heavy-islands-serve.md
+++ b/.changeset/heavy-islands-serve.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app-next': patch
+---
+
+Fix formatting of min participation setting value for token-voting plugin

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -1559,7 +1559,7 @@
           "holders": "{{count}} token holders",
           "minDurationDefinition": "{{days}} days {{hours}} hours {{minutes}} minutes",
           "minDurationTerm": "Minimum duration",
-          "minParticipationDefinition": "≥ {{minParticipation}}%",
+          "minParticipationDefinition": "≥ {{minParticipation}}",
           "minParticipationTerm": "Minimum participation",
           "supplyTerm": "Supply",
           "supportDefinition": "> {{threshold}}%",

--- a/src/plugins/tokenPlugin/components/tokenProcessBodyField/tokenProcessBodyField.tsx
+++ b/src/plugins/tokenPlugin/components/tokenProcessBodyField/tokenProcessBodyField.tsx
@@ -77,6 +77,10 @@ export const TokenProcessBodyField = (props: ITokenProcessBodyFieldProps) => {
         fallback: '0',
     });
 
+    const formattedMinParticipation = formatterUtils.formatNumber(minParticipation / 100, {
+        format: NumberFormat.PERCENTAGE_LONG,
+    });
+
     const voteChangeLabel = votingMode === DaoTokenVotingMode.VOTE_REPLACEMENT ? 'enabled' : 'disabled';
     const earlyExecutionLabel = votingMode === DaoTokenVotingMode.EARLY_EXECUTION ? 'enabled' : 'disabled';
 
@@ -88,14 +92,9 @@ export const TokenProcessBodyField = (props: ITokenProcessBodyFieldProps) => {
     const { buildEntityUrl } = useBlockExplorer({ chainId: networkDefinitions[dao!.network].id });
 
     const readOnlyTokenProps = {
-        link: {
-            href: buildEntityUrl({ type: ChainEntityType.TOKEN, id: tokenAddress }),
-        },
+        link: { href: buildEntityUrl({ type: ChainEntityType.TOKEN, id: tokenAddress }) },
         copyValue: tokenAddress,
-        description: t('app.plugins.token.tokenMemberInfo.tokenNameAndSymbol', {
-            tokenName: tokenName,
-            tokenSymbol: tokenSymbol,
-        }),
+        description: t('app.plugins.token.tokenMemberInfo.tokenNameAndSymbol', { tokenName, tokenSymbol }),
     };
 
     const contractInfo = useDaoPluginInfo({ daoId, address: body.type === SetupBodyType.EXISTING ? body.address : '' });
@@ -123,14 +122,7 @@ export const TokenProcessBodyField = (props: ITokenProcessBodyFieldProps) => {
             {numberOfMembers! > 0 && (
                 <DefinitionList.Item
                     term={t('app.plugins.token.tokenProcessBodyField.distributionTerm')}
-                    link={
-                        readOnly
-                            ? {
-                                  href: daoUtils.getDaoUrl(dao, 'members'),
-                                  isExternal: false,
-                              }
-                            : undefined
-                    }
+                    link={readOnly ? { href: daoUtils.getDaoUrl(dao, 'members'), isExternal: false } : undefined}
                 >
                     {t('app.plugins.token.tokenProcessBodyField.holders', {
                         count: numberOfMembers,
@@ -147,7 +139,7 @@ export const TokenProcessBodyField = (props: ITokenProcessBodyFieldProps) => {
             </DefinitionList.Item>
             <DefinitionList.Item term={t('app.plugins.token.tokenProcessBodyField.minParticipationTerm')}>
                 {t('app.plugins.token.tokenProcessBodyField.minParticipationDefinition', {
-                    minParticipation: minParticipation,
+                    minParticipation: formattedMinParticipation,
                 })}
             </DefinitionList.Item>
             {!isAdvancedGovernance && (

--- a/src/plugins/tokenPlugin/utils/tokenSettingsUtils/tokenSettingsUtils.test.ts
+++ b/src/plugins/tokenPlugin/utils/tokenSettingsUtils/tokenSettingsUtils.test.ts
@@ -34,14 +34,14 @@ describe('tokenSettings utils', () => {
         });
 
         it('correctly formats and displays the minimum participation', () => {
-            const settings = generateTokenPluginSettings({ minParticipation: 200000 });
+            const settings = generateTokenPluginSettings({ minParticipation: 123456 });
             const result = tokenSettingsUtils.parseSettings({ settings, t: mockTranslations.tMock });
 
             const [, minimumParticipationTerm] = result;
 
             expect(minimumParticipationTerm.term).toMatch(/tokenGovernanceSettings.minimumParticipation/);
             expect(minimumParticipationTerm.definition).toMatch(
-                /tokenGovernanceSettings.participation \(participation=20%,tokenValue=0,tokenSymbol=ETH\)/,
+                /tokenGovernanceSettings.participation \(participation=12\.35%,tokenValue=0,tokenSymbol=ETH\)/,
             );
         });
 
@@ -56,7 +56,7 @@ describe('tokenSettings utils', () => {
 
             expect(minimumParticipationTerm.term).toMatch(/tokenGovernanceSettings.minimumParticipation/);
             expect(minimumParticipationTerm.definition).toMatch(
-                /tokenGovernanceSettings.participation \(participation=20%,tokenValue=400,tokenSymbol=ETH\)/,
+                /tokenGovernanceSettings.participation \(participation=20\.00%,tokenValue=400,tokenSymbol=ETH\)/,
             );
         });
 

--- a/src/plugins/tokenPlugin/utils/tokenSettingsUtils/tokenSettingsUtils.tsx
+++ b/src/plugins/tokenPlugin/utils/tokenSettingsUtils/tokenSettingsUtils.tsx
@@ -55,7 +55,7 @@ class TokenSettingsUtils {
 
         const parsedMinParticipation = this.ratioToPercentage(minParticipation);
         const formattedMinParticipation = formatterUtils.formatNumber(parsedMinParticipation / 100, {
-            format: NumberFormat.PERCENTAGE_SHORT,
+            format: NumberFormat.PERCENTAGE_LONG,
         });
 
         const minParticipationToken = Math.round((Number(processedTotalSupply) * parsedMinParticipation) / 100);


### PR DESCRIPTION
# Description

As specified on the ticket, we decided to use the same formatting for the token-body-field and token-settings. Updated both the utilities to use `PERCENTAGE_LONG` as format.

Task: [APP-4416](https://aragonassociation.atlassian.net/browse/APP-4416)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [x] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [x] Confirmed that changes follow the code style guidelines of this project


[APP-4416]: https://aragonassociation.atlassian.net/browse/APP-4416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ