### PR TITLE
feat(APP-357): Implement stacked dialogs

### DIFF
--- a/.changeset/odd-papayas-fold.md
+++ b/.changeset/odd-papayas-fold.md
@@ -2,4 +2,4 @@
 '@aragon/app': minor
 ---
 
-Extend current dialog architecture to support parent-child stacked dialogs where parent state is perserved
+Extend current dialog architecture to support parent-child stacked dialogs where parent state is preserved

--- a/.changeset/odd-papayas-fold.md
+++ b/.changeset/odd-papayas-fold.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app': minor
+---
+
+Extend current dialog architecture to support parent-child stacked dialogs where parent state is perserved

--- a/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.tsx
+++ b/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.tsx
@@ -23,6 +23,7 @@ export const ConnectWalletDialog: React.FC<IConnectWalletDialogProps> = (props) 
     const { params, id } = props.location;
     const { onSuccess, onError } = params ?? {};
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { close, updateOptions } = useDialogContext();
     const { open: openWeb3Modal } = useAppKit();
     const { open: isAppKitModalOpen } = useAppKitState();

--- a/src/modules/finance/components/assetInput/assetInput.tsx
+++ b/src/modules/finance/components/assetInput/assetInput.tsx
@@ -179,9 +179,9 @@ export const AssetInput: React.FC<IAssetInputProps> = (props) => {
         const params: IAssetSelectionDialogParams = {
             initialParams: fetchAssetsParams,
             onAssetClick: handleAssetChange,
-            close,
+            close: () => close(FinanceDialogId.ASSET_SELECTION),
         };
-        open(FinanceDialogId.ASSET_SELECTION, { params });
+        open(FinanceDialogId.ASSET_SELECTION, { params, stack: true });
     };
 
     const handleMaxAmount = (e: MouseEvent<HTMLButtonElement>) => {

--- a/src/modules/governance/dialogs/permissionCheckDialog/permissionCheckDialog.tsx
+++ b/src/modules/governance/dialogs/permissionCheckDialog/permissionCheckDialog.tsx
@@ -35,6 +35,7 @@ export const PermissionCheckDialog: React.FC<IPermissionCheckDialogProps> = (pro
     const { slotId, onSuccess, onError, permissionNamespace, plugin, ...otherParams } = params;
 
     const { t } = useTranslations();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { close, updateOptions } = useDialogContext();
 
     const checkPermissions = useSlotSingleFunction<IPermissionCheckGuardParams, IPermissionCheckGuardResult>({

--- a/src/modules/governance/dialogs/walletConnectActionDialog/walletConnectActionDialogListener.tsx
+++ b/src/modules/governance/dialogs/walletConnectActionDialog/walletConnectActionDialogListener.tsx
@@ -28,6 +28,7 @@ export const WalletConnectActionDialogListener: React.FC<IWalletConnectActionDia
     const { appMetadata, actions, onAddActionsClick, onClose } = props;
 
     const { t } = useTranslations();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { updateOptions } = useDialogContext();
 
     const { name, icons, url } = appMetadata;

--- a/src/shared/components/dialogProvider/dialogProvider.api.ts
+++ b/src/shared/components/dialogProvider/dialogProvider.api.ts
@@ -18,6 +18,11 @@ export interface IDialogLocationOptions<TParams extends DialogComponentProps = D
      * Callback triggered instead of the default close function.
      */
     onClose?: () => void;
+    /**
+     * If true, adds the dialog to the stack. If false (default), replaces all dialogs with this one.
+     * Set to true for nested dialogs that should preserve parent dialog state.
+     */
+    stack?: boolean;
 }
 
 export interface IDialogLocation<TParams extends DialogComponentProps = DialogComponentProps>
@@ -30,15 +35,36 @@ export interface IDialogLocation<TParams extends DialogComponentProps = DialogCo
 
 export interface IDialogContext {
     /**
-     * Definitions for the current active dialog.
+     * Stack of currently open dialogs. The last item is the topmost (active) dialog.
+     */
+    locations: IDialogLocation[];
+    /**
+     * The currently active (topmost) dialog location.
      */
     location?: IDialogLocation;
     /**
      * Opens the specified dialog.
+     * @param id - The dialog ID to open
+     * @param options - Dialog options
+     * @example
+     * // Replace all dialogs (default behavior)
+     * open('MY_DIALOG', { params: { data } });
+     *
+     * @example
+     * // Add to stack, preserving parent dialog state
+     * open('CHILD_DIALOG', { params: { data }, stack: true });
      */
     open: (id: string, options?: IDialogLocationOptions) => void;
     /**
-     * Closes the current active dialog if there's one.
+     * Closes dialogs.
+     * @param id - Optional dialog ID to close. If not provided, closes all dialogs.
+     * @example
+     * // Close all dialogs
+     * close();
+     *
+     * @example
+     * // Close a specific dialog (removes it from stack)
+     * close('SPECIFIC_DIALOG_ID');
      */
     close: (id?: string) => void;
     /**

--- a/src/shared/components/dialogProvider/dialogProvider.api.ts
+++ b/src/shared/components/dialogProvider/dialogProvider.api.ts
@@ -68,7 +68,7 @@ export interface IDialogContext {
     /**
      * Updates the options for the current active dialog.
      *
-     * @deprecated This method was mostly used to fix rough edges previous modal approach had. With the new approach there is no state reusing between modals. To be refactored.
+     * @deprecated This method was mostly used to fix rough edges previous modal approach had. With the new approach there is no state reusing between modals. TODO: APP-358.
      */
     updateOptions: (options: Partial<IDialogLocationOptions>) => void;
 }

--- a/src/shared/components/dialogProvider/dialogProvider.api.ts
+++ b/src/shared/components/dialogProvider/dialogProvider.api.ts
@@ -19,7 +19,9 @@ export interface IDialogLocationOptions<TParams extends DialogComponentProps = D
      */
     onClose?: () => void;
     /**
-     * If true, adds the dialog to the stack. If false (default), replaces all dialogs with this one.
+     * If true, adds the dialog onto the stack. If false (default), replaces
+     * existing dialogs with the new one (as in the previous approach with 1 dialog).
+     *
      * Set to true for nested dialogs that should preserve parent dialog state.
      */
     stack?: boolean;
@@ -36,16 +38,12 @@ export interface IDialogLocation<TParams extends DialogComponentProps = DialogCo
 export interface IDialogContext {
     /**
      * Stack of currently open dialogs. The last item is the topmost (active) dialog.
+     * Only active dialog is visible.
      */
     locations: IDialogLocation[];
     /**
-     * The currently active (topmost) dialog location.
-     */
-    location?: IDialogLocation;
-    /**
      * Opens the specified dialog.
-     * @param id - The dialog ID to open
-     * @param options - Dialog options
+     *
      * @example
      * // Replace all dialogs (default behavior)
      * open('MY_DIALOG', { params: { data } });
@@ -57,9 +55,9 @@ export interface IDialogContext {
     open: (id: string, options?: IDialogLocationOptions) => void;
     /**
      * Closes dialogs.
-     * @param id - Optional dialog ID to close. If not provided, closes all dialogs.
+     *
      * @example
-     * // Close all dialogs
+     * // Close all dialogs on stack
      * close();
      *
      * @example
@@ -69,6 +67,8 @@ export interface IDialogContext {
     close: (id?: string) => void;
     /**
      * Updates the options for the current active dialog.
+     *
+     * @deprecated This method was mostly used to fix rough edges previous modal approach had. With the new approach there is no state reusing between modals. To be refactored.
      */
     updateOptions: (options: Partial<IDialogLocationOptions>) => void;
 }

--- a/src/shared/components/dialogProvider/dialogProvider.test.tsx
+++ b/src/shared/components/dialogProvider/dialogProvider.test.tsx
@@ -25,19 +25,63 @@ describe('<DialogProvider /> component', () => {
             const { result } = renderHook(() => useDialogContext(), { wrapper: createTestComponent });
             expect(result.current.open).toBeDefined();
             expect(result.current.close).toBeDefined();
-            expect(result.current.location).not.toBeDefined();
+            expect(result.current.locations).toEqual([]);
         });
 
         it('updates active location on dialog open and close', () => {
             const newLocation = { id: 'dialog-id', params: { customDialogParams: 'value' } };
             const { result } = renderHook(() => useDialogContext(), { wrapper: createTestComponent });
-            expect(result.current.location).not.toBeDefined();
+            expect(result.current.locations).toEqual([]);
 
             act(() => result.current.open(newLocation.id, { params: newLocation.params }));
-            expect(result.current.location).toEqual(newLocation);
+            expect(result.current.locations).toEqual([newLocation]);
 
             act(() => result.current.close());
-            expect(result.current.location).not.toBeDefined();
+            expect(result.current.locations).toEqual([]);
+        });
+
+        it('overwrites the previous dialog by default', () => {
+            const location1 = { id: 'dialog-id-1', params: { customDialogParams: 'value 1' } };
+            const location2 = { id: 'dialog-id-2', params: { customDialogParams: 'value 2' } };
+            const { result } = renderHook(() => useDialogContext(), { wrapper: createTestComponent });
+
+            act(() => result.current.open(location1.id, { params: location1.params }));
+            act(() => result.current.open(location2.id, { params: location2.params }));
+            expect(result.current.locations).toEqual([location2]);
+        });
+
+        it('supports stacked dialogs (parent-child)', () => {
+            const location1 = { id: 'parent-dialog-id', params: { customDialogParams: 'value 1' } };
+            const location2 = { id: 'child-dialog-id', params: { customDialogParams: 'value 2' } };
+            const { result } = renderHook(() => useDialogContext(), { wrapper: createTestComponent });
+
+            act(() => result.current.open(location1.id, { params: location1.params }));
+            act(() => result.current.open(location2.id, { params: location2.params, stack: true }));
+            expect(result.current.locations).toEqual([location1, location2]);
+        });
+
+        it('closes all dialogs by default', () => {
+            const location1 = { id: 'parent-dialog-id', params: { customDialogParams: 'value 1' } };
+            const location2 = { id: 'child-dialog-id', params: { customDialogParams: 'value 2' } };
+            const { result } = renderHook(() => useDialogContext(), { wrapper: createTestComponent });
+
+            act(() => result.current.open(location1.id, { params: location1.params }));
+            act(() => result.current.open(location2.id, { params: location2.params, stack: true }));
+            act(() => result.current.close());
+
+            expect(result.current.locations).toEqual([]);
+        });
+
+        it('closes only selected dialog if provided with ID', () => {
+            const location1 = { id: 'parent-dialog-id', params: { customDialogParams: 'value 1' } };
+            const location2 = { id: 'child-dialog-id', params: { customDialogParams: 'value 2' } };
+            const { result } = renderHook(() => useDialogContext(), { wrapper: createTestComponent });
+
+            act(() => result.current.open(location1.id, { params: location1.params }));
+            act(() => result.current.open(location2.id, { params: location2.params, stack: true }));
+            act(() => result.current.close(location2.id));
+
+            expect(result.current.locations).toEqual([location1]);
         });
     });
 });

