### PR TITLE
feat: Implement support for adding custom plugin pages to the left and right

### DIFF
--- a/src/modules/application/components/navigations/navigationDao/navigationDaoUtils.ts
+++ b/src/modules/application/components/navigations/navigationDao/navigationDaoUtils.ts
@@ -12,9 +12,9 @@ class NavigationDaoUtils {
         const baseUrl = daoUtils.getDaoUrl(dao)!;
 
         const defaultLinks = this.getDefaultLinks(dao, baseUrl, context);
-        const pluginLinks = this.getPluginLinks(dao, baseUrl, context);
+        const { left, right } = this.getPluginLinks(dao, baseUrl, context);
 
-        return defaultLinks.concat(pluginLinks);
+        return [...left, ...defaultLinks, ...right];
     };
 
     private getDefaultLinks = (dao: IDao, baseUrl: string, context: NavigationDaoContext): INavigationLink[] => {
@@ -65,13 +65,20 @@ class NavigationDaoUtils {
         ];
     };
 
-    private getPluginLinks = (dao: IDao, baseUrl: string, context: NavigationDaoContext): INavigationLink[] => {
-        const pluginLinks = dao.plugins.reduce<INavigationLink[]>((current, plugin) => {
-            const pluginInfo = pluginRegistryUtils.getPlugin(plugin.interfaceType) as IPluginInfo | undefined;
-            const pluginPages = pluginInfo?.pages?.(baseUrl, context) ?? [];
+    private getPluginLinks = (dao: IDao, baseUrl: string, context: NavigationDaoContext) => {
+        const pluginLinks = dao.plugins.reduce<{ left: INavigationLink[]; right: INavigationLink[] }>(
+            (current, plugin) => {
+                const pluginInfo = pluginRegistryUtils.getPlugin(plugin.interfaceType) as IPluginInfo | undefined;
+                const pluginPagesLeft = pluginInfo?.pageLinksLeft?.(baseUrl, context) ?? [];
+                const pluginPagesRight = pluginInfo?.pageLinksRight?.(baseUrl, context) ?? [];
 
-            return current.concat(pluginPages);
-        }, []);
+                return {
+                    left: current.left.concat(pluginPagesLeft),
+                    right: current.right.concat(pluginPagesRight),
+                };
+            },
+            { left: [], right: [] },
+        );
 
         return pluginLinks;
     };

--- a/src/plugins/capitalDistributorPlugin/constants/capitalDistributorPlugin.ts
+++ b/src/plugins/capitalDistributorPlugin/constants/capitalDistributorPlugin.ts
@@ -24,7 +24,7 @@ export const capitalDistributorPlugin: IPluginInfo = {
         [Network.CORN_MAINNET]: '0x0000000000000000000000000000000000000000',
         [Network.CHILIZ_MAINNET]: '0x0000000000000000000000000000000000000000',
     },
-    pages: (baseUrl, context) => [
+    pageLinksRight: (baseUrl, context) => [
         {
             label: 'app.plugins.capitalDistributor.meta.link.rewards',
             link: `${baseUrl}/${CapitalDistributorPluginPages.REWARDS}`,

--- a/src/plugins/gaugeVoterPlugin/constants/gaugeVoterPlugin.ts
+++ b/src/plugins/gaugeVoterPlugin/constants/gaugeVoterPlugin.ts
@@ -24,7 +24,7 @@ export const gaugeVoterPlugin: IPluginInfo = {
         [Network.CORN_MAINNET]: '0x0000000000000000000000000000000000000000',
         [Network.CHILIZ_MAINNET]: '0x0000000000000000000000000000000000000000',
     },
-    pages: (baseUrl, context) => [
+    pageLinksLeft: (baseUrl, context) => [
         {
             label: 'app.plugins.gaugeVoter.meta.link.gauges',
             link: `${baseUrl}/${GaugeVoterPluginPages.GAUGES}`,

--- a/src/shared/types/pluginInfo.ts
+++ b/src/shared/types/pluginInfo.ts
@@ -23,11 +23,11 @@ export interface IPluginInfo extends IPlugin {
      */
     setup?: IPluginInfoSetup;
     /**
-     * Plugin-specific pages shown on the DAO navigation, on left to existing nav links.
+     * Plugin-specific pages shown on the DAO navigation, on the left to the existing nav links.
      */
     pageLinksLeft?: (baseUrl: string, context: string) => INavigationLink[];
     /**
-     * Plugin-specific pages shown on the DAO navigation, on right to existing nav links.
+     * Plugin-specific pages shown on the DAO navigation, on the right to the existing nav links.
      */
     pageLinksRight?: (baseUrl: string, context: string) => INavigationLink[];
 }

--- a/src/shared/types/pluginInfo.ts
+++ b/src/shared/types/pluginInfo.ts
@@ -23,7 +23,11 @@ export interface IPluginInfo extends IPlugin {
      */
     setup?: IPluginInfoSetup;
     /**
-     * Plugin-specific pages shown on the DAO navigation.
+     * Plugin-specific pages shown on the DAO navigation, on left to existing nav links.
      */
-    pages?: (baseUrl: string, context: string) => INavigationLink[];
+    pageLinksLeft?: (baseUrl: string, context: string) => INavigationLink[];
+    /**
+     * Plugin-specific pages shown on the DAO navigation, on right to existing nav links.
+     */
+    pageLinksRight?: (baseUrl: string, context: string) => INavigationLink[];
 }


### PR DESCRIPTION
# Description

Custom plugin pages nav links are always added to the right. Add option to choose if link should be added to the left or to the right of default nav links.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
