### PR TITLE
feat: Hide tenderly if proposal is in a terminal status

### DIFF
--- a/.changeset/disabled-buttons-stink.md
+++ b/.changeset/disabled-buttons-stink.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app': minor
+---
+
+Hide Tenderly simulation if the proposal is in a terminal status

--- a/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.tsx
@@ -75,7 +75,12 @@ export const DaoProposalDetailsPageClient: React.FC<IDaoProposalDetailsPageClien
     );
     const actionsCount = actionData?.rawActions?.length ?? 0;
 
-    const showActionSimulation = proposal?.hasActions && tenderlySupport;
+    const isSimulationSupportedByStatus =
+        [ProposalStatus.ACTIVE, ProposalStatus.ADVANCEABLE, ProposalStatus.PENDING, ProposalStatus.EXECUTABLE].includes(
+            proposalStatus,
+        );
+
+    const showActionSimulation = proposal?.hasActions && tenderlySupport && isSimulationSupportedByStatus;
 
     const {
         data: lastSimulation,
@@ -131,11 +136,7 @@ export const DaoProposalDetailsPageClient: React.FC<IDaoProposalDetailsPageClien
         { label: proposalSlug.toUpperCase() },
     ];
 
-    const canSimulate =
-        [ProposalStatus.ACTIVE, ProposalStatus.ADVANCEABLE, ProposalStatus.PENDING, ProposalStatus.EXECUTABLE].includes(
-            proposalStatus,
-        ) &&
-        (lastSimulation == null || Date.now() - lastSimulation.runAt > actionSimulationLimitMillis);
+    const canSimulate = lastSimulation == null || Date.now() - lastSimulation.runAt > actionSimulationLimitMillis;
 
     const processedLastSimulation = lastSimulation ? { ...lastSimulation, timestamp: lastSimulation.runAt } : undefined;
     const simulationErrorContext = hasSimulationFailed ? 'simulationError' : 'lastSimulationError';

--- a/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.tsx
@@ -75,10 +75,12 @@ export const DaoProposalDetailsPageClient: React.FC<IDaoProposalDetailsPageClien
     );
     const actionsCount = actionData?.rawActions?.length ?? 0;
 
-    const isSimulationSupportedByStatus =
-        [ProposalStatus.ACTIVE, ProposalStatus.ADVANCEABLE, ProposalStatus.PENDING, ProposalStatus.EXECUTABLE].includes(
-            proposalStatus,
-        );
+    const isSimulationSupportedByStatus = [
+        ProposalStatus.ACTIVE,
+        ProposalStatus.ADVANCEABLE,
+        ProposalStatus.PENDING,
+        ProposalStatus.EXECUTABLE,
+    ].includes(proposalStatus);
 
     const showActionSimulation = proposal?.hasActions && tenderlySupport && isSimulationSupportedByStatus;
 


### PR DESCRIPTION
# Description

Logic was moved from the Tenderly simulation button to the card itself to hide/disable if the proposal is terminal. Now, the tenderly card just hides when the proposal is done. This was feedback from several users that didn't understand why they would see the simulation, but not be able to interact with it. For example, it was very strange on the admin plugin.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
