### PR TITLE
chore: Improve PR checklist based on retro feedback

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,19 +3,18 @@
 Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
 any dependencies that are required for this change.
 
-Task: [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)
-
 ## Type of Change
 
 <!--- Please delete the options that are not relevant. -->
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
+- [ ] Minor: Feature (non-breaking change which adds new functionality)
+- [ ] Patch: Enhancement (non-breaking change to an existing feature)
+- [ ] Patch: Bug fix (non-breaking change which fixes an issue)
 
 ## Developer Checklist:
 
-- [ ] Manually smoke tested the functionality locally
+- [ ] Manually smoke tested the functionality in a preview or locally
 - [ ] Confirmed there are no new warnings or errors in the browser console
 - [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
 - [ ] Confirmed there are no new warnings on automated tests
@@ -28,5 +27,5 @@ Task: [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)
 
 ## Review Checklist:
 
-- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
+- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
 - [ ] Confirmed that changes follow the code style guidelines of this project


### PR DESCRIPTION
# Description

Updated the pull request template to include new task options and modified checklist items for clarity and removing jira link since Linear is smarter than Jira.