--- a/src/shared/components/dialogProvider/dialogProvider.tsx
+++ b/src/shared/components/dialogProvider/dialogProvider.tsx
@@ -20,29 +20,63 @@ export const DialogContext = createContext<IDialogContext | null>(null);
 export const DialogProvider: React.FC<IDialogProviderProps> = (props) => {
     const { children } = props;
 
-    const [location, setLocation] = useState<IDialogLocation>();
+    const [locations, setLocations] = useState<IDialogLocation[]>([]);
 
     const updateOptions = useCallback((options?: Partial<IDialogLocationOptions>) => {
-        setLocation((currentLocation) => (currentLocation != null ? { ...currentLocation, ...options } : undefined));
+        setLocations((currentLocations) => {
+            if (currentLocations.length === 0) {
+                return currentLocations;
+            }
+            const updatedLocations = [...currentLocations];
+            const lastIndex = updatedLocations.length - 1;
+            updatedLocations[lastIndex] = { ...updatedLocations[lastIndex], ...options };
+            return updatedLocations;
+        });
     }, []);
 
     const open = useCallback(
         <TParams extends DialogComponentProps = DialogComponentProps>(
             id: string,
             options?: IDialogLocationOptions<TParams>,
-        ) => setLocation({ id, ...options }),
+        ) => {
+            const { stack = false, ...restOptions } = options ?? {};
+            setLocations((currentLocations) => {
+                // If stack is true, add to stack; otherwise replace all dialogs
+                if (stack) {
+                    return [...currentLocations, { id, ...restOptions }];
+                }
+                return [{ id, ...restOptions }];
+            });
+        },
         [],
     );
 
