### PR TITLE
fix: Add chain context on several more assetinput components that were missing it

### DIFF
--- a/.changeset/several-components-confuse.md
+++ b/.changeset/several-components-confuse.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app': patch
+---
+
+Fixed several instances of AddressInput that linked to the wrong block explorer.

--- a/.changeset/several-components-confuse.md
+++ b/.changeset/several-components-confuse.md
@@ -2,4 +2,5 @@
 '@aragon/app': patch
 ---
 
-Fixed several instances of AddressInput that linked to the wrong block explorer.
+Centralize block explorer links and network context with useDaoChain hook, fixes several instances AddressInput that
+linked to the wrong block explorer

--- a/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionCreate/gaugeRegistrarRegisterGaugeActionCreate.tsx
+++ b/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionCreate/gaugeRegistrarRegisterGaugeActionCreate.tsx
@@ -21,7 +21,7 @@ export interface IGaugeRegistrarRegisterGaugeActionCreateProps
 export const GaugeRegistrarRegisterGaugeActionCreate: React.FC<IGaugeRegistrarRegisterGaugeActionCreateProps> = (
     props,
 ) => {
-    const { index } = props;
+    const { index, chainId } = props;
 
     const { mutateAsync: pinJsonAsync } = usePinJson();
     const { mutateAsync: pinFileAsync } = usePinFile();
@@ -73,5 +73,5 @@ export const GaugeRegistrarRegisterGaugeActionCreate: React.FC<IGaugeRegistrarRe
         addPrepareAction(GaugeRegistrarActionType.REGISTER_GAUGE, prepareAction);
     }, [addPrepareAction, prepareAction]);
 
-    return <GaugeRegistrarRegisterGaugeActionCreateForm fieldPrefix={`${fieldName}.gaugeDetails`} />;
+    return <GaugeRegistrarRegisterGaugeActionCreateForm fieldPrefix={`${fieldName}.gaugeDetails`} chainId={chainId} />;
 };

--- a/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionCreate/gaugeRegistrarRegisterGaugeActionCreateForm.tsx
+++ b/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionCreate/gaugeRegistrarRegisterGaugeActionCreateForm.tsx
@@ -24,6 +24,10 @@ export interface IGaugeRegistrarRegisterGaugeActionCreateFormProps {
      * Prefix to prepend to all the form fields.
      */
     fieldPrefix: string;
+    /**
+     * Chain id used for contextual block explorer links.
+     */
+    chainId?: number;
 }
 
 export interface IGaugeRegistrarRegisterGaugeFormData {
@@ -65,7 +69,7 @@ const maxAvatarDimension = 1024;
 export const GaugeRegistrarRegisterGaugeActionCreateForm: React.FC<
     IGaugeRegistrarRegisterGaugeActionCreateFormProps
 > = (props) => {
-    const { fieldPrefix } = props;
+    const { fieldPrefix, chainId } = props;
     const { t } = useTranslations();
 
     const { value: nameValue, ...nameFieldRest } = useFormField<IGaugeRegistrarRegisterGaugeFormData, 'name'>('name', {
@@ -185,6 +189,7 @@ export const GaugeRegistrarRegisterGaugeActionCreateForm: React.FC<
                 value={qiTokenAddressInput}
                 onChange={setQiTokenAddressInput}
                 onAccept={onQiTokenAddressChange}
+                chainId={chainId}
                 {...qiTokenAddressField}
             />
             <RadioGroup
@@ -221,6 +226,7 @@ export const GaugeRegistrarRegisterGaugeActionCreateForm: React.FC<
                 value={rewardControllerAddressInput}
                 onChange={setRewardControllerAddressInput}
                 onAccept={onRewardControllerAddressChange}
+                chainId={chainId}
                 {...rewardControllerAddressField}
             />
             <GaugeRegistrarActiveVotingAlert />

--- a/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionDetails/gaugeRegistrarRegisterGaugeActionDetails.tsx
+++ b/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionDetails/gaugeRegistrarRegisterGaugeActionDetails.tsx
@@ -3,7 +3,7 @@
 import { type IProposalActionData } from '@/modules/governance/components/createProposalForm';
 import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { ipfsUtils } from '@/shared/utils/ipfsUtils';
 import {
     addressUtils,
@@ -14,7 +14,6 @@ import {
     type IProposalActionComponentProps,
     type IProposalActionInputDataParameter,
     Link,
-    useBlockExplorer,
 } from '@aragon/gov-ui-kit';
 import { GaugeIncentiveType } from '../../types/enum/gaugeIncentiveType';
 import type { IGaugeRegistrarActionRegisterGauge } from '../../types/gaugeRegistrarActionRegisterGauge';
@@ -47,15 +46,13 @@ export const GaugeRegistrarRegisterGaugeActionDetails: React.FC<IGaugeRegistrarR
     const avatarSrc = ipfsUtils.cidToSrc(avatar);
 
     const { t } = useTranslations();
-    const { buildEntityUrl } = useBlockExplorer();
     const { data: dao } = useDao({ urlParams: { id: daoId } });
+    const { buildEntityUrl } = useDaoChain({ network: dao?.network });
 
-    const chainId = dao ? networkDefinitions[dao.network].id : undefined;
-    const qiTokenAddressLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: qiTokenAddress, chainId });
+    const qiTokenAddressLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: qiTokenAddress });
     const rewardControllerAddressLink = buildEntityUrl({
         type: ChainEntityType.ADDRESS,
         id: rewardControllerAddress,
-        chainId,
     });
 
     return (

--- a/src/modules/application/components/navigations/navigationDao/navigationDao.tsx
+++ b/src/modules/application/components/navigations/navigationDao/navigationDao.tsx
@@ -5,17 +5,9 @@ import { type IDao } from '@/shared/api/daoService';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { Navigation, type INavigationContainerProps } from '@/shared/components/navigation';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { ipfsUtils } from '@/shared/utils/ipfsUtils';
-import {
-    addressUtils,
-    ChainEntityType,
-    Clipboard,
-    DaoAvatar,
-    Link,
-    useBlockExplorer,
-    Wallet,
-} from '@aragon/gov-ui-kit';
+import { addressUtils, ChainEntityType, Clipboard, DaoAvatar, Link, Wallet } from '@aragon/gov-ui-kit';
 import classNames from 'classnames';
 import { useState } from 'react';
 import { useAccount } from 'wagmi';
@@ -38,7 +30,7 @@ export const NavigationDao: React.FC<INavigationDaoProps> = (props) => {
     const { address, isConnected } = useAccount();
     const { open } = useDialogContext();
 
-    const { buildEntityUrl } = useBlockExplorer({ chainId: networkDefinitions[dao.network].id });
+    const { buildEntityUrl } = useDaoChain({ network: dao.network });
     const addressLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: dao.address });
 
     const handleWalletClick = () => {

--- a/src/modules/createDao/components/createProcessForm/createProcessFormGovernance/fields/governanceBodyField/governanceBodiesFieldItemDefault.tsx
+++ b/src/modules/createDao/components/createProcessForm/createProcessFormGovernance/fields/governanceBodyField/governanceBodiesFieldItemDefault.tsx
@@ -1,8 +1,8 @@
 import { type ISetupBodyForm } from '@/modules/createDao/dialogs/setupBodyDialog';
 import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
-import { addressUtils, ChainEntityType, DefinitionList, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
+import { addressUtils, ChainEntityType, DefinitionList } from '@aragon/gov-ui-kit';
 import type { Hash } from 'viem';
 import { useEnsName } from 'wagmi';
 import { BodyType } from '../../../../../types/enum';
@@ -23,8 +23,8 @@ export const GovernanceBodiesFieldItemDefault: React.FC<IGovernanceBodiesFieldIt
     const { body, daoId } = props;
 
     const { t } = useTranslations();
-    const { buildEntityUrl } = useBlockExplorer();
     const { data: dao } = useDao({ urlParams: { id: daoId } });
+    const { buildEntityUrl } = useDaoChain({ network: dao?.network });
 
     const { data: ensName } = useEnsName({
         address: body.type !== BodyType.NEW ? (body.address as Hash) : undefined,
@@ -34,8 +34,7 @@ export const GovernanceBodiesFieldItemDefault: React.FC<IGovernanceBodiesFieldIt
         return null;
     }
 
-    const chainId = dao ? networkDefinitions[dao.network].id : undefined;
-    const bodyAddressLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: body.address, chainId });
+    const bodyAddressLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: body.address });
 
     return (
         <DefinitionList.Container>

--- a/src/modules/dashboard/pages/daoDashboardPage/daoDashboardPageClient.tsx
+++ b/src/modules/dashboard/pages/daoDashboardPage/daoDashboardPageClient.tsx
@@ -9,7 +9,7 @@ import { useDao } from '@/shared/api/daoService';
 import { Page } from '@/shared/components/page';
 import { PluginSingleComponent } from '@/shared/components/pluginSingleComponent';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDaoPluginFilterUrlParam } from '@/shared/hooks/useDaoPluginFilterUrlParam';
 import { PluginType } from '@/shared/types';
 import { daoUtils } from '@/shared/utils/daoUtils';
@@ -22,7 +22,6 @@ import {
     Link,
     addressUtils,
     formatterUtils,
-    useBlockExplorer,
 } from '@aragon/gov-ui-kit';
 import { DashboardDefaultHeader } from '../../components/dashboardDefaultHeader';
 import { DashboardDaoSlotId } from '../../constants/moduleDaoSlots';
