### PR TITLE
feat(APP-249): Integrate chainId into address input components

### DIFF
--- a/.changeset/three-places-take.md
+++ b/.changeset/three-places-take.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app': patch
+---
+
+Integrate chainId into address input components

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@aragon/gov-ui-kit": "^1.22.0",
+    "@aragon/gov-ui-kit": "^1.23.0",
     "@floating-ui/react": "^0.27.16",
     "@number-flow/react": "^0.5.10",
     "@radix-ui/react-dialog": "1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@aragon/gov-ui-kit':
-        specifier: ^1.22.0
-        version: 1.22.0(@emotion/is-prop-valid@1.4.0)(@floating-ui/dom@1.7.4)(@tailwindcss/typography@0.5.19(tailwindcss@4.1.14))(@tanstack/react-query@5.90.5(react@19.2.0))(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react-hook-form@7.65.0(react@19.2.0))(react@19.2.0)(tailwindcss@4.1.14)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4))(wagmi@2.18.1(@tanstack/query-core@5.90.5)(@tanstack/react-query@5.90.5(react@19.2.0))(@types/react@19.2.2)(@vercel/blob@1.0.2)(bufferutil@4.0.9)(immer@10.1.3)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))
+        specifier: ^1.23.0
+        version: 1.23.0(@emotion/is-prop-valid@1.4.0)(@floating-ui/dom@1.7.4)(@tailwindcss/typography@0.5.19(tailwindcss@4.1.14))(@tanstack/react-query@5.90.5(react@19.2.0))(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react-hook-form@7.65.0(react@19.2.0))(react@19.2.0)(tailwindcss@4.1.14)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4))(wagmi@2.18.1(@tanstack/query-core@5.90.5)(@tanstack/react-query@5.90.5(react@19.2.0))(@types/react@19.2.2)(@vercel/blob@1.0.2)(bufferutil@4.0.9)(immer@10.1.3)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))
       '@floating-ui/react':
         specifier: ^0.27.16
         version: 0.27.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -238,9 +238,9 @@ packages:
   '@apm-js-collab/tracing-hooks@0.3.1':
     resolution: {integrity: sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==}
 
-  '@aragon/gov-ui-kit@1.22.0':
-    resolution: {integrity: sha512-hXEYDNbPtY3VAckJa+I6yY9P9mOj0dQ5K//0hCXGfeb/AZ87OWy/GgkfZo94miylnKdbKaKNj1BzPmPyT+u1qQ==}
-    engines: {node: '>=22.0.0'}
+  '@aragon/gov-ui-kit@1.23.0':
+    resolution: {integrity: sha512-OSnmcYeIT5Wt9aRc1YnTP+J/G4CplIlh7V17nLDpnqV34qwrAdN8XyA/Aj/d6V354fRUoKItSBOIYq/qPAdX2g==}
+    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
       '@tailwindcss/typography': ^0.5.0
       '@tanstack/react-query': ^5.90.0
@@ -7765,7 +7765,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@aragon/gov-ui-kit@1.22.0(@emotion/is-prop-valid@1.4.0)(@floating-ui/dom@1.7.4)(@tailwindcss/typography@0.5.19(tailwindcss@4.1.14))(@tanstack/react-query@5.90.5(react@19.2.0))(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react-hook-form@7.65.0(react@19.2.0))(react@19.2.0)(tailwindcss@4.1.14)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4))(wagmi@2.18.1(@tanstack/query-core@5.90.5)(@tanstack/react-query@5.90.5(react@19.2.0))(@types/react@19.2.2)(@vercel/blob@1.0.2)(bufferutil@4.0.9)(immer@10.1.3)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))':
+  '@aragon/gov-ui-kit@1.23.0(@emotion/is-prop-valid@1.4.0)(@floating-ui/dom@1.7.4)(@tailwindcss/typography@0.5.19(tailwindcss@4.1.14))(@tanstack/react-query@5.90.5(react@19.2.0))(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react-hook-form@7.65.0(react@19.2.0))(react@19.2.0)(tailwindcss@4.1.14)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4))(wagmi@2.18.1(@tanstack/query-core@5.90.5)(@tanstack/react-query@5.90.5(react@19.2.0))(@types/react@19.2.2)(@vercel/blob@1.0.2)(bufferutil@4.0.9)(immer@10.1.3)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))':
     dependencies:
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -7792,6 +7792,7 @@ snapshots:
       blockies-ts: 1.0.0
       classnames: 2.5.1
       framer-motion: 12.23.24(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      imask: 7.6.1
       luxon: 3.7.2
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)