-    const close = useCallback(
-        (id?: string) =>
-            setLocation((currentLocation) => (id != null && currentLocation?.id != id ? currentLocation : undefined)),
-        [],
-    );
+    const close = useCallback((id?: string) => {
+        setLocations((currentLocations) => {
+            if (currentLocations.length === 0) {
+                return currentLocations;
+            }
+
+            // If no ID provided, close all dialogs (backward compatibility)
+            if (id == null) {
+                return [];
+            }
+
+            // If ID provided, close that specific dialog
+            const index = currentLocations.findIndex((loc) => loc.id === id);
+            if (index === -1) {
+                return currentLocations;
+            }
+
+            return [...currentLocations.slice(0, index), ...currentLocations.slice(index + 1)];
+        });
+    }, []);
+
+    const location = locations.length > 0 ? locations[locations.length - 1] : undefined;
 
     const contextValues = useMemo(
-        () => ({ open, close, location, updateOptions }),
-        [open, close, updateOptions, location],
+        () => ({ open, close, location, locations, updateOptions }),
+        [open, close, updateOptions, location, locations],
     );
 
     return <DialogContext.Provider value={contextValues}>{children}</DialogContext.Provider>;

--- a/src/shared/components/dialogProvider/dialogProvider.tsx
+++ b/src/shared/components/dialogProvider/dialogProvider.tsx
@@ -62,12 +62,7 @@ export const DialogProvider: React.FC<IDialogProviderProps> = (props) => {
             }
 
             // If ID provided, close that specific dialog