@@ -49,7 +48,7 @@ export const DaoDashboardPageClient: React.FC<IDaoDashboardPageClientProps> = (p
     const useDaoParams = { id: daoId };
     const { data: dao } = useDao({ urlParams: useDaoParams });
 
-    const { buildEntityUrl } = useBlockExplorer();
+    const { buildEntityUrl, networkDefinition } = useDaoChain({ network: dao?.network });
 
     const daoEns = daoUtils.getDaoEns(dao);
     const truncatedAddress = addressUtils.truncateAddress(dao?.address);
@@ -89,9 +88,8 @@ export const DaoDashboardPageClient: React.FC<IDaoDashboardPageClientProps> = (p
         format: DateFormat.YEAR_MONTH,
     });
 
-    const { id: chainId } = networkDefinitions[dao.network];
-    const daoAddressLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: dao.address, chainId });
-    const daoCreationLink = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: dao.transactionHash, chainId });
+    const daoAddressLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: dao.address });
+    const daoCreationLink = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: dao.transactionHash });
 
     const membersPageUrl = `${daoUrl}/members?${daoMembersPageFilterParam}=${membersPlugin?.meta.slug ?? ''}`;
     const proposalsPageUrl = `${daoUrl}/proposals?${daoProposalsPageFilterParam}=${proposalsPlugin?.meta.slug ?? ''}`;
