### PR TITLE
fix: Update token voting repo address which was wrong

### DIFF
--- a/.changeset/new-chains-upset.md
+++ b/.changeset/new-chains-upset.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app': patch
+---
+
+Fix token voting repo address on Avalanche

--- a/src/plugins/tokenPlugin/constants/tokenPlugin.ts
+++ b/src/plugins/tokenPlugin/constants/tokenPlugin.ts
@@ -24,7 +24,7 @@ export const tokenPlugin: IPluginInfo = {
         [Network.OPTIMISM_MAINNET]: '0x666bFa1c64c40faEE8582496B040AAE35E25c19d',
         [Network.CORN_MAINNET]: '0x67C579fC2676a496DCE7dAB9695D323219d339EB',
         [Network.CHILIZ_MAINNET]: '0x62c82a443692A1bE4D0421b1E4678F0dff8F3c1B',
-        [Network.AVAX_MAINNET]: '0xb7401cD221ceAFC54093168B814Cc3d42579287f',
+        [Network.AVAX_MAINNET]: '0xf56e330a183cABaC0b082b1a318F2c7ba66fe4d6',
     },
     setup: {
         nameKey: 'app.plugins.token.meta.setup.name',


### PR DESCRIPTION
# Description

For some reason this address was wrong. Just updated it from the artifacts.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