-            const index = currentLocations.findIndex((loc) => loc.id === id);
-            if (index === -1) {
-                return currentLocations;
-            }
-
-            return [...currentLocations.slice(0, index), ...currentLocations.slice(index + 1)];
+            return currentLocations.filter((location) => location.id !== id);
         });
     }, []);
 

--- a/src/shared/components/dialogProvider/dialogProvider.tsx
+++ b/src/shared/components/dialogProvider/dialogProvider.tsx
@@ -27,9 +27,11 @@ export const DialogProvider: React.FC<IDialogProviderProps> = (props) => {
             if (currentLocations.length === 0) {
                 return currentLocations;
             }
+
             const updatedLocations = [...currentLocations];
             const lastIndex = updatedLocations.length - 1;
             updatedLocations[lastIndex] = { ...updatedLocations[lastIndex], ...options };
+
             return updatedLocations;
         });
     }, []);
@@ -40,13 +42,10 @@ export const DialogProvider: React.FC<IDialogProviderProps> = (props) => {
             options?: IDialogLocationOptions<TParams>,
         ) => {
             const { stack = false, ...restOptions } = options ?? {};
-            setLocations((currentLocations) => {
-                // If stack is true, add to stack; otherwise replace all dialogs
-                if (stack) {
-                    return [...currentLocations, { id, ...restOptions }];
-                }
-                return [{ id, ...restOptions }];
-            });
+
+            setLocations((currentLocations) =>
+                stack ? [...currentLocations, { id, ...restOptions }] : [{ id, ...restOptions }],
+            );
         },
         [],
     );
@@ -72,11 +71,9 @@ export const DialogProvider: React.FC<IDialogProviderProps> = (props) => {
         });
     }, []);
 
-    const location = locations.length > 0 ? locations[locations.length - 1] : undefined;
-
     const contextValues = useMemo(
-        () => ({ open, close, location, locations, updateOptions }),
-        [open, close, updateOptions, location, locations],
+        () => ({ open, close, locations, updateOptions }),
+        [open, close, updateOptions, locations],
     );
 
     return <DialogContext.Provider value={contextValues}>{children}</DialogContext.Provider>;