@@ -164,7 +162,7 @@ export const DaoDashboardPageClient: React.FC<IDaoDashboardPageClientProps> = (p
                     <Page.AsideCard title={t('app.dashboard.daoDashboardPage.aside.details.title')}>
                         <DefinitionList.Container>
                             <DefinitionList.Item term={t('app.dashboard.daoDashboardPage.aside.details.chain')}>
-                                <p className="text-neutral-500">{networkDefinitions[dao.network].name}</p>
+                                <p className="text-neutral-500">{networkDefinition?.name}</p>
                             </DefinitionList.Item>
                             <DefinitionList.Item
                                 term={t('app.dashboard.daoDashboardPage.aside.details.address')}

--- a/src/modules/finance/components/assetList/assetListItem.tsx
+++ b/src/modules/finance/components/assetList/assetListItem.tsx
@@ -1,6 +1,6 @@
 import type { IAsset } from '@/modules/finance/api/financeService';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
-import { AssetDataListItemStructure, ChainEntityType, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
+import { AssetDataListItemStructure, ChainEntityType } from '@aragon/gov-ui-kit';
 
 export interface IAssetListItemProps {
     /**
@@ -17,10 +17,9 @@ export const AssetListItem: React.FC<IAssetListItemProps> = (props) => {
     const { asset, onAssetClick } = props;
     const { token, amount } = asset;
 
-    const { buildEntityUrl } = useBlockExplorer();
+    const { buildEntityUrl } = useDaoChain({ network: token.network });
 
-    const { id: chainId } = networkDefinitions[token.network];
-    const entityUrl = buildEntityUrl({ type: ChainEntityType.TOKEN, id: token.address, chainId });
+    const entityUrl = buildEntityUrl({ type: ChainEntityType.TOKEN, id: token.address });
 
     const processedEntityUrl = onAssetClick != null ? undefined : entityUrl;
     const processedTarget = onAssetClick != null ? undefined : '_blank';

--- a/src/modules/finance/components/financeDetailsList/financeDetailsList.tsx
+++ b/src/modules/finance/components/financeDetailsList/financeDetailsList.tsx
@@ -2,6 +2,7 @@ import { type IDao } from '@/shared/api/daoService';
 import { Page } from '@/shared/components/page';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import {
     Button,
@@ -9,7 +10,6 @@ import {
     DefinitionList,
     IconType,
     addressUtils,
-    useBlockExplorer,
     type IDefinitionListContainerProps,
 } from '@aragon/gov-ui-kit';
 
@@ -26,7 +26,7 @@ export const FinanceDetailsList: React.FC<IFinanceDetailsListProps> = (props) =>
 
     const { t } = useTranslations();
 
-    const { buildEntityUrl } = useBlockExplorer({ chainId: networkDefinitions[network].id });
+    const { buildEntityUrl } = useDaoChain({ network });
     const daoAddressLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: address });
 
     const daoEns = daoUtils.getDaoEns(dao);

--- a/src/modules/governance/components/createProposalForm/createProposalFormActions/createProposalFormActions.tsx
+++ b/src/modules/governance/components/createProposalForm/createProposalFormActions/createProposalFormActions.tsx
@@ -2,7 +2,7 @@ import { useAllowedActions } from '@/modules/governance/api/executeSelectorsServ
 import { ProposalActionType } from '@/modules/governance/api/governanceService';
 import { useDao, useDaoPermissions } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import {
     IconType,
@@ -47,6 +47,7 @@ export const CreateProposalFormActions: React.FC<ICreateProposalFormActionsProps
     const hasConditionalPermissions = processPlugin.conditionAddress != null;
 
     const { t } = useTranslations();
+    const { chainId } = useDaoChain({ daoId });
 
     const { control, getValues, setValue } = useFormContext<ICreateProposalFormData>();
 
@@ -172,7 +173,7 @@ export const CreateProposalFormActions: React.FC<ICreateProposalFormActionsProps
                             CustomComponent={customActionComponents[action.type]}
                             dropdownItems={getActionDropdownItems(index)}
                             formPrefix={`actions.${index.toString()}`}
-                            chainId={networkDefinitions[dao!.network].id}
+                            chainId={chainId}
                             editMode={true}
                         />
                     ))}

--- a/src/modules/governance/components/proposalExecutionStatus/proposalExecutionStatus.tsx
+++ b/src/modules/governance/components/proposalExecutionStatus/proposalExecutionStatus.tsx
@@ -1,16 +1,9 @@
 import type { IExecuteDialogParams } from '@/modules/governance/dialogs/executeDialog';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useSlotSingleFunction } from '@/shared/hooks/useSlotSingleFunction';
-import {
-    Button,
-    ChainEntityType,
-    type IButtonProps,
-    IconType,
-    ProposalStatus,
-    useBlockExplorer,
-} from '@aragon/gov-ui-kit';
+import { Button, ChainEntityType, type IButtonProps, IconType, ProposalStatus } from '@aragon/gov-ui-kit';
 import type { IProposal } from '../../api/governanceService';
 import { GovernanceDialogId } from '../../constants/governanceDialogId';
 import { GovernanceSlotId } from '../../constants/moduleSlots';
@@ -31,11 +24,10 @@ export const ProposalExecutionStatus: React.FC<IProposalExecutionStatusProps> = 
     const { daoId, proposal } = props;
 
     const { t } = useTranslations();
-    const { buildEntityUrl } = useBlockExplorer();
     const { open } = useDialogContext();
 
     const { network, pluginInterfaceType, executed } = proposal;
-    const { id: chainId } = networkDefinitions[network];
+    const { buildEntityUrl } = useDaoChain({ network });
 
     const proposalStatus = useSlotSingleFunction<IProposal, ProposalStatus>({
         params: proposal,
@@ -46,7 +38,6 @@ export const ProposalExecutionStatus: React.FC<IProposalExecutionStatusProps> = 
     const executedBlockLink = buildEntityUrl({
         type: ChainEntityType.TRANSACTION,
         id: executed.transactionHash,
-        chainId,
     });
 
     const openTransactionDialog = () => {

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
@@ -7,7 +7,7 @@ import { useDao } from '@/shared/api/daoService';
 import { Page } from '@/shared/components/page';
 import { type IPageHeaderStat } from '@/shared/components/page/pageHeader/pageHeaderStat';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useSlotSingleFunction } from '@/shared/hooks/useSlotSingleFunction';
 import { networkUtils } from '@/shared/utils/networkUtils';
 import {
@@ -17,7 +17,6 @@ import {
     DefinitionList,
     formatterUtils,
     MemberAvatar,
-    useBlockExplorer,
 } from '@aragon/gov-ui-kit';
 import { useBlock } from 'wagmi';
 import EfpLogo from '../../../../assets/images/efp-logo.svg';
@@ -47,7 +46,6 @@ export const DaoMemberDetailsPageClient: React.FC<IDaoMemberDetailsPageClientPro
     const { address, daoId } = props;
 
     const { t } = useTranslations();
-    const { buildEntityUrl } = useBlockExplorer();
 
     const efpParams = { urlParams: { address } };
     const { data: efpStats } = useEfpStats(efpParams);
@@ -69,7 +67,7 @@ export const DaoMemberDetailsPageClient: React.FC<IDaoMemberDetailsPageClientPro
 
     const { lastActivity, firstActivity } = member?.metrics ?? {};
 
-    const chainId = dao ? networkDefinitions[dao.network].id : undefined;
+    const { chainId, buildEntityUrl } = useDaoChain({ daoId });
 
     const firstBlockNumber = firstActivity != null ? BigInt(firstActivity) : undefined;
     const lastBlockNumber = lastActivity != null ? BigInt(lastActivity) : undefined;
@@ -116,7 +114,7 @@ export const DaoMemberDetailsPageClient: React.FC<IDaoMemberDetailsPageClientPro
     const truncatedAddress = addressUtils.truncateAddress(address);
     const memberName = ens ?? truncatedAddress;
 
-    const addressUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: address, chainId });
+    const addressUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: address });
 
     const pageBreadcrumbs = [
         {

--- a/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.tsx
@@ -7,7 +7,7 @@ import { Page } from '@/shared/components/page';
 import { PluginSingleComponent } from '@/shared/components/pluginSingleComponent';
 import { SafeDocumentParser } from '@/shared/components/SafeDocumentParser';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useSlotSingleFunction } from '@/shared/hooks/useSlotSingleFunction';
 import { actionViewRegistry } from '@/shared/utils/actionViewRegistry';
 import { daoUtils } from '@/shared/utils/daoUtils';
@@ -24,7 +24,6 @@ import {
     ProposalStatus,
     proposalStatusToTagVariant,
     Tag,
-    useBlockExplorer,
     useGukModulesContext,
 } from '@aragon/gov-ui-kit';
 import { useQueryClient } from '@tanstack/react-query';
@@ -58,7 +57,6 @@ export const DaoProposalDetailsPageClient: React.FC<IDaoProposalDetailsPageClien
     const { daoId, proposalSlug } = props;
 
     const { t } = useTranslations();
-    const { buildEntityUrl } = useBlockExplorer();
     const { copy } = useGukModulesContext();
     const queryClient = useQueryClient();
 
@@ -68,7 +66,9 @@ export const DaoProposalDetailsPageClient: React.FC<IDaoProposalDetailsPageClien
 
     const daoParams = { id: daoId };
     const { data: dao } = useDao({ urlParams: daoParams });
-    const { tenderlySupport } = dao ? networkDefinitions[dao.network] : {};
+
+    const { networkDefinition, buildEntityUrl, chainId } = useDaoChain({ network: proposal?.network });
+    const { tenderlySupport } = networkDefinition ?? {};
 
     const proposalStatus = useSlotSingleFunction<IProposal, ProposalStatus>({
         params: proposal!,
@@ -135,9 +135,8 @@ export const DaoProposalDetailsPageClient: React.FC<IDaoProposalDetailsPageClien
 
     const creatorName = creator.ens ?? addressUtils.truncateAddress(creator.address);
 
-    const { id: chainId } = networkDefinitions[proposal.network];
-    const creatorLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: creator.address, chainId });
-    const creationBlockLink = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: transactionHash, chainId });
+    const creatorLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: creator.address });
+    const creationBlockLink = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: transactionHash });
 
     const statusTag = {
         label: copy.proposalDataListItemStatus.statusLabel[proposalStatus],

--- a/src/modules/settings/components/daoSettingsInfo/daoSettingsInfo.tsx
+++ b/src/modules/settings/components/daoSettingsInfo/daoSettingsInfo.tsx
@@ -1,18 +1,10 @@
 import type { IDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { ipfsUtils } from '@/shared/utils/ipfsUtils';
-import {
-    Card,
-    ChainEntityType,
-    Collapsible,
-    DaoAvatar,
-    DefinitionList,
-    Link,
-    Tag,
-    useBlockExplorer,
-} from '@aragon/gov-ui-kit';
+import { Card, ChainEntityType, Collapsible, DaoAvatar, DefinitionList, Link, Tag } from '@aragon/gov-ui-kit';
 
 export interface IDaoSettingsInfoProps {
     /**
@@ -27,8 +19,7 @@ export const DaoSettingsInfo: React.FC<IDaoSettingsInfoProps> = (props) => {
 
     const daoAvatar = ipfsUtils.cidToSrc(dao.avatar);
 
-    const { id: chainId } = networkDefinitions[dao.network];
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
+    const { buildEntityUrl } = useDaoChain({ network: dao.network });
 
     return (
         <Card className="p-6">

--- a/src/modules/settings/components/daoVersionInfo/daoVersionInfo.tsx
+++ b/src/modules/settings/components/daoVersionInfo/daoVersionInfo.tsx
@@ -1,9 +1,9 @@
 import type { IDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
 import { daoUtils } from '@/shared/utils/daoUtils';
-import { addressUtils, ChainEntityType, DefinitionList, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { addressUtils, ChainEntityType, DefinitionList } from '@aragon/gov-ui-kit';
 
 export interface IDaoVersionInfoProps {
     /**
@@ -16,10 +16,9 @@ export const DaoVersionInfo: React.FC<IDaoVersionInfoProps> = (props) => {
     const { dao } = props;
     const { t } = useTranslations();
 
-    const { id: chainId } = networkDefinitions[dao.network];
-    const { buildEntityUrl } = useBlockExplorer();
+    const { buildEntityUrl } = useDaoChain({ network: dao.network });
 
-    const daoLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: dao.address, chainId });
+    const daoLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: dao.address });
     const processPlugins = useDaoPlugins({ daoId: dao.id, includeSubPlugins: true });
 
     return (
@@ -37,7 +36,7 @@ export const DaoVersionInfo: React.FC<IDaoVersionInfoProps> = (props) => {
                     key={plugin.uniqueId}
                     term={daoUtils.getPluginName(plugin.meta)}
                     copyValue={plugin.meta.address}
-                    link={{ href: buildEntityUrl({ type: ChainEntityType.ADDRESS, id: plugin.meta.address, chainId }) }}
+                    link={{ href: buildEntityUrl({ type: ChainEntityType.ADDRESS, id: plugin.meta.address }) }}
                     description={t('app.settings.daoVersionInfo.governanceValue', {
                         name: daoUtils.getPluginName(plugin.meta),
                         release: plugin.meta.release,

--- a/src/plugins/capitalDistributorPlugin/components/capitalDistributorCampaignList/capitalDistributorCampaignListItemStructure.tsx
+++ b/src/plugins/capitalDistributorPlugin/components/capitalDistributorCampaignList/capitalDistributorCampaignListItemStructure.tsx
@@ -1,7 +1,7 @@
 import { type IDao, PluginInterfaceType } from '@/shared/api/daoService/domain';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins/useDaoPlugins';
 import {
     Avatar,
@@ -11,7 +11,6 @@ import {
     formatterUtils,
     IconType,
     NumberFormat,
-    useBlockExplorer,
 } from '@aragon/gov-ui-kit';
 import { formatUnits } from 'viem';
 import { CampaignStatus, type ICampaign } from '../../api/capitalDistributorService';
@@ -51,7 +50,7 @@ export const CapitalDistributorCampaignListItemStructure: React.FC<
     const value = Number(parsedAmount) * Number(token.priceUsd);
     const formattedValue = formatterUtils.formatNumber(value, { format: NumberFormat.FIAT_TOTAL_SHORT });
 
-    const { buildEntityUrl } = useBlockExplorer({ chainId: networkDefinitions[network].id });
+    const { buildEntityUrl } = useDaoChain({ network });
     const addressLink = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: claims[0]?.transactionHash });
 
     const handleOpenDialog = () => {

--- a/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterGaugeDetailsDialog/gaugeVoterGaugeDetailsDialogContent/gaugeVoterGaugeDetailsDialogContent.tsx
+++ b/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterGaugeDetailsDialog/gaugeVoterGaugeDetailsDialogContent/gaugeVoterGaugeDetailsDialogContent.tsx
@@ -1,7 +1,7 @@
 import type { Network } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
-import { addressUtils, ChainEntityType, DefinitionList, Tag, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
+import { addressUtils, ChainEntityType, DefinitionList, Tag } from '@aragon/gov-ui-kit';
 import type { IGauge } from '../../../api/gaugeVoterService/domain';
 
 export interface IGaugeVoterGaugeDetailsDialogContentProps {
@@ -24,7 +24,7 @@ export const GaugeVoterGaugeDetailsDialogContent: React.FC<IGaugeVoterGaugeDetai
 
     const { t } = useTranslations();
 
-    const { buildEntityUrl } = useBlockExplorer({ chainId: networkDefinitions[network].id });
+    const { buildEntityUrl } = useDaoChain({ network });
     const gaugeAddressLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: gauge.address });
 
     const hasVoted = userVotes > 0;

--- a/src/plugins/lockToVotePlugin/components/lockToVoteProcessBodyField/lockToVoteProcessBodyField.tsx
+++ b/src/plugins/lockToVotePlugin/components/lockToVoteProcessBodyField/lockToVoteProcessBodyField.tsx
@@ -9,18 +9,11 @@ import type {
 } from '@/plugins/tokenPlugin/components/tokenSetupMembership';
 import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDaoPluginInfo } from '@/shared/hooks/useDaoPluginInfo';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { dateUtils } from '@/shared/utils/dateUtils';
-import {
-    ChainEntityType,
-    DefinitionList,
-    formatterUtils,
-    NumberFormat,
-    Tag,
-    useBlockExplorer,
-} from '@aragon/gov-ui-kit';
+import { ChainEntityType, DefinitionList, formatterUtils, NumberFormat, Tag } from '@aragon/gov-ui-kit';
 import { formatUnits } from 'viem';
 import { DaoLockToVoteVotingMode } from '../../types';
 import type { ILockToVoteSetupGovernanceForm } from '../lockToVoteSetupGovernance/lockToVoteSetupGovernance.api';
@@ -58,6 +51,7 @@ export const LockToVoteProcessBodyField = (props: ILockToVoteProcessBodyFieldPro
     const { data: dao } = useDao({ urlParams: daoUrlParams });
 
     const { t } = useTranslations();
+    const { buildEntityUrl } = useDaoChain({ network: dao?.network });
 
     const { membership, governance } = body;
 
@@ -94,8 +88,6 @@ export const LockToVoteProcessBodyField = (props: ILockToVoteProcessBodyFieldPro
     );
 
     const numberOfMembers = readOnly ? memberList?.pages[0].metadata.totalRecords : membership.members.length;
-
-    const { buildEntityUrl } = useBlockExplorer({ chainId: networkDefinitions[dao!.network].id });
 
     const readOnlyTokenProps = {
         link: { href: buildEntityUrl({ type: ChainEntityType.TOKEN, id: tokenAddress }) },

--- a/src/plugins/lockToVotePlugin/components/lockToVoteSetupMembership/lockToVoteSetupMembership.tsx
+++ b/src/plugins/lockToVotePlugin/components/lockToVoteSetupMembership/lockToVoteSetupMembership.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import { useDao } from '@/shared/api/daoService';
 import {
     type ITransactionInfo,
     type ITransactionStatusStepMeta,
     TransactionStatus,
 } from '@/shared/components/transactionStatus';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useFormField } from '@/shared/hooks/useFormField';
 import type { IStepperStep } from '@/shared/utils/stepperUtils';
 import { AddressInput, addressUtils } from '@aragon/gov-ui-kit';
@@ -25,9 +24,7 @@ export const LockToVoteSetupMembership: React.FC<ILockToVoteSetupMembershipProps
     const tokenFormPrefix = `${formPrefix}.token`;
     const { setValue } = useFormContext();
 
-    const useDaoParams = { id: daoId };
-    const { data: dao } = useDao({ urlParams: useDaoParams });
-    const chainId = dao ? networkDefinitions[dao.network].id : undefined;
+    const { chainId } = useDaoChain({ daoId });
 
     useFormField<ILockToVoteSetupMembershipForm['token'], 'name'>('name', {
         defaultValue: '',

--- a/src/plugins/lockToVotePlugin/components/lockToVoteSubmitVote/lockToVoteSubmitVote.tsx
+++ b/src/plugins/lockToVotePlugin/components/lockToVoteSubmitVote/lockToVoteSubmitVote.tsx
@@ -10,9 +10,9 @@ import { TokenVotingOptions } from '@/plugins/tokenPlugin/components/tokenSubmit
 import { VoteOption, type ITokenVote } from '@/plugins/tokenPlugin/types';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
-import { Button, Card, ChainEntityType, IconType, useBlockExplorer, type VoteIndicator } from '@aragon/gov-ui-kit';
+import { Button, Card, ChainEntityType, IconType, type VoteIndicator } from '@aragon/gov-ui-kit';
 import { useCallback, useEffect, useState } from 'react';
 import { LockToVotePluginDialogId } from '../../constants/lockToVotePluginDialogId';
 import type { ILockToVoteSubmitVoteFeedbackDialogParams } from '../../dialogs/lockToVoteSubmitVoteFeedbackDialog';
@@ -49,8 +49,7 @@ export const LockToVoteSubmitVote: React.FC<ILockToVoteSubmitVoteProps> = (props
     const plugins = useDaoPlugins({ daoId, pluginAddress, includeSubPlugins: true })!;
     const plugin = plugins[0].meta as ILockToVotePlugin;
 
-    const { id: chainId } = networkDefinitions[network];
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
+    const { buildEntityUrl } = useDaoChain({ network });
     const latestVoteTxHref = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: latestVote?.transactionHash });
 
     const { balance, allowance, approveTokens } = useLockToVoteData({ plugin, daoId });

--- a/src/plugins/lockToVotePlugin/hooks/useLockToVotePermissionCheckVoteSubmission/useLockToVotePermissionCheckVoteSubmission.tsx
+++ b/src/plugins/lockToVotePlugin/hooks/useLockToVotePermissionCheckVoteSubmission/useLockToVotePermissionCheckVoteSubmission.tsx
@@ -2,8 +2,8 @@
 
 import type { IPermissionCheckGuardParams, IPermissionCheckGuardResult } from '@/modules/governance/types';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
-import { ChainEntityType, DateFormat, formatterUtils, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
+import { ChainEntityType, DateFormat, formatterUtils } from '@aragon/gov-ui-kit';
 import type { ILockToVotePlugin } from '../../types';
 import { useLockToVoteData } from '../useLockToVoteData';
 
@@ -23,14 +23,12 @@ export const useLockToVotePermissionCheckVoteSubmission = (
 
     const { token } = plugin.settings;
     const { blockTimestamp, network, transactionHash } = proposal!;
-    const { id: chainId } = networkDefinitions[network];
 
     const { balance, lockedAmount, isLoading } = useLockToVoteData({ plugin, daoId });
+    const { buildEntityUrl } = useDaoChain({ network });
 
     const creationDate = blockTimestamp * 1000;
     const formattedCreationDate = formatterUtils.formatDate(creationDate, { format: DateFormat.YEAR_MONTH_DAY });
-
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
     const proposalCreationUrl = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: transactionHash });
 
     const settings = [

--- a/src/plugins/multisigPlugin/components/multisigActions/multisigAddMembersAction/multisigAddMembersAction.tsx
+++ b/src/plugins/multisigPlugin/components/multisigActions/multisigAddMembersAction/multisigAddMembersAction.tsx
@@ -59,6 +59,7 @@ export const MultisigAddMembersAction: React.FC<IMultisigAddMembersActionProps> 
             formPrefix={actionFieldName}
             pluginAddress={action.to}
             network={network}
+            daoId={action.daoId}
             hideLabel={true}
         />
     );

--- a/src/plugins/multisigPlugin/components/multisigActions/multisigRemoveMembersAction/multisigRemoveMembersAction.tsx
+++ b/src/plugins/multisigPlugin/components/multisigActions/multisigRemoveMembersAction/multisigRemoveMembersAction.tsx
@@ -78,6 +78,7 @@ export const MultisigRemoveMembersAction: React.FC<IMultisigRemoveMembersActionP
             disabled={true}
             onAddClick={handleAddClick}
             hideLabel={true}
+            daoId={action.daoId}
         />
     );
 };

--- a/src/plugins/multisigPlugin/components/multisigSetupMembership/components/multisigSetupMembershipItem.tsx
+++ b/src/plugins/multisigPlugin/components/multisigSetupMembership/components/multisigSetupMembershipItem.tsx
@@ -1,7 +1,7 @@
 import { useMemberExists } from '@/modules/governance/api/governanceService';
 import type { Network } from '@/shared/api/daoService';
 import { AddressesInput } from '@/shared/components/forms/addressesInput';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { addressUtils, type ICompositeAddress } from '@aragon/gov-ui-kit';
 
 export interface IMultisigSetupMembershipItemProps {
@@ -33,7 +33,7 @@ export interface IMultisigSetupMembershipItemProps {
 
 export const MultisigSetupMembershipItem: React.FC<IMultisigSetupMembershipItemProps> = (props) => {
     const { disabled, index, pluginAddress, member, network } = props;
-    const chainId = network ? networkDefinitions[network].id : undefined;
+    const { chainId } = useDaoChain({ network });
 
     const memberExistsParams = {
         urlParams: { memberAddress: member.address, pluginAddress: pluginAddress! },

--- a/src/plugins/multisigPlugin/components/multisigSetupMembership/multisigSetupMembership.api.ts
+++ b/src/plugins/multisigPlugin/components/multisigSetupMembership/multisigSetupMembership.api.ts
@@ -20,6 +20,10 @@ export interface IMultisigSetupMembershipProps extends IPluginSetupMembershipPar
      */
     network?: Network;
     /**
+     * ID of the DAO, used to derive the chain when the plugin network is not provided.
+     */
+    daoId?: string;
+    /**
      * Hides the field label and help-text when set to true.
      */
     hideLabel?: boolean;

--- a/src/plugins/multisigPlugin/components/multisigSetupMembership/multisigSetupMembership.tsx
+++ b/src/plugins/multisigPlugin/components/multisigSetupMembership/multisigSetupMembership.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useDao } from '@/shared/api/daoService';
 import { AddressesInput } from '@/shared/components/forms/addressesInput';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useWatch } from 'react-hook-form';
@@ -7,9 +8,11 @@ import { MultisigSetupMembershipItem } from './components/multisigSetupMembershi
 import type { IMultisigSetupMembershipForm, IMultisigSetupMembershipProps } from './multisigSetupMembership.api';
 
 export const MultisigSetupMembership: React.FC<IMultisigSetupMembershipProps> = (props) => {
-    const { formPrefix, disabled, onAddClick, pluginAddress, hideLabel, network } = props;
+    const { formPrefix, disabled, onAddClick, pluginAddress, hideLabel, network, daoId } = props;
 
     const { t } = useTranslations();
+    const { data: dao } = useDao({ urlParams: { id: daoId ?? '' } }, { enabled: daoId != null });
+    const membershipNetwork = network ?? dao?.network;
 
     const watchMembersField = useWatch<Record<string, IMultisigSetupMembershipForm['members']>>({
         name: `${formPrefix}.members`,
@@ -30,7 +33,7 @@ export const MultisigSetupMembership: React.FC<IMultisigSetupMembershipProps> = 
                     disabled={disabled}
                     member={watchMembersField[index]}
                     pluginAddress={pluginAddress}
-                    network={network}
+                    network={membershipNetwork}
                 />
             ))}
         </AddressesInput.Container>

--- a/src/plugins/multisigPlugin/components/multisigSubmitVote/multisigSubmitVote.tsx
+++ b/src/plugins/multisigPlugin/components/multisigSubmitVote/multisigSubmitVote.tsx
@@ -8,9 +8,9 @@ import { useUserVote } from '@/modules/governance/hooks/useUserVote';
 import type { ISubmitVoteProps } from '@/modules/governance/types';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
-import { Button, ChainEntityType, IconType, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { Button, ChainEntityType, IconType } from '@aragon/gov-ui-kit';
 import type { IMultisigProposal, IMultisigVote } from '../../types';
 
 export interface IMultisigSubmitVoteProps extends ISubmitVoteProps<IMultisigProposal> {}
@@ -25,8 +25,7 @@ export const MultisigSubmitVote: React.FC<IMultisigSubmitVoteProps> = (props) =>
     const userVote = useUserVote<IMultisigVote>({ proposal, network });
     const voted = userVote != null;
 
-    const { id: chainId } = networkDefinitions[network];
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
+    const { buildEntityUrl } = useDaoChain({ network });
     const voteTransactionHref = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: userVote?.transactionHash });
 
     const openTransactionDialog = () => {

--- a/src/plugins/multisigPlugin/hooks/useMultisigPermissionCheckVoteSubmission/useMultisigPermissionCheckVoteSubmission.tsx
+++ b/src/plugins/multisigPlugin/hooks/useMultisigPermissionCheckVoteSubmission/useMultisigPermissionCheckVoteSubmission.tsx
@@ -2,8 +2,8 @@ import type { IPermissionCheckGuardParams, IPermissionCheckGuardResult } from '@
 import type { IMultisigPluginSettings } from '@/plugins/multisigPlugin/types';
 import type { IDaoPlugin } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
-import { ChainEntityType, DateFormat, formatterUtils, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
+import { ChainEntityType, DateFormat, formatterUtils } from '@aragon/gov-ui-kit';
 import type { Hex } from 'viem';
 import { useAccount, useReadContract } from 'wagmi';
 
@@ -32,10 +32,11 @@ export const useMultisigPermissionCheckVoteSubmission = (
     const { t } = useTranslations();
 
     const { blockTimestamp, network, transactionHash, proposalIndex, pluginAddress } = proposal!;
+    const { chainId, buildEntityUrl } = useDaoChain({ network });
 
     const { data: hasPermission, isLoading } = useReadContract({
         address: pluginAddress as Hex,
-        chainId: networkDefinitions[network].id,
+        chainId: chainId,
         abi: multisigAbi,
         functionName: 'canApprove',
         args: [BigInt(proposalIndex), address as Hex],
@@ -46,8 +47,6 @@ export const useMultisigPermissionCheckVoteSubmission = (
         format: DateFormat.YEAR_MONTH_DAY,
     });
 
-    const { id: chainId } = networkDefinitions[network];
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
     const proposalCreationUrl = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: transactionHash });
 
     const settings = [

--- a/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppStageStatus.tsx
+++ b/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppStageStatus.tsx
@@ -5,9 +5,9 @@ import { type ISppProposal, type ISppStage } from '@/plugins/sppPlugin/types';
 import { sppStageUtils } from '@/plugins/sppPlugin/utils/sppStageUtils';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDynamicValue } from '@/shared/hooks/useDynamicValue';
-import { Button, ChainEntityType, IconType, ProposalStatus, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { Button, ChainEntityType, IconType, ProposalStatus } from '@aragon/gov-ui-kit';
 import { DateTime } from 'luxon';
 
 export interface ISppStageStatusProps {
@@ -31,8 +31,7 @@ export const SppStageStatus: React.FC<ISppStageStatusProps> = (props) => {
     const { t } = useTranslations();
     const { open } = useDialogContext();
 
-    const { id: chainId } = networkDefinitions[proposal.network];
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
+    const { buildEntityUrl } = useDaoChain({ network: proposal.network });
 
     const openAdvanceStageDialog = () => {
         const params: ISppAdvanceStageDialogParams = { daoId, proposal };

--- a/src/plugins/sppPlugin/hooks/useSppGovernanceSettingsDefault/useSppGovernanceSettingsDefault.ts
+++ b/src/plugins/sppPlugin/hooks/useSppGovernanceSettingsDefault/useSppGovernanceSettingsDefault.ts
@@ -1,8 +1,8 @@
 import type { IUseGovernanceSettingsParams } from '@/modules/settings/types';
 import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
-import { ChainEntityType, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
+import { ChainEntityType } from '@aragon/gov-ui-kit';
 import type { Hex } from 'viem';
 import { mainnet } from 'viem/chains';
 import { useEnsName } from 'wagmi';
@@ -16,8 +16,7 @@ export const useSppGovernanceSettingsDefault = (params: IUseSppGovernanceSetting
     const { t } = useTranslations();
     const { data: dao } = useDao({ urlParams: { id: daoId } });
 
-    const { id: chainId } = networkDefinitions[dao!.network];
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
+    const { buildEntityUrl } = useDaoChain({ network: dao?.network });
 
     const { data: bodyName } = useEnsName({ address: pluginAddress as Hex, chainId: mainnet.id });
     const url = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: pluginAddress })!;

--- a/src/plugins/tokenPlugin/components/tokenMemberInfo/tokenMemberInfo.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberInfo/tokenMemberInfo.tsx
@@ -3,15 +3,8 @@
 import type { ITokenPluginSettings } from '@/plugins/tokenPlugin/types';
 import { type IDaoPlugin, useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
-import {
-    addressUtils,
-    ChainEntityType,
-    DefinitionList,
-    formatterUtils,
-    NumberFormat,
-    useBlockExplorer,
-} from '@aragon/gov-ui-kit';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
+import { addressUtils, ChainEntityType, DefinitionList, formatterUtils, NumberFormat } from '@aragon/gov-ui-kit';
 import { formatUnits } from 'viem';
 import { useMemberList } from '../../../../modules/governance/api/governanceService';
 import { daoUtils } from '../../../../shared/utils/daoUtils';
@@ -40,8 +33,7 @@ export const TokenMemberInfo: React.FC<ITokenMemberInfoProps> = (props) => {
 
     const distribution = memberList?.pages[0]?.metadata.totalRecords ?? '';
 
-    const { id: chainId } = networkDefinitions[plugin.settings.token.network];
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
+    const { buildEntityUrl } = useDaoChain({ network: plugin.settings.token.network });
 
     const { token } = plugin.settings;
     const parsedTotalSupply = token.totalSupply && formatUnits(BigInt(token.totalSupply), token.decimals);

--- a/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenDelegation/tokenDelegationForm.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenDelegation/tokenDelegationForm.tsx
@@ -5,7 +5,7 @@ import { useTokenCurrentDelegate } from '@/plugins/tokenPlugin/hooks/useTokenCur
 import { useDao } from '@/shared/api/daoService';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useFormField } from '@/shared/hooks/useFormField';
 import {
     AddressInput,
@@ -31,7 +31,7 @@ export const TokenDelegationForm: React.FC<ITokenDelegationFormProps> = (props) 
     const { t } = useTranslations();
     const { address } = useAccount();
     const { data: dao } = useDao({ urlParams: { id: daoId } });
-    const chainId = dao ? networkDefinitions[dao.network].id : undefined;
+    const { chainId } = useDaoChain({ daoId });
 
     const { data: currentDelegate, isLoading: isCurrentDelegateLoading } = useTokenCurrentDelegate({
         userAddress: address,

--- a/src/plugins/tokenPlugin/components/tokenProcessBodyField/tokenProcessBodyField.tsx
+++ b/src/plugins/tokenPlugin/components/tokenProcessBodyField/tokenProcessBodyField.tsx
@@ -5,18 +5,11 @@ import { BodyType } from '@/modules/createDao/types/enum';
 import { useMemberList } from '@/modules/governance/api/governanceService';
 import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDaoPluginInfo } from '@/shared/hooks/useDaoPluginInfo';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { dateUtils } from '@/shared/utils/dateUtils';
-import {
-    ChainEntityType,
-    DefinitionList,
-    formatterUtils,
-    NumberFormat,
-    Tag,
-    useBlockExplorer,
-} from '@aragon/gov-ui-kit';
+import { ChainEntityType, DefinitionList, formatterUtils, NumberFormat, Tag } from '@aragon/gov-ui-kit';
 import { formatUnits } from 'viem';
 import { DaoTokenVotingMode } from '../../types';
 import type { ITokenSetupGovernanceForm } from '../tokenSetupGovernance';
@@ -82,7 +75,7 @@ export const TokenProcessBodyField = (props: ITokenProcessBodyFieldProps) => {
 
     const numberOfMembers = isExisting ? memberList?.pages[0].metadata.totalRecords : membership.members.length;
 
-    const { buildEntityUrl } = useBlockExplorer({ chainId: networkDefinitions[dao!.network].id });
+    const { buildEntityUrl } = useDaoChain({ network: dao?.network });
 
     const existingTokenProps = {
         link: { href: buildEntityUrl({ type: ChainEntityType.TOKEN, id: tokenAddress }) },

--- a/src/plugins/tokenPlugin/components/tokenSetupMembership/components/tokenSetupMembershipCreateToken/tokenSetupMembershipCreateToken.tsx
+++ b/src/plugins/tokenPlugin/components/tokenSetupMembership/components/tokenSetupMembershipCreateToken/tokenSetupMembershipCreateToken.tsx
@@ -1,5 +1,7 @@
 import type { ITokenSetupMembershipForm } from '@/plugins/tokenPlugin/components/tokenSetupMembership';
+import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { useFormField } from '@/shared/hooks/useFormField';
 import { sanitizePlainText } from '@/shared/security';
 import { Button, IconType, InputContainer, InputText } from '@aragon/gov-ui-kit';
@@ -14,6 +16,10 @@ export interface ITokenSetupMembershipCreateTokenProps {
      * Prefix to be appended to all form fields.
      */
     formPrefix: string;
+    /**
+     * ID of the DAO.
+     */
+    daoId: string;
 }
 
 const nameMaxLength = 40;
@@ -22,10 +28,12 @@ const symbolMaxLength = 12;
 const symbolRegex = /^[A-Z][A-Z0-9]*$/;
 
 export const TokenSetupMembershipCreateToken: React.FC<ITokenSetupMembershipCreateTokenProps> = (props) => {
-    const { formPrefix } = props;
+    const { formPrefix, daoId } = props;
 
     const { t } = useTranslations();
     const { setValue } = useFormContext();
+    const { data: dao } = useDao({ urlParams: { id: daoId } });
+    const chainId = dao ? networkDefinitions[dao.network].id : undefined;
 
     const tokenFormPrefix = `${formPrefix}.token`;
 
@@ -116,6 +124,7 @@ export const TokenSetupMembershipCreateToken: React.FC<ITokenSetupMembershipCrea
                         initialValue={member.address}
                         index={index}
                         members={controlledMembersField}
+                        chainId={chainId}
                         onRemove={membersField.length > 1 ? () => removeMember(index) : undefined}
                     />
                 ))}

--- a/src/plugins/tokenPlugin/components/tokenSetupMembership/components/tokenSetupMembershipCreateToken/tokenSetupMembershipCreateToken.tsx
+++ b/src/plugins/tokenPlugin/components/tokenSetupMembership/components/tokenSetupMembershipCreateToken/tokenSetupMembershipCreateToken.tsx
@@ -1,7 +1,6 @@
 import type { ITokenSetupMembershipForm } from '@/plugins/tokenPlugin/components/tokenSetupMembership';
-import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useFormField } from '@/shared/hooks/useFormField';
 import { sanitizePlainText } from '@/shared/security';
 import { Button, IconType, InputContainer, InputText } from '@aragon/gov-ui-kit';
@@ -32,8 +31,7 @@ export const TokenSetupMembershipCreateToken: React.FC<ITokenSetupMembershipCrea
 
     const { t } = useTranslations();
     const { setValue } = useFormContext();
-    const { data: dao } = useDao({ urlParams: { id: daoId } });
-    const chainId = dao ? networkDefinitions[dao.network].id : undefined;
+    const { chainId } = useDaoChain({ daoId });
 
     const tokenFormPrefix = `${formPrefix}.token`;
 

--- a/src/plugins/tokenPlugin/components/tokenSetupMembership/components/tokenSetupMembershipCreateToken/tokenSetupMembershipCreateTokenMember.tsx
+++ b/src/plugins/tokenPlugin/components/tokenSetupMembership/components/tokenSetupMembershipCreateToken/tokenSetupMembershipCreateTokenMember.tsx
@@ -34,9 +34,13 @@ export interface ITokenSetupMembershipCreateTokenMemberProps {
      * All members in the list for duplicate checking.
      */
     members: ITokenSetupMembershipForm['members'];
+    /**
+     * Chain id used to contextualize explorer links.
+     */
+    chainId?: number;
 }
 export const TokenSetupMembershipCreateTokenMember: React.FC<ITokenSetupMembershipCreateTokenMemberProps> = (props) => {
-    const { formPrefix, onRemove, initialValue, index, members } = props;
+    const { formPrefix, onRemove, initialValue, index, members, chainId } = props;
 
     const { t } = useTranslations();
 
@@ -77,6 +81,7 @@ export const TokenSetupMembershipCreateTokenMember: React.FC<ITokenSetupMembersh
                     onChange={setMemberInput}
                     onAccept={handleAddressAccept}
                     className="basis-[65%]"
+                    chainId={chainId}
                     {...memberField}
                 />
                 <InputNumber className="basis-1/3" min={0} {...tokenAmountField} />

--- a/src/plugins/tokenPlugin/components/tokenSetupMembership/components/tokenSetupMembershipImportToken/tokenSetupMembershipImportToken.tsx
+++ b/src/plugins/tokenPlugin/components/tokenSetupMembership/components/tokenSetupMembershipImportToken/tokenSetupMembershipImportToken.tsx
@@ -1,12 +1,11 @@
 import type { ITokenSetupMembershipForm } from '@/plugins/tokenPlugin/components/tokenSetupMembership';
-import { useDao } from '@/shared/api/daoService';
 import {
     type ITransactionInfo,
     type ITransactionStatusStepMeta,
     TransactionStatus,
 } from '@/shared/components/transactionStatus';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useFormField } from '@/shared/hooks/useFormField';
 import type { IStepperStep } from '@/shared/utils/stepperUtils';
 import { AddressInput, addressUtils, Link } from '@aragon/gov-ui-kit';
@@ -37,9 +36,7 @@ export const TokenSetupMembershipImportToken: React.FC<ITokenSetupMembershipImpo
     const tokenFormPrefix = `${formPrefix}.token`;
     const { setValue } = useFormContext();
 
-    const useDaoParams = { id: daoId };
-    const { data: dao } = useDao({ urlParams: useDaoParams });
-    const chainId = dao ? networkDefinitions[dao.network].id : undefined;
+    const { chainId } = useDaoChain({ daoId });
 
     useFormField<ITokenSetupMembershipForm['token'], 'name'>('name', {
         defaultValue: '',

--- a/src/plugins/tokenPlugin/components/tokenSetupMembership/tokenSetupMembership.tsx
+++ b/src/plugins/tokenPlugin/components/tokenSetupMembership/tokenSetupMembership.tsx
@@ -62,7 +62,7 @@ export const TokenSetupMembership: React.FC<ITokenSetupMembershipProps> = (props
                 </RadioGroup>
             </InputContainer>
             {tokenType === 'imported' && <TokenSetupMembershipImportToken formPrefix={formPrefix} daoId={daoId} />}
-            {tokenType === 'new' && <TokenSetupMembershipCreateToken formPrefix={formPrefix} />}
+            {tokenType === 'new' && <TokenSetupMembershipCreateToken formPrefix={formPrefix} daoId={daoId} />}
         </div>
     );
 };

--- a/src/plugins/tokenPlugin/components/tokenSubmitVote/tokenSubmitVote.tsx
+++ b/src/plugins/tokenPlugin/components/tokenSubmitVote/tokenSubmitVote.tsx
@@ -7,9 +7,9 @@ import { usePermissionCheckGuard } from '@/modules/governance/hooks/usePermissio
 import { useUserVote } from '@/modules/governance/hooks/useUserVote';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
-import { Button, Card, ChainEntityType, IconType, useBlockExplorer, type VoteIndicator } from '@aragon/gov-ui-kit';
+import { Button, Card, ChainEntityType, IconType, type VoteIndicator } from '@aragon/gov-ui-kit';
 import { useCallback, useEffect, useState } from 'react';
 import { DaoTokenVotingMode, VoteOption, type ITokenProposal, type ITokenVote } from '../../types';
 import { TokenVotingOptions } from './components/tokenVotingOptions';
@@ -45,8 +45,7 @@ export const TokenSubmitVote: React.FC<ITokenSubmitVoteProps> = (props) => {
     const latestVote = useUserVote<ITokenVote>({ proposal, network });
     const { meta: plugin } = useDaoPlugins({ daoId, pluginAddress, includeSubPlugins: true })![0];
 
-    const { id: chainId } = networkDefinitions[network];
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
+    const { buildEntityUrl } = useDaoChain({ network });
     const latestVoteTxHref = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: latestVote?.transactionHash });
 
     const [showOptions, setShowOptions] = useState(false);

--- a/src/plugins/tokenPlugin/hooks/useTokenPermissionCheckVoteSubmission/useTokenPermissionCheckVoteSubmission.tsx
+++ b/src/plugins/tokenPlugin/hooks/useTokenPermissionCheckVoteSubmission/useTokenPermissionCheckVoteSubmission.tsx
@@ -2,8 +2,8 @@ import type { IPermissionCheckGuardParams, IPermissionCheckGuardResult } from '@
 import { VoteOption, type ITokenPluginSettings } from '@/plugins/tokenPlugin/types';
 import type { IDaoPlugin } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
-import { ChainEntityType, DateFormat, formatterUtils, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
+import { ChainEntityType, DateFormat, formatterUtils } from '@aragon/gov-ui-kit';
 import type { Hex } from 'viem';
 import { useAccount, useReadContract } from 'wagmi';
 
@@ -35,9 +35,11 @@ export const useTokenPermissionCheckVoteSubmission = (
     const { symbol: tokenSymbol } = plugin.settings.token;
     const { blockTimestamp, network, transactionHash, proposalIndex, pluginAddress } = proposal!;
 
+    const { chainId, buildEntityUrl } = useDaoChain({ network });
+
     const { data: hasPermission, isLoading } = useReadContract({
         address: pluginAddress as Hex,
-        chainId: networkDefinitions[network].id,
+        chainId: chainId,
         abi: tokenVotingAbi,
         functionName: 'canVote',
         // Passing YES as vote option because we are only checking permission to vote and the option does not matter
@@ -47,10 +49,6 @@ export const useTokenPermissionCheckVoteSubmission = (
 
     const creationDate = blockTimestamp * 1000;
     const formattedCreationDate = formatterUtils.formatDate(creationDate, { format: DateFormat.YEAR_MONTH_DAY });
-
-    const { id: chainId } = networkDefinitions[network];
-
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
     const proposalCreationUrl = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: transactionHash });
 
     const settings = [

--- a/src/shared/components/transactionDialog/transactionDialog.test.tsx
+++ b/src/shared/components/transactionDialog/transactionDialog.test.tsx
@@ -8,7 +8,6 @@ import { Dialog, GukModulesProvider, IconType } from '@aragon/gov-ui-kit';
 import * as ReactQuery from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import type { WaitForTransactionReceiptErrorType } from 'viem';
-import { polygon } from 'viem/chains';
 import * as Wagmi from 'wagmi';
 import { TransactionDialog } from './transactionDialog';
 import {
@@ -279,14 +278,14 @@ describe('<TransactionDialog /> component', () => {
 
     it('displays the link to the block explorer for the confirmation step on transaction success', () => {
         const transactionHash = '0x1234';
-        useAccountSpy.mockReturnValue({ chainId: polygon.id } as unknown as Wagmi.UseAccountReturnType);
+        const network = Network.POLYGON_MAINNET;
         useSendTransactionSpy.mockReturnValue({
             data: transactionHash,
         } as unknown as Wagmi.UseSendTransactionReturnType);
         render(createTestComponent());
         const updateSteps = jest.fn() as jest.Mock<void, Array<Array<IStepperStep<ITransactionDialogStepMeta>>>>;
         const stepper = generateStepperResult<ITransactionDialogStepMeta, string>({ updateSteps });
-        render(createTestComponent({ stepper }));
+        render(createTestComponent({ stepper, network }));
         const confirmStep = updateSteps.mock.calls[0][0][2];
         expect(confirmStep.meta.addon).toEqual({
             label: expect.stringMatching(/CONFIRM.addon/) as unknown,

--- a/src/shared/components/transactionDialog/transactionDialog.tsx
+++ b/src/shared/components/transactionDialog/transactionDialog.tsx
@@ -1,8 +1,8 @@
 import { Network } from '@/shared/api/daoService';
 import { useTransactionStatus } from '@/shared/api/transactionService';
 import { useDialogContext } from '@/shared/components/dialogProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
-import { ChainEntityType, Dialog, IconType, useBlockExplorer } from '@aragon/gov-ui-kit';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
+import { ChainEntityType, Dialog, IconType } from '@aragon/gov-ui-kit';
 import { useMutation } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAccount, useSendTransaction, useSwitchChain, useWaitForTransactionReceipt } from 'wagmi';
@@ -47,8 +47,7 @@ export const TransactionDialog = <TCustomStepId extends string>(props: ITransact
     const onSuccessRef = useRef(onSuccess);
 
     const { chainId, address } = useAccount();
-    const { id: requiredChainId } = networkDefinitions[network];
-    const { buildEntityUrl } = useBlockExplorer({ chainId });
+    const { chainId: requiredChainId, buildEntityUrl } = useDaoChain({ network });
 
     const handleTransactionError = useCallback(
         (stepId?: string) => (error: unknown, context?: Record<string, unknown>) =>
@@ -98,7 +97,7 @@ export const TransactionDialog = <TCustomStepId extends string>(props: ITransact
     }, [transaction, sendTransaction, handleTransactionError]);
 
     const handleSwitchNetwork = useCallback(
-        () => switchChain({ chainId: requiredChainId }, { onSuccess: handleSendTransaction }),
+        () => switchChain({ chainId: requiredChainId! }, { onSuccess: handleSendTransaction }),
         [switchChain, requiredChainId, handleSendTransaction],
     );
 

--- a/src/shared/hooks/useDaoChain/index.ts
+++ b/src/shared/hooks/useDaoChain/index.ts
@@ -1,0 +1,2 @@
+export { useDaoChain } from './useDaoChain';
+export type { IUseDaoChainParams, IUseDaoChainReturn } from './useDaoChain.api';

--- a/src/shared/hooks/useDaoChain/useDaoChain.api.ts
+++ b/src/shared/hooks/useDaoChain/useDaoChain.api.ts
@@ -1,0 +1,36 @@
+import type { Network } from '@/shared/api/daoService';
+import type { ChainEntityType } from '@aragon/gov-ui-kit';
+
+export interface IUseDaoChainParams {
+    /**
+     * DAO ID to derive chain context from.
+     */
+    daoId?: string;
+    /**
+     * Network to use directly (bypasses DAO fetch if provided).
+     */
+    network?: Network;
+    /**
+     * Chain ID to use directly (bypasses DAO and network if provided).
+     */
+    chainId?: number;
+}
+
+export interface IUseDaoChainReturn {
+    /**
+     * Chain ID for the DAO's network.
+     */
+    chainId: number | undefined;
+    /**
+     * Network for the DAO.
+     */
+    network: Network | undefined;
+    /**
+     * Build block explorer URLs for the chain.
+     */
+    buildEntityUrl: (params: { type: ChainEntityType; id?: string; chainId?: number }) => string | undefined;
+    /**
+     * Whether DAO data is loading.
+     */
+    isLoading: boolean;
+}

--- a/src/shared/hooks/useDaoChain/useDaoChain.api.ts
+++ b/src/shared/hooks/useDaoChain/useDaoChain.api.ts
@@ -1,4 +1,5 @@
 import type { Network } from '@/shared/api/daoService';
+import type { INetworkDefinition } from '@/shared/constants/networkDefinitions';
 import type { ChainEntityType } from '@aragon/gov-ui-kit';
 
 export interface IUseDaoChainParams {
@@ -25,6 +26,10 @@ export interface IUseDaoChainReturn {
      * Network for the DAO.
      */
     network: Network | undefined;
+    /**
+     * The network definition for the DAO's network.
+     */
+    networkDefinition: INetworkDefinition | undefined;
     /**
      * Build block explorer URLs for the chain.
      */

--- a/src/shared/hooks/useDaoChain/useDaoChain.test.ts
+++ b/src/shared/hooks/useDaoChain/useDaoChain.test.ts
@@ -1,0 +1,122 @@
+import * as DaoService from '@/shared/api/daoService';
+import { Network } from '@/shared/api/daoService';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { generateDao, generateReactQueryResultLoading, generateReactQueryResultSuccess } from '@/shared/testUtils';
+import * as GovUiKit from '@aragon/gov-ui-kit';
+import { ChainEntityType } from '@aragon/gov-ui-kit';
+import { renderHook } from '@testing-library/react';
+import { useDaoChain } from './useDaoChain';
+
+describe('useDaoChain hook', () => {
+    const useDaoSpy = jest.spyOn(DaoService, 'useDao');
+    const useBlockExplorerSpy = jest.spyOn(GovUiKit, 'useBlockExplorer');
+
+    beforeEach(() => {
+        useDaoSpy.mockReturnValue(generateReactQueryResultSuccess({ data: generateDao() }));
+        useBlockExplorerSpy.mockReturnValue({
+            buildEntityUrl: jest.fn((params) => `https://etherscan.io/${params.type}/${params.id}`),
+            getBlockExplorer: jest.fn(),
+        } as ReturnType<typeof GovUiKit.useBlockExplorer>);
+    });
+
+    afterEach(() => {
+        useDaoSpy.mockReset();
+        useBlockExplorerSpy.mockReset();
+    });
+
+    describe('with daoId', () => {
+        it('fetches DAO and derives chainId from network', () => {
+            const mockDao = generateDao({ network: Network.ETHEREUM_MAINNET });
+            useDaoSpy.mockReturnValue(generateReactQueryResultSuccess({ data: mockDao }));
+
+            const { result } = renderHook(() => useDaoChain({ daoId: 'dao-test' }));
+
+            expect(useDaoSpy).toHaveBeenCalledWith({ urlParams: { id: 'dao-test' } }, { enabled: true });
+            expect(result.current.chainId).toBe(networkDefinitions[Network.ETHEREUM_MAINNET].id);
+            expect(result.current.network).toBe(Network.ETHEREUM_MAINNET);
+            expect(result.current.buildEntityUrl).toEqual(expect.any(Function));
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        it('returns undefined chainId when DAO is not loaded yet', () => {
+            useDaoSpy.mockReturnValue(generateReactQueryResultLoading() as ReturnType<typeof DaoService.useDao>);
+
+            const { result } = renderHook(() => useDaoChain({ daoId: 'dao-missing' }));
+
+            expect(result.current.chainId).toBeUndefined();
+            expect(result.current.network).toBeUndefined();
+            expect(result.current.isLoading).toBe(true);
+        });
+    });
+
+    describe('with network', () => {
+        it('derives chainId from network without fetching DAO', () => {
+            const { result } = renderHook(() => useDaoChain({ network: Network.POLYGON_MAINNET }));
+
+            expect(useDaoSpy).toHaveBeenCalledWith({ urlParams: { id: '' } }, { enabled: false });
+            expect(result.current.chainId).toBe(networkDefinitions[Network.POLYGON_MAINNET].id);
+            expect(result.current.network).toBe(Network.POLYGON_MAINNET);
+            expect(result.current.isLoading).toBe(false);
+        });
+    });
+
+    describe('with chainId', () => {
+        it('uses provided chainId without fetching DAO', () => {
+            const { result } = renderHook(() => useDaoChain({ chainId: 42161 }));
+
+            expect(useDaoSpy).toHaveBeenCalledWith({ urlParams: { id: '' } }, { enabled: false });
+            expect(result.current.chainId).toBe(42161);
+            expect(result.current.isLoading).toBe(false);
+        });
+    });
+
+    describe('priority resolution', () => {
+        it('prioritizes chainId over network', () => {
+            const { result } = renderHook(() =>
+                useDaoChain({
+                    chainId: 42161,
+                    network: Network.ETHEREUM_MAINNET,
+                }),
+            );
+
+            expect(result.current.chainId).toBe(42161);
+            expect(result.current.network).toBe(Network.ETHEREUM_MAINNET);
+        });
+
+        it('prioritizes network over daoId', () => {
+            const { result } = renderHook(() =>
+                useDaoChain({
+                    daoId: 'dao-test',
+                    network: Network.POLYGON_MAINNET,
+                }),
+            );
+
+            expect(useDaoSpy).toHaveBeenCalledWith({ urlParams: { id: 'dao-test' } }, { enabled: false });
+            expect(result.current.chainId).toBe(networkDefinitions[Network.POLYGON_MAINNET].id);
+            expect(result.current.network).toBe(Network.POLYGON_MAINNET);
+        });
+    });
+
+    describe('buildEntityUrl', () => {
+        it('returns a function that builds explorer URLs', () => {
+            const buildEntityUrl = jest.fn((params) => `https://etherscan.io/${params.type}/${params.id}`);
+            useBlockExplorerSpy.mockReturnValue({
+                buildEntityUrl,
+                getBlockExplorer: jest.fn(),
+            } as ReturnType<typeof GovUiKit.useBlockExplorer>);
+
+            const { result } = renderHook(() => useDaoChain({ network: Network.ETHEREUM_MAINNET }));
+
+            const url = result.current.buildEntityUrl({
+                type: ChainEntityType.ADDRESS,
+                id: '0x1234567890123456789012345678901234567890',
+            });
+
+            expect(buildEntityUrl).toHaveBeenCalledWith({
+                type: ChainEntityType.ADDRESS,
+                id: '0x1234567890123456789012345678901234567890',
+            });
+            expect(url).toBe('https://etherscan.io/address/0x1234567890123456789012345678901234567890');
+        });
+    });
+});

--- a/src/shared/hooks/useDaoChain/useDaoChain.test.ts
+++ b/src/shared/hooks/useDaoChain/useDaoChain.test.ts
@@ -7,14 +7,20 @@ import { ChainEntityType } from '@aragon/gov-ui-kit';
 import { renderHook } from '@testing-library/react';
 import { useDaoChain } from './useDaoChain';
 
+type BuildEntityUrlParams = Parameters<ReturnType<typeof GovUiKit.useBlockExplorer>['buildEntityUrl']>[0];
+
 describe('useDaoChain hook', () => {
     const useDaoSpy = jest.spyOn(DaoService, 'useDao');
     const useBlockExplorerSpy = jest.spyOn(GovUiKit, 'useBlockExplorer');
 
+    const mockChainEntityUrl = jest.fn(({ type, id }: BuildEntityUrlParams) => {
+        return `https://etherscan.io/${type}/${id ?? ''}`;
+    });
+
     beforeEach(() => {
         useDaoSpy.mockReturnValue(generateReactQueryResultSuccess({ data: generateDao() }));
         useBlockExplorerSpy.mockReturnValue({
-            buildEntityUrl: jest.fn((params) => `https://etherscan.io/${params.type}/${params.id}`),
+            buildEntityUrl: mockChainEntityUrl,
             getBlockExplorer: jest.fn(),
         } as ReturnType<typeof GovUiKit.useBlockExplorer>);
     });
@@ -22,6 +28,7 @@ describe('useDaoChain hook', () => {
     afterEach(() => {
         useDaoSpy.mockReset();
         useBlockExplorerSpy.mockReset();
+        mockChainEntityUrl.mockClear();
     });
 
     describe('with daoId', () => {
@@ -99,9 +106,8 @@ describe('useDaoChain hook', () => {
 
     describe('buildEntityUrl', () => {
         it('returns a function that builds explorer URLs', () => {
-            const buildEntityUrl = jest.fn((params) => `https://etherscan.io/${params.type}/${params.id}`);
             useBlockExplorerSpy.mockReturnValue({
-                buildEntityUrl,
+                buildEntityUrl: mockChainEntityUrl,
                 getBlockExplorer: jest.fn(),
             } as ReturnType<typeof GovUiKit.useBlockExplorer>);
 
@@ -112,7 +118,7 @@ describe('useDaoChain hook', () => {
                 id: '0x1234567890123456789012345678901234567890',
             });
 
-            expect(buildEntityUrl).toHaveBeenCalledWith({
+            expect(mockChainEntityUrl).toHaveBeenCalledWith({
                 type: ChainEntityType.ADDRESS,
                 id: '0x1234567890123456789012345678901234567890',
             });

--- a/src/shared/hooks/useDaoChain/useDaoChain.ts
+++ b/src/shared/hooks/useDaoChain/useDaoChain.ts
@@ -11,13 +11,15 @@ export const useDaoChain = (params: IUseDaoChainParams): IUseDaoChainReturn => {
     const { data: dao, isLoading } = useDao({ urlParams: { id: daoId ?? '' } }, { enabled: shouldFetchDao });
 
     const resolvedNetwork = network ?? dao?.network;
-    const chainId = providedChainId ?? (resolvedNetwork != null ? networkDefinitions[resolvedNetwork].id : undefined);
+    const networkDefinition = resolvedNetwork != null ? networkDefinitions[resolvedNetwork] : undefined;
+    const chainId = providedChainId ?? networkDefinition?.id;
 
     const { buildEntityUrl } = useBlockExplorer({ chainId });
 
     return {
         chainId,
         network: resolvedNetwork,
+        networkDefinition,
         buildEntityUrl,
         isLoading: shouldFetchDao ? isLoading : false,
     };

--- a/src/shared/hooks/useDaoChain/useDaoChain.ts
+++ b/src/shared/hooks/useDaoChain/useDaoChain.ts
@@ -1,0 +1,24 @@
+import { useDao } from '@/shared/api/daoService';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { useBlockExplorer } from '@aragon/gov-ui-kit';
+import type { IUseDaoChainParams, IUseDaoChainReturn } from './useDaoChain.api';
+
+export const useDaoChain = (params: IUseDaoChainParams): IUseDaoChainReturn => {
+    const { daoId, network, chainId: providedChainId } = params;
+
+    const shouldFetchDao = daoId != null && providedChainId == null && network == null;
+
+    const { data: dao, isLoading } = useDao({ urlParams: { id: daoId ?? '' } }, { enabled: shouldFetchDao });
+
+    const resolvedNetwork = network ?? dao?.network;
+    const chainId = providedChainId ?? (resolvedNetwork != null ? networkDefinitions[resolvedNetwork].id : undefined);
+
+    const { buildEntityUrl } = useBlockExplorer({ chainId });
+
+    return {
+        chainId,
+        network: resolvedNetwork,
+        buildEntityUrl,
+        isLoading: shouldFetchDao ? isLoading : false,
+    };
+};

--- a/src/shared/hooks/useDaoPluginInfo/useDaoPluginInfo.ts
+++ b/src/shared/hooks/useDaoPluginInfo/useDaoPluginInfo.ts
@@ -1,15 +1,8 @@
 import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { daoUtils } from '@/shared/utils/daoUtils';
-import {
-    addressUtils,
-    ChainEntityType,
-    DateFormat,
-    formatterUtils,
-    type IDefinitionSetting,
-    useBlockExplorer,
-} from '@aragon/gov-ui-kit';
+import { addressUtils, ChainEntityType, DateFormat, formatterUtils, type IDefinitionSetting } from '@aragon/gov-ui-kit';
+import { useDaoChain } from '../useDaoChain';
 import { useDaoPlugins } from '../useDaoPlugins';
 
 export interface IUseDaoPluginInfoParams {
@@ -31,10 +24,11 @@ export const useDaoPluginInfo = (params: IUseDaoPluginInfoParams): IDefinitionSe
     const { daoId, address, settings = [] } = params;
 
     const { t } = useTranslations();
-    const { buildEntityUrl } = useBlockExplorer();
 
     const { data: dao } = useDao({ urlParams: { id: daoId } });
     const plugin = useDaoPlugins({ daoId, pluginAddress: address, includeSubPlugins: true })?.[0];
+
+    const { buildEntityUrl } = useDaoChain({ network: dao?.network });
 
     if (dao == null || plugin == null) {
         return settings;
@@ -43,11 +37,10 @@ export const useDaoPluginInfo = (params: IUseDaoPluginInfoParams): IDefinitionSe
     const { blockTimestamp, transactionHash, release, build } = plugin.meta;
     const pluginLaunchedAt = formatterUtils.formatDate(blockTimestamp * 1000, { format: DateFormat.YEAR_MONTH })!;
 
-    const { id: chainId } = networkDefinitions[dao.network];
-    const pluginCreationLink = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: transactionHash, chainId });
+    const pluginCreationLink = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: transactionHash });
 
     const name = daoUtils.getPluginName(plugin.meta);
-    const pluginLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: address, chainId });
+    const pluginLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: address });
 
     return [
         {

--- a/src/shared/testUtils/generators/reactQueryResponse.ts
+++ b/src/shared/testUtils/generators/reactQueryResponse.ts
@@ -75,6 +75,22 @@ export const generateReactQueryResultError = <TData, TError>(
     status: 'error',
 });
 
+export const generateReactQueryResultLoading = <TData, TError>(
+    result?: Partial<QueryObserverBaseResult<TData, TError>>,
+): QueryObserverBaseResult<TData, TError> => ({
+    ...generateReactQueryResultBase(result),
+    data: undefined,
+    error: null,
+    isError: false,
+    isPending: true,
+    isLoading: true,
+    isLoadingError: false,
+    isRefetchError: false,
+    isSuccess: false,
+    isPlaceholderData: false,
+    status: 'pending',
+});
+
 const generateReactQueryInfiniteResultBase = <TData, TError>(
     result?: Partial<InfiniteQueryObserverBaseResult<TData, TError>>,
 ): InfiniteQueryObserverBaseResult<TData, TError> => ({


### PR DESCRIPTION
# Description

Several address input uses were missing the chain context and linked to the wrong block explorer. 

While I have already tested that this works in the contexts it fixed, this is obviously AI generated code, so maybe it's dumb.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
