### PR TITLE
fix(APP-250): Adjust Sentry replaysOnErrorSampleRate

### DIFF
--- a/.changeset/dirty-hairs-poke.md
+++ b/.changeset/dirty-hairs-poke.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app': patch
+---
+
+Adjust Sentry replaysOnErrorSampleRate

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -14,9 +14,8 @@ Sentry.init({
         }),
     ],
 
-    // Capture Replay for 10% of all sessions, plus for 100% of sessions with an error.
     replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
+    replaysOnErrorSampleRate: 0.5,
 });
 
 // eslint-disable-next-line import/namespace


### PR DESCRIPTION
# Description

Reduce amount of Sentry replays to be in quota

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [ ] Manually smoke tested the functionality locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
