### PR TITLE
fix(APP-228): Refactor plugin name retrieval to use getPluginName method

### DIFF
--- a/.changeset/heavy-pants-lay.md
+++ b/.changeset/heavy-pants-lay.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app': patch
+---
+
+Improve plugin name fallback chain to use slug or interfaceType when subdomain is unavailable

--- a/src/modules/governance/components/actionComposer/actionComposerUtils.ts
+++ b/src/modules/governance/components/actionComposer/actionComposerUtils.ts
@@ -368,7 +368,7 @@ class ActionComposerUtils {
             proposedMetadata: existingMetadata,
             inputData: {
                 function: 'setMetadata',
-                contract: plugin.subdomain,
+                contract: plugin.subdomain ?? plugin.interfaceType,
                 parameters: [
                     { name: '_metadata', type: 'bytes', notice: 'The IPFS hash of the new metadata object', value: '' },
                 ],

--- a/src/modules/governance/components/actionComposer/actionComposerUtils.ts
+++ b/src/modules/governance/components/actionComposer/actionComposerUtils.ts
@@ -368,7 +368,7 @@ class ActionComposerUtils {
             proposedMetadata: existingMetadata,
             inputData: {
                 function: 'setMetadata',
-                contract: plugin.subdomain ?? plugin.interfaceType,
+                contract: plugin.interfaceType,
                 parameters: [
                     { name: '_metadata', type: 'bytes', notice: 'The IPFS hash of the new metadata object', value: '' },
                 ],

--- a/src/modules/settings/components/daoProcessDetailsInfo/daoProcessDetailsInfo.tsx
+++ b/src/modules/settings/components/daoProcessDetailsInfo/daoProcessDetailsInfo.tsx
@@ -34,7 +34,10 @@ export const DaoProcessDetailsInfo: React.FC<IDaoProcessDetailsInfoProps> = (pro
 
     const pluginInfoSettings = [
         { term: t('app.settings.daoProcessDetailsInfo.pluginName'), definition: daoUtils.getPluginName(plugin) },
-        { term: t('app.settings.daoProcessDetailsInfo.processKey'), definition: plugin.slug.toUpperCase() },
+        {
+            term: t('app.settings.daoProcessDetailsInfo.processKey'),
+            definition: plugin.slug.toUpperCase(),
+        },
     ];
 
     const eventLogParams: IGetLastPluginEventLogUrlParams = {

--- a/src/modules/settings/components/daoVersionInfo/daoVersionInfo.tsx
+++ b/src/modules/settings/components/daoVersionInfo/daoVersionInfo.tsx
@@ -39,7 +39,7 @@ export const DaoVersionInfo: React.FC<IDaoVersionInfoProps> = (props) => {
                     copyValue={plugin.meta.address}
                     link={{ href: buildEntityUrl({ type: ChainEntityType.ADDRESS, id: plugin.meta.address, chainId }) }}
                     description={t('app.settings.daoVersionInfo.governanceValue', {
-                        name: daoUtils.parsePluginSubdomain(plugin.meta.subdomain),
+                        name: daoUtils.getPluginName(plugin.meta),
                         release: plugin.meta.release,
                         build: plugin.meta.build,
                     })}

--- a/src/modules/settings/dialogs/prepareDaoContractsUpdateDialog/prepareDaoContractsUpdateDialogUtils.ts
+++ b/src/modules/settings/dialogs/prepareDaoContractsUpdateDialog/prepareDaoContractsUpdateDialogUtils.ts
@@ -169,7 +169,7 @@ class PrepareDaoContractsUpdateDialogUtils {
             pluginRegistryUtils.getPlugin(interfaceType) as IPluginInfo
         ).installVersion;
 
-        const pluginName = daoUtils.parsePluginSubdomain(subdomain);
+        const pluginName = daoUtils.getPluginName(plugin);
         const updatedVersion = `${pluginName} ${release.toString()}.${build.toString()}`;
         const currentVersion = `${pluginName} ${currentRelease}.${currentBuild}`;
 

--- a/src/modules/settings/dialogs/prepareDaoContractsUpdateDialog/prepareDaoContractsUpdateDialogUtils.ts
+++ b/src/modules/settings/dialogs/prepareDaoContractsUpdateDialog/prepareDaoContractsUpdateDialogUtils.ts
@@ -164,7 +164,7 @@ class PrepareDaoContractsUpdateDialogUtils {
     };
 
     private getPluginUpdateDetails = (plugin: IDaoPlugin) => {
-        const { interfaceType, subdomain, release: currentRelease, build: currentBuild } = plugin;
+        const { interfaceType, release: currentRelease, build: currentBuild } = plugin;
         const { release, build, description, releaseNotes } = (
             pluginRegistryUtils.getPlugin(interfaceType) as IPluginInfo
         ).installVersion;

--- a/src/modules/settings/dialogs/updateDaoContractsListDialog/updateDaoContractsListDialog.tsx
+++ b/src/modules/settings/dialogs/updateDaoContractsListDialog/updateDaoContractsListDialog.tsx
@@ -70,7 +70,7 @@ export const UpdateDaoContractsListDialog: React.FC<IUpdateDaoContractsListDialo
                         <UpdateDaoContractsCard
                             key={plugin.address}
                             name={daoUtils.getPluginName(plugin)}
-                            smartContractName={daoUtils.parsePluginSubdomain(plugin.subdomain)}
+                            smartContractName={daoUtils.getPluginName(plugin)}
                             address={plugin.address}
                             currentVersion={plugin}
                             newVersion={

--- a/src/shared/api/daoService/domain/daoPlugin.ts
+++ b/src/shared/api/daoService/domain/daoPlugin.ts
@@ -26,7 +26,7 @@ export interface IDaoPlugin<TSettings extends IPluginSettings = IPluginSettings>
     /**
      * Subdomain of the plugin.
      */
-    subdomain: string;
+    subdomain?: string;
     /**
      * Plugin interface type. Used as a plugin type identifier.
      */

--- a/src/shared/hooks/useDaoPluginInfo/useDaoPluginInfo.ts
+++ b/src/shared/hooks/useDaoPluginInfo/useDaoPluginInfo.ts
@@ -46,7 +46,7 @@ export const useDaoPluginInfo = (params: IUseDaoPluginInfoParams): IDefinitionSe
     const { id: chainId } = networkDefinitions[dao.network];
     const pluginCreationLink = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: transactionHash, chainId });
 
-    const name = daoUtils.parsePluginSubdomain(plugin.meta.subdomain);
+    const name = daoUtils.getPluginName(plugin.meta);
     const pluginLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: address, chainId });
 
     return [

--- a/src/shared/utils/daoUtils/daoUtils.test.ts
+++ b/src/shared/utils/daoUtils/daoUtils.test.ts
@@ -71,16 +71,40 @@ describe('dao utils', () => {
     });
 
     describe('getPluginName', () => {
-        it('formats plugin subdomain', () => {
-            const subdomain = 'token-voting';
-            const plugin = generateDaoPlugin({ subdomain });
-            expect(daoUtils.getPluginName(plugin)).toEqual('Token Voting');
-        });
-
         it('returns plugin name when available', () => {
             const name = 'Custom plugin';
             const plugin = generateDaoPlugin({ name });
             expect(daoUtils.getPluginName(plugin)).toEqual(name);
+        });
+
+        it('formats plugin subdomain when name is not available', () => {
+            const subdomain = 'token-voting';
+            const plugin = generateDaoPlugin({ subdomain, name: undefined });
+            expect(daoUtils.getPluginName(plugin)).toEqual('Token Voting');
+        });
+
+        it('falls back to slug when subdomain is null and name is not available', () => {
+            const slug = 'multisig-plugin';
+            const plugin = generateDaoPlugin({ subdomain: undefined, slug, name: undefined });
+            expect(daoUtils.getPluginName(plugin)).toEqual('Multisig Plugin');
+        });
+
+        it('falls back to slug when subdomain is undefined and name is not available', () => {
+            const slug = 'admin-plugin';
+            const plugin = generateDaoPlugin({ subdomain: undefined, slug, name: undefined });
+            expect(daoUtils.getPluginName(plugin)).toEqual('Admin Plugin');
+        });
+
+        it('falls back to interfaceType when both subdomain and slug are null', () => {
+            const interfaceType = PluginInterfaceType.TOKEN_VOTING;
+            const plugin = generateDaoPlugin({ subdomain: undefined, slug: undefined, interfaceType, name: undefined });
+            expect(daoUtils.getPluginName(plugin)).toEqual('TokenVoting');
+        });
+
+        it('falls back to interfaceType when both subdomain and slug are undefined', () => {
+            const interfaceType = PluginInterfaceType.MULTISIG;
+            const plugin = generateDaoPlugin({ subdomain: undefined, slug: undefined, interfaceType, name: undefined });
+            expect(daoUtils.getPluginName(plugin)).toEqual('Multisig');
         });
     });
 

--- a/src/shared/utils/daoUtils/daoUtils.test.ts
+++ b/src/shared/utils/daoUtils/daoUtils.test.ts
@@ -83,28 +83,65 @@ describe('dao utils', () => {
             expect(daoUtils.getPluginName(plugin)).toEqual('Token Voting');
         });
 
-        it('falls back to slug when subdomain is null and name is not available', () => {
-            const slug = 'multisig-plugin';
-            const plugin = generateDaoPlugin({ subdomain: undefined, slug, name: undefined });
+        it('uses subdomain over interfaceType when both are present', () => {
+            const subdomain = 'multisig-plugin';
+            const interfaceType = PluginInterfaceType.MULTISIG;
+            const plugin = generateDaoPlugin({ subdomain, interfaceType, name: undefined });
             expect(daoUtils.getPluginName(plugin)).toEqual('Multisig Plugin');
         });
 
-        it('falls back to slug when subdomain is undefined and name is not available', () => {
-            const slug = 'admin-plugin';
-            const plugin = generateDaoPlugin({ subdomain: undefined, slug, name: undefined });
-            expect(daoUtils.getPluginName(plugin)).toEqual('Admin Plugin');
-        });
-
-        it('falls back to interfaceType when both subdomain and slug are null', () => {
+        it('formats subdomain and interfaceType with the same format (spaces)', () => {
+            const subdomain = 'token-voting';
             const interfaceType = PluginInterfaceType.TOKEN_VOTING;
-            const plugin = generateDaoPlugin({ subdomain: undefined, slug: undefined, interfaceType, name: undefined });
-            expect(daoUtils.getPluginName(plugin)).toEqual('TokenVoting');
+            const pluginWithSubdomain = generateDaoPlugin({ subdomain, interfaceType, name: undefined });
+            const pluginWithoutSubdomain = generateDaoPlugin({ subdomain: undefined, interfaceType, name: undefined });
+
+            expect(daoUtils.getPluginName(pluginWithSubdomain)).toEqual('Token Voting');
+            expect(daoUtils.getPluginName(pluginWithoutSubdomain)).toEqual('Token Voting');
         });
 
-        it('falls back to interfaceType when both subdomain and slug are undefined', () => {
+        it('falls back to interfaceType when subdomain is null and name is not available', () => {
             const interfaceType = PluginInterfaceType.MULTISIG;
-            const plugin = generateDaoPlugin({ subdomain: undefined, slug: undefined, interfaceType, name: undefined });
+            const plugin = generateDaoPlugin({
+                subdomain: undefined,
+                interfaceType,
+                name: undefined,
+            });
             expect(daoUtils.getPluginName(plugin)).toEqual('Multisig');
+        });
+
+        it('falls back to interfaceType when subdomain is undefined and name is not available', () => {
+            const interfaceType = PluginInterfaceType.ADMIN;
+            const plugin = generateDaoPlugin({
+                subdomain: undefined,
+                interfaceType,
+                name: undefined,
+            });
+            expect(daoUtils.getPluginName(plugin)).toEqual('Admin');
+        });
+
+        it('falls back to interfaceType when subdomain is null', () => {
+            const interfaceType = PluginInterfaceType.TOKEN_VOTING;
+            const plugin = generateDaoPlugin({ subdomain: undefined, interfaceType, name: undefined });
+            expect(daoUtils.getPluginName(plugin)).toEqual('Token Voting');
+        });
+
+        it('falls back to interfaceType when subdomain is undefined', () => {
+            const interfaceType = PluginInterfaceType.MULTISIG;
+            const plugin = generateDaoPlugin({ subdomain: undefined, interfaceType, name: undefined });
+            expect(daoUtils.getPluginName(plugin)).toEqual('Multisig');
+        });
+
+        it('formats camelCase interfaceType with multiple words correctly', () => {
+            const interfaceType = PluginInterfaceType.CAPITAL_DISTRIBUTOR;
+            const plugin = generateDaoPlugin({ subdomain: undefined, interfaceType, name: undefined });
+            expect(daoUtils.getPluginName(plugin)).toEqual('Capital Distributor');
+        });
+
+        it('formats camelCase interfaceType with three words correctly', () => {
+            const interfaceType = PluginInterfaceType.LOCK_TO_VOTE;
+            const plugin = generateDaoPlugin({ subdomain: undefined, interfaceType, name: undefined });
+            expect(daoUtils.getPluginName(plugin)).toEqual('Lock To Vote');
         });
     });
 
@@ -381,6 +418,33 @@ describe('dao utils', () => {
             const subdomain = 'multisig';
             const expectedResult = 'Multisig';
             expect(daoUtils.parsePluginSubdomain(subdomain)).toEqual(expectedResult);
+        });
+    });
+
+    describe('parsePluginInterfaceType', () => {
+        it('correctly parses camelCase interfaceType with two words', () => {
+            const interfaceType = 'tokenVoting';
+            const expectedResult = 'Token Voting';
+
+            expect(daoUtils.parsePluginInterfaceType(interfaceType)).toEqual(expectedResult);
+        });
+
+        it('correctly parses camelCase interfaceType with multiple words', () => {
+            const interfaceType = 'capitalDistributor';
+            const expectedResult = 'Capital Distributor';
+            expect(daoUtils.parsePluginInterfaceType(interfaceType)).toEqual(expectedResult);
+        });
+
+        it('correctly parses camelCase interfaceType with three words', () => {
+            const interfaceType = 'lockToVote';
+            const expectedResult = 'Lock To Vote';
+            expect(daoUtils.parsePluginInterfaceType(interfaceType)).toEqual(expectedResult);
+        });
+
+        it('correctly parses single word interfaceType', () => {
+            const interfaceType = 'multisig';
+            const expectedResult = 'Multisig';
+            expect(daoUtils.parsePluginInterfaceType(interfaceType)).toEqual(expectedResult);
         });
     });
 

--- a/src/shared/utils/daoUtils/daoUtils.ts
+++ b/src/shared/utils/daoUtils/daoUtils.ts
@@ -68,9 +68,11 @@ class DaoUtils {
             return plugin.name;
         }
 
-        // Fallback chain: subdomain → slug → interfaceType
-        const pluginIdentifier = (plugin.subdomain ?? plugin.slug) || plugin.interfaceType;
-        return this.parsePluginSubdomain(pluginIdentifier);
+        if (plugin.subdomain) {
+            return this.parsePluginSubdomain(plugin.subdomain);
+        }
+
+        return this.parsePluginInterfaceType(plugin.interfaceType);
     };
 
     getDaoPlugins = (dao?: IDao, params?: IGetDaoPluginsParams) => {
@@ -87,10 +89,33 @@ class DaoUtils {
         );
     };
 
+    /**
+     * Parses the plugin subdomain to a human readable string.
+     * @example
+     * parsePluginSubdomain('token-voting') -> 'Token Voting'
+     * parsePluginSubdomain('lock-to-vote-plugin') -> 'Lock to Vote Plugin'
+     * @param subdomain - The subdomain to parse.
+     * @returns The parsed subdomain in Title Case.
+     */
     parsePluginSubdomain = (subdomain: string): string => {
         const parts = subdomain.split('-');
 
         return parts.map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ');
+    };
+
+    /**
+     * Parses the plugin interface type to a human readable string.
+     * @example
+     * parsePluginInterfaceType('tokenVoting') -> 'Token Voting'
+     * parsePluginInterfaceType('multisig') -> 'Multisig'
+     * parsePluginInterfaceType('lockToVote') -> 'Lock to Vote'
+     * @param interfaceType - The interface type to parse.
+     * @returns The parsed interface type in Title Case.
+     */
+    parsePluginInterfaceType = (interfaceType: string): string => {
+        const parts = interfaceType.split(/(?=[A-Z])/);
+
+        return parts.map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()).join(' ');
     };
 
     hasAvailableUpdates = (dao?: IDao): IDaoAvailableUpdates => {

--- a/src/shared/utils/daoUtils/daoUtils.ts
+++ b/src/shared/utils/daoUtils/daoUtils.ts
@@ -69,7 +69,7 @@ class DaoUtils {
         }
 
         // Fallback chain: subdomain → slug → interfaceType
-        const pluginIdentifier = plugin.subdomain ?? plugin.slug ?? plugin.interfaceType;
+        const pluginIdentifier = (plugin.subdomain ?? plugin.slug) || plugin.interfaceType;
         return this.parsePluginSubdomain(pluginIdentifier);
     };
 

--- a/src/shared/utils/daoUtils/daoUtils.ts
+++ b/src/shared/utils/daoUtils/daoUtils.ts
@@ -67,7 +67,7 @@ class DaoUtils {
         if (plugin.name) {
             return plugin.name;
         }
-        const safePluginName = plugin.subdomain || plugin.slug || plugin.interfaceType || 'Unknown Plugin';
+        const safePluginName = plugin.subdomain || plugin.slug || plugin.interfaceType;
         return this.parsePluginSubdomain(safePluginName);
     };
 

--- a/src/shared/utils/daoUtils/daoUtils.ts
+++ b/src/shared/utils/daoUtils/daoUtils.ts
@@ -67,8 +67,8 @@ class DaoUtils {
         if (plugin.name) {
             return plugin.name;
         }
-
-        return this.parsePluginSubdomain(plugin.subdomain);
+        const safePluginName = plugin.subdomain || plugin.slug || plugin.interfaceType || 'Unknown Plugin';
+        return this.parsePluginSubdomain(safePluginName);
     };
 
     getDaoPlugins = (dao?: IDao, params?: IGetDaoPluginsParams) => {

--- a/src/shared/utils/daoUtils/daoUtils.ts
+++ b/src/shared/utils/daoUtils/daoUtils.ts
@@ -67,8 +67,10 @@ class DaoUtils {
         if (plugin.name) {
             return plugin.name;
         }
-        const safePluginName = plugin.subdomain || plugin.slug || plugin.interfaceType;
-        return this.parsePluginSubdomain(safePluginName);
+
+        // Fallback chain: subdomain → slug → interfaceType
+        const pluginIdentifier = plugin.subdomain ?? plugin.slug ?? plugin.interfaceType;
+        return this.parsePluginSubdomain(pluginIdentifier);
     };
 
     getDaoPlugins = (dao?: IDao, params?: IGetDaoPluginsParams) => {


### PR DESCRIPTION
# Description

This pull request refactors how plugin names are derived and displayed throughout the DAO settings and dialogs. The main improvement is the consistent use of the new `getPluginName` utility, which provides a more robust and fallback-friendly way to determine plugin names, replacing the previous reliance on `parsePluginSubdomain`. This change enhances reliability in displaying plugin names, especially when certain fields may be missing.

**Refactoring plugin name resolution:**

* Updated all usages of `parsePluginSubdomain` to use the new `getPluginName` method in the following components and hooks: `DaoVersionInfo`, `UpdateDaoContractsListDialog`, `useDaoPluginInfo`, and `PrepareDaoContractsUpdateDialogUtils`. This ensures consistent and more reliable plugin name display across the application. [[1]](diffhunk://#diff-e3ac1d9880cc97ab0102d54d583038d68d1974ae5518cc5a7866a2349dbe20c5L43-R43) [[2]](diffhunk://#diff-6ce0d15b12ad7aeb0322b038dd4bd4c8596b9a40246554f2f888c297497977dfL69-R69) [[3]](diffhunk://#diff-fa0ef13364a7764ed03f6fda4b480b0be2dc5e11a593445571b10d870f3549dcL49-R49) [[4]](diffhunk://#diff-c796f3e4f7d5317d32de5721ed075259b2478d8c947debf228ec70b6520c469fL172-R172)

**Enhancements to utility logic:**

* Improved the `getPluginName` method in `daoUtils` to fall back to `subdomain`, `slug`, or `interfaceType` (in that order) if `plugin.name` is not available, ensuring a default value of `'Unknown Plugin'` if all else fails. The method then parses this value for a displayable plugin name.

https://linear.app/aragon/issue/APP-228/frontend-onboarding-some-daos-are-crashing-the-app

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [x] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [x] Confirmed that changes follow the code style guidelines of this project