--- a/src/shared/components/dialogRoot/dialogRoot.test.tsx
+++ b/src/shared/components/dialogRoot/dialogRoot.test.tsx
@@ -26,8 +26,8 @@ describe('<DialogRoot /> component', () => {
     };
 
     it('renders empty container when no dialog is active', () => {
-        const location = undefined;
-        useDialogContextSpy.mockReturnValue(generateDialogContext({ location }));
+        const locations = undefined;
+        useDialogContextSpy.mockReturnValue(generateDialogContext({ locations }));
         const { container } = render(createTestComponent());
         expect(container).toBeEmptyDOMElement();
     });
@@ -36,8 +36,8 @@ describe('<DialogRoot /> component', () => {
         const dialogId = 'connect-wallet';
         const dialogContent = 'connect-wallet-content';
         const dialogs = { [dialogId]: { Component: () => dialogContent } };
-        const location = { id: dialogId };
-        useDialogContextSpy.mockReturnValue(generateDialogContext({ location }));
+        const locations = [{ id: dialogId }];
+        useDialogContextSpy.mockReturnValue(generateDialogContext({ locations }));
         render(createTestComponent({ dialogs }));
         expect(screen.getByRole('dialog')).toBeInTheDocument();
         expect(screen.getByText(dialogContent)).toBeInTheDocument();
@@ -48,8 +48,8 @@ describe('<DialogRoot /> component', () => {
         const hiddenTitle = 'test-title';
         const hiddenDescription = 'test-description';
         const dialogs = { [dialogId]: { Component: () => 'test', hiddenTitle, hiddenDescription } };
-        const location = { id: dialogId };
-        useDialogContextSpy.mockReturnValue(generateDialogContext({ location }));
+        const locations = [{ id: dialogId }];
+        useDialogContextSpy.mockReturnValue(generateDialogContext({ locations }));
         render(createTestComponent({ dialogs }));
         expect(screen.getByText(hiddenTitle)).toBeInTheDocument();
         expect(screen.getByText(hiddenDescription)).toBeInTheDocument();
@@ -58,9 +58,9 @@ describe('<DialogRoot /> component', () => {
     it('calls the close function set on the dialog-provider on dialog close', async () => {
         const dialogId = 'test';
         const dialogs = { [dialogId]: { Component: () => null } };
-        const location = { id: dialogId };
+        const locations = [{ id: dialogId }];
         const close = jest.fn();
-        useDialogContextSpy.mockReturnValue(generateDialogContext({ location, close }));
+        useDialogContextSpy.mockReturnValue(generateDialogContext({ locations, close }));
         render(createTestComponent({ dialogs }));
         await userEvent.keyboard('{Escape}');
         expect(close).toHaveBeenCalled();
@@ -71,8 +71,8 @@ describe('<DialogRoot /> component', () => {
         const dialogId = 'test';
         const variant = 'critical' as const;
         const dialogs = { [dialogId]: { Component: () => 'test', variant } };
-        const location = { id: dialogId };
-        useDialogContextSpy.mockReturnValue(generateDialogContext({ location }));
+        const locations = [{ id: dialogId }];
+        useDialogContextSpy.mockReturnValue(generateDialogContext({ locations }));
         render(createTestComponent({ dialogs }));
         expect(screen.getByRole('alertdialog')).toBeInTheDocument();
     });

--- a/src/shared/components/dialogRoot/dialogRoot.tsx
+++ b/src/shared/components/dialogRoot/dialogRoot.tsx
@@ -15,49 +15,70 @@ export const DialogRoot: React.FC<IDialogRootProps> = (props) => {
     const { dialogs } = props;
 
     const { t } = useTranslations();
-    const { location, close } = useDialogContext();
+    const { locations, close } = useDialogContext();
 
-    const isOpen = location != null;
-    const activeDialog = location != null ? dialogs[location.id] : undefined;
-
-    const {
-        Component: ActiveDialogComponent,
-        hiddenTitle,
-        hiddenDescription,
-        ...activeDialogProps
-    } = activeDialog ?? {};
-
-    const isAlertDialog = 'variant' in activeDialogProps;
-    const { disableOutsideClick, onClose } = location ?? {};
-
-    const handleInteractOutside = (event: Event) => {
-        if (disableOutsideClick) {
-            event.preventDefault();
-        }
-    };
-
-    const handleOpenChange = () => {
-        const closeFunction = onClose ?? close;
-        closeFunction();
-    };
-
-    const DialogWrapper = isAlertDialog ? DialogAlert.Root : Dialog.Root;
-
-    const processedHiddenTitle = hiddenTitle ? t(hiddenTitle) : undefined;
-    const processedHiddenDescription = hiddenDescription ? t(hiddenDescription) : undefined;
-    const onOpenChange = !isAlertDialog ? handleOpenChange : undefined;
-
+    // Render each dialog in the stack but only top one should be visible.
+    // Non-visible dialogs should still be rendered in order to keep the state. Useful in parent-child dialog relationships.
     return (
-        <DialogWrapper
-            {...props}
-            open={isOpen}
-            onOpenChange={onOpenChange}
-            onInteractOutside={handleInteractOutside}
-            hiddenTitle={processedHiddenTitle}
-            hiddenDescription={processedHiddenDescription}
-            {...activeDialogProps}
-        >
-            {ActiveDialogComponent && <ActiveDialogComponent location={location!} />}
-        </DialogWrapper>
+        <>
+            {locations.map((location, index) => {
+                const isTopmost = index === locations.length - 1;
+                const activeDialog = dialogs[location.id];
+
+                if (!activeDialog) {
+                    return null;
+                }
+
+                const {
+                    Component: ActiveDialogComponent,
+                    hiddenTitle,
+                    hiddenDescription,
+                    ...activeDialogProps
+                } = activeDialog;
+
+                const isAlertDialog = 'variant' in activeDialogProps;
+                const { disableOutsideClick, onClose } = location;
+
+                const handleInteractOutside = (event: Event) => {
+                    // Only handle interaction for the topmost dialog
+                    if (!isTopmost) {
+                        event.preventDefault();
+                        return;
+                    }
+
+                    if (disableOutsideClick) {
+                        event.preventDefault();
+                    }
+                };
+
+                const handleOpenChange = () => {
+                    const closeFunction = onClose ?? (() => close(location.id));
+                    closeFunction();
+                };
+
+                const DialogWrapper = isAlertDialog ? DialogAlert.Root : Dialog.Root;
+
+                const processedHiddenTitle = hiddenTitle ? t(hiddenTitle) : undefined;
+                const processedHiddenDescription = hiddenDescription ? t(hiddenDescription) : undefined;
+                const onOpenChange = !isAlertDialog ? handleOpenChange : undefined;
+
+                return (
+                    <DialogWrapper
+                        key={`${location.id}-${index}`}
+                        {...props}
+                        open={true}
+                        onOpenChange={onOpenChange}
+                        onInteractOutside={handleInteractOutside}
+                        hiddenTitle={processedHiddenTitle}
+                        hiddenDescription={processedHiddenDescription}
+                        {...activeDialogProps}
+                    >
+                        <div style={{ display: isTopmost ? 'contents' : 'none' }}>
+                            <ActiveDialogComponent location={location} />
+                        </div>
+                    </DialogWrapper>
+                );
+            })}
+        </>
     );
 };

--- a/src/shared/components/dialogRoot/dialogRoot.tsx
+++ b/src/shared/components/dialogRoot/dialogRoot.tsx
@@ -8,7 +8,7 @@ export interface IDialogRootProps extends IGukDialogRootProps {
     /**
      * Dialogs of the application.
      */
-    dialogs: Record<string, IDialogComponentDefinitions>;
+    dialogs: Partial<Record<string, IDialogComponentDefinitions>>;
 }
 
 export const DialogRoot: React.FC<IDialogRootProps> = (props) => {
@@ -23,9 +23,9 @@ export const DialogRoot: React.FC<IDialogRootProps> = (props) => {
         <>
             {locations.map((location, index) => {
                 const isTopmost = index === locations.length - 1;
-                const activeDialog = dialogs[location.id];
+                const dialogDefinition = dialogs[location.id];
 
-                if (!activeDialog) {
+                if (dialogDefinition == null) {
                     return null;
                 }
 
@@ -33,10 +33,10 @@ export const DialogRoot: React.FC<IDialogRootProps> = (props) => {
                     Component: ActiveDialogComponent,
                     hiddenTitle,
                     hiddenDescription,
-                    ...activeDialogProps
-                } = activeDialog;
+                    ...otherDialogProps
+                } = dialogDefinition;
 
-                const isAlertDialog = 'variant' in activeDialogProps;
+                const isAlertDialog = 'variant' in otherDialogProps;
                 const { disableOutsideClick, onClose } = location;
 
                 const handleInteractOutside = (event: Event) => {
@@ -64,14 +64,13 @@ export const DialogRoot: React.FC<IDialogRootProps> = (props) => {
 
                 return (
                     <DialogWrapper
-                        key={`${location.id}-${index}`}
-                        {...props}
+                        key={`${location.id}-${String(index)}`}
                         open={true}
                         onOpenChange={onOpenChange}
                         onInteractOutside={handleInteractOutside}
                         hiddenTitle={processedHiddenTitle}
                         hiddenDescription={processedHiddenDescription}
-                        {...activeDialogProps}
+                        {...otherDialogProps}
                     >
                         <div style={{ display: isTopmost ? 'contents' : 'none' }}>
                             <ActiveDialogComponent location={location} />

--- a/src/shared/components/transactionDialog/transactionDialog.tsx
+++ b/src/shared/components/transactionDialog/transactionDialog.tsx
@@ -41,6 +41,7 @@ export const TransactionDialog = <TCustomStepId extends string>(props: ITransact
 
     const { t } = useTranslations();
     const { switchChain, status: switchChainStatus } = useSwitchChain();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { updateOptions } = useDialogContext();
 
     // Make the onSuccess property stable to only trigger it once on transaction success

--- a/src/shared/components/wizards/wizardDialog/wizardDialogContainer/wizardDialogContainer.tsx
+++ b/src/shared/components/wizards/wizardDialog/wizardDialogContainer/wizardDialogContainer.tsx
@@ -28,6 +28,7 @@ export const WizardDialogContainer = <TFormData extends FieldValues = FieldValue
     const { title, description, formId, initialSteps, submitLabel, onSubmit, children, defaultValues, ...formProps } =
         props;
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { close, updateOptions } = useDialogContext();
 
     useEffect(() => {

--- a/src/shared/testUtils/generators/dialogContext.ts
+++ b/src/shared/testUtils/generators/dialogContext.ts
@@ -1,18 +1,13 @@
 import type { IDialogContext } from '@/shared/components/dialogProvider';
 
 export const generateDialogContext = (values?: Partial<IDialogContext>): IDialogContext => {
-    const { location, locations, ...rest } = values ?? {};
-    
-    // If location is provided but not locations, create locations array from location
-    const finalLocations = locations ?? (location ? [location] : []);
-    const finalLocation = finalLocations.length > 0 ? finalLocations[finalLocations.length - 1] : undefined;
-    
+    const { locations, ...rest } = values ?? {};
+
     return {
         open: jest.fn(),
         close: jest.fn(),
         updateOptions: jest.fn(),
-        locations: finalLocations,
-        location: finalLocation,
+        locations: locations ?? [],
         ...rest,
     };
 };

--- a/src/shared/testUtils/generators/dialogContext.ts
+++ b/src/shared/testUtils/generators/dialogContext.ts
@@ -1,8 +1,18 @@
 import type { IDialogContext } from '@/shared/components/dialogProvider';
 
-export const generateDialogContext = (values?: Partial<IDialogContext>): IDialogContext => ({
-    open: jest.fn(),
-    close: jest.fn(),
-    updateOptions: jest.fn(),
-    ...values,
-});
+export const generateDialogContext = (values?: Partial<IDialogContext>): IDialogContext => {
+    const { location, locations, ...rest } = values ?? {};
+    
+    // If location is provided but not locations, create locations array from location
+    const finalLocations = locations ?? (location ? [location] : []);
+    const finalLocation = finalLocations.length > 0 ? finalLocations[finalLocations.length - 1] : undefined;
+    
+    return {
+        open: jest.fn(),
+        close: jest.fn(),
+        updateOptions: jest.fn(),
+        locations: finalLocations,
+        location: finalLocation,
+        ...rest,
+    };
+};


### PR DESCRIPTION
# Description

Extend current dialog architecture to support parent-child stacked dialogs where parent state is preserved. 
Some nice side effects:
- transitions between dialogs are smoother now, because each dialog is inside it's own wrapper.
- updateOptions and its kludges are probably not needed any more. I left it for now, not to spend time refactoring further, but in general new implementation is intended to be backward compatible.

Task: APP-357

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