--- a/src/modules/createDao/dialogs/setupBodyDialog/setupBodySialogExternalAddress/setupBodyDialogExternalAddress.tsx
+++ b/src/modules/createDao/dialogs/setupBodyDialog/setupBodySialogExternalAddress/setupBodyDialogExternalAddress.tsx
@@ -4,6 +4,7 @@ import {
     TransactionStatus,
 } from '@/shared/components/transactionStatus';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { useFormField } from '@/shared/hooks/useFormField';
 import { useIsSafeContract } from '@/shared/hooks/useIsSafeContract';
 import { daoUtils } from '@/shared/utils/daoUtils';
@@ -24,6 +25,7 @@ export const SetupBodyDialogExternalAddress: React.FC<ISetupBodyDialogExternalAd
     const { daoId } = props;
     const { network } = daoUtils.parseDaoId(daoId);
     const { t } = useTranslations();
+    const { id: chainId } = networkDefinitions[network];
 
     const { setValue } = useFormContext<ISetupBodyForm>();
 
@@ -85,6 +87,7 @@ export const SetupBodyDialogExternalAddress: React.FC<ISetupBodyDialogExternalAd
                 value={addressInput}
                 onChange={setAddressInput}
                 onAccept={handleAddressAccept}
+                chainId={chainId}
                 {...addressField}
             />
             {value && (

--- a/src/modules/finance/components/transferAssetForm/transferAssetForm.tsx
+++ b/src/modules/finance/components/transferAssetForm/transferAssetForm.tsx
@@ -1,6 +1,7 @@
 import { AssetInput, type IAssetInputFormData, type IAssetInputProps } from '@/modules/finance/components/assetInput';
 import type { Network } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { useFormField } from '@/shared/hooks/useFormField';
 import { AddressInput, addressUtils } from '@aragon/gov-ui-kit';
 import classNames from 'classnames';
@@ -39,6 +40,7 @@ export const TransferAssetForm: React.FC<ITransferAssetFormProps> = (props) => {
     const [receiverInput, setReceiverInput] = useState<string | undefined>(value?.address);
 
     const fetchAssetsParams = { queryParams: { address: sender, network } };
+    const { id: chainId } = networkDefinitions[network];
 
     return (
         <div className={classNames('flex w-full flex-col', { 'gap-6': !assetValue })}>
@@ -53,6 +55,7 @@ export const TransferAssetForm: React.FC<ITransferAssetFormProps> = (props) => {
                 value={receiverInput}
                 onChange={setReceiverInput}
                 onAccept={onReceiverChange}
+                chainId={chainId}
                 {...receiverField}
             />
         </div>

--- a/src/modules/governance/dialogs/verifySmartContractDialog/verifySmartContractDialog.tsx
+++ b/src/modules/governance/dialogs/verifySmartContractDialog/verifySmartContractDialog.tsx
@@ -6,6 +6,7 @@ import {
     type ITransactionStatusStepMeta,
 } from '@/shared/components/transactionStatus';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { useFormField } from '@/shared/hooks/useFormField';
 import type { IStepperStep } from '@/shared/utils/stepperUtils';
 import { AddressInput, addressUtils, Dialog, invariant, type ICompositeAddress } from '@aragon/gov-ui-kit';
@@ -48,6 +49,7 @@ export const VerifySmartContractDialog: React.FC<IVerifySmartContractDialogProps
 
     invariant(location.params != null, 'VerifySmartContractDialog: params must be defined.');
     const { network, onSubmit, initialValue = '' } = location.params;
+    const { id: chainId } = networkDefinitions[network];
 
     const { t } = useTranslations();
     const { close } = useDialogContext();
@@ -141,6 +143,7 @@ export const VerifySmartContractDialog: React.FC<IVerifySmartContractDialogProps
                         value={addressInput}
                         onChange={setAddressInput}
                         onAccept={onSmartContractChange}
+                        chainId={chainId}
                         {...smartContractField}
                     />
                     {smartContractValue?.address != null && (

--- a/src/plugins/adminPlugin/dialogs/adminManageMembersDialog/adminManageMembersDialog.tsx
+++ b/src/plugins/adminPlugin/dialogs/adminManageMembersDialog/adminManageMembersDialog.tsx
@@ -7,6 +7,7 @@ import { PluginInterfaceType, useDao } from '@/shared/api/daoService';
 import { useDialogContext, type IDialogComponentProps } from '@/shared/components/dialogProvider';
 import { AddressesInput } from '@/shared/components/forms/addressesInput';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
 import { addressUtils, Dialog, invariant, type ICompositeAddress } from '@aragon/gov-ui-kit';
 import { useEffect, useMemo } from 'react';
@@ -47,6 +48,7 @@ export const AdminManageMembersDialog: React.FC<IAdminManageMembersDialogProps> 
 
     const { data: dao } = useDao({ urlParams: { id: daoId } });
     invariant(dao != null, 'ManageAdminsDialogPublish: DAO data must be set.');
+    const { id: chainId } = networkDefinitions[dao.network];
 
     // TODO: (APP-4045). Setting this to the max pageSize of 50 for now to ensure we get all of the data
     // in the future we should find a better way to handle this.
@@ -116,7 +118,7 @@ export const AdminManageMembersDialog: React.FC<IAdminManageMembersDialogProps> 
                 >
                     <AddressesInput.Container name="members" allowEmptyList={true}>
                         {watchMembersField.map((field, index) => (
-                            <AddressesInput.Item key={index} index={index} />
+                            <AddressesInput.Item key={index} index={index} chainId={chainId} />
                         ))}
                     </AddressesInput.Container>
                 </form>

--- a/src/plugins/multisigPlugin/components/multisigSetupMembership/components/multisigSetupMembershipItem.tsx
+++ b/src/plugins/multisigPlugin/components/multisigSetupMembership/components/multisigSetupMembershipItem.tsx
@@ -1,6 +1,7 @@
 import { useMemberExists } from '@/modules/governance/api/governanceService';
 import type { Network } from '@/shared/api/daoService';
 import { AddressesInput } from '@/shared/components/forms/addressesInput';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { addressUtils, type ICompositeAddress } from '@aragon/gov-ui-kit';
 
 export interface IMultisigSetupMembershipItemProps {
@@ -32,6 +33,7 @@ export interface IMultisigSetupMembershipItemProps {
 
 export const MultisigSetupMembershipItem: React.FC<IMultisigSetupMembershipItemProps> = (props) => {
     const { disabled, index, pluginAddress, member, network } = props;
+    const chainId = network ? networkDefinitions[network].id : undefined;
 
     const memberExistsParams = {
         urlParams: { memberAddress: member.address, pluginAddress: pluginAddress! },
@@ -45,5 +47,7 @@ export const MultisigSetupMembershipItem: React.FC<IMultisigSetupMembershipItemP
 
     const customValidator = () => (isMember ? 'app.plugins.multisig.multisigSetupMembership.item.alreadyMember' : true);
 
-    return <AddressesInput.Item index={index} disabled={disabled} customValidator={customValidator} />;
+    return (
+        <AddressesInput.Item index={index} disabled={disabled} customValidator={customValidator} chainId={chainId} />
+    );
 };

--- a/src/plugins/tokenPlugin/components/tokenActions/tokenMintTokensAction/tokenMintTokensAction.tsx
+++ b/src/plugins/tokenPlugin/components/tokenActions/tokenMintTokensAction/tokenMintTokensAction.tsx
@@ -41,7 +41,7 @@ const mintTokensAbi = {
 };
 
 export const TokenMintTokensAction: React.FC<ITokenMintTokensActionProps> = (props) => {
-    const { index, action } = props;
+    const { index, action, chainId } = props;
 
     const { t } = useTranslations();
 
@@ -97,6 +97,7 @@ export const TokenMintTokensAction: React.FC<ITokenMintTokensActionProps> = (pro
                 value={receiverInput}
                 onChange={setReceiverInput}
                 onAccept={onReceiverChange}
+                chainId={chainId}
                 {...receiverField}
             />
             <InputNumber

--- a/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenDelegation/tokenDelegationForm.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenDelegation/tokenDelegationForm.tsx
@@ -5,6 +5,7 @@ import { useTokenCurrentDelegate } from '@/plugins/tokenPlugin/hooks/useTokenCur
 import { useDao } from '@/shared/api/daoService';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { useFormField } from '@/shared/hooks/useFormField';
 import {
     AddressInput,
@@ -30,6 +31,7 @@ export const TokenDelegationForm: React.FC<ITokenDelegationFormProps> = (props) 
     const { t } = useTranslations();
     const { address } = useAccount();
     const { data: dao } = useDao({ urlParams: { id: daoId } });
+    const chainId = dao ? networkDefinitions[dao.network].id : undefined;
 
     const { data: currentDelegate, isLoading: isCurrentDelegateLoading } = useTokenCurrentDelegate({
         userAddress: address,
@@ -125,6 +127,7 @@ export const TokenDelegationForm: React.FC<ITokenDelegationFormProps> = (props) 
                 onChange={setDelegateInput}
                 onAccept={handleDelegateChange}
                 disabled={selectionValue === TokenDelegationSelection.YOURSELF}
+                chainId={chainId}
                 {...delegateField}
             />
             <div className="flex flex-col gap-3">

--- a/src/shared/components/forms/addressesInput/addressesInputItem/addressesInputItem.tsx
+++ b/src/shared/components/forms/addressesInput/addressesInputItem/addressesInputItem.tsx
@@ -29,10 +29,14 @@ export interface IAddressesInputItemProps extends ComponentProps<'div'> {
      * Custom validator function that extends the default validation.
      */
     customValidator?: (member: IAddressInputResolvedValue) => string | true;
+    /**
+     * Chain id used to build the explorer link for the address input.
+     */
+    chainId?: number;
 }
 
 export const AddressesInputItem: React.FC<IAddressesInputItemProps> = (props) => {
-    const { index, disabled, customValidator } = props;
+    const { index, disabled, customValidator, chainId } = props;
 
     const { t } = useTranslations();
 
@@ -81,6 +85,7 @@ export const AddressesInputItem: React.FC<IAddressesInputItemProps> = (props) =>
                 onAccept={handleAddressAccept}
                 placeholder={t('app.shared.addressesInput.item.input.placeholder')}
                 disabled={disabled}
+                chainId={chainId}
                 {...addressField}
             />
 


### PR DESCRIPTION
# Description

Ensures all AddressInput external links open the correct block explorer for the DAO’s chain (not always Ethereum mainnet).

## Tested
Before:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/f7e28d41-596c-4160-9b83-ef0f4e93a3a7" />

After:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/f5da1c8d-ff1d-4501-8820-6bf9a5a50382" />


## Type of Change

<!--- Please delete the options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
