### PR TITLE
fix: correct `actions` type in `ICreateProposalFormData`

### DIFF
--- a/src/modules/governance/pages/createProposalPage/createProposalPageClientSteps.tsx
+++ b/src/modules/governance/pages/createProposalPage/createProposalPageClientSteps.tsx
@@ -40,7 +40,7 @@ export const CreateProposalPageClientSteps: React.FC<ICreateProposalPageClientSt
     const { trigger } = useFormContext();
 
     const addActions = useWatch<ICreateProposalFormData>({ name: 'addActions' });
-    const actions = useWatch<Record<string, ICreateProposalFormData['actions']>>({ name: 'actions' });
+    const actions = useWatch<ICreateProposalFormData['actions']>({ name: 'actions' });
     const { prepareActions } = useCreateProposalFormContext();
 
     const [metadataStep, actionsStep, settingsStep] = steps;


### PR DESCRIPTION
# Description

`actions` in `ICreateProposalFormData` is actually an array, not an object.
the old `Record<string, ...>` type was incorrect and could cause runtime errors when accessing `actions.length`.
this change updates the type to match the real structure and prevents potential bugs.

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

* [x] Manually smoke tested the functionality locally
* [x] Confirmed there are no new warnings or errors in the browser console
* [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
* [x] Confirmed there are no new warnings on automated tests
* [ ] Merged and published any dependent changes in downstream modules
* [x] Selected the correct base branch
* [x] Commented the code in hard-to-understand areas
* [x] Followed the code style guidelines of this project
* [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
* [x] Confirmed the pipeline checks are not failing

## Review Checklist:

* [x] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
* [x] Confirmed that changes follow the code style guidelines of this project