### PR TITLE
fix(APP-372): Fix DAO display without plugins

### DIFF
--- a/.changeset/sharp-sheep-appear.md
+++ b/.changeset/sharp-sheep-appear.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app': patch
+---
+
+Improve handling for DAOs which have no installed plugins

--- a/src/shared/api/aragonBackendService/aragonBackendServiceError.test.ts
+++ b/src/shared/api/aragonBackendService/aragonBackendServiceError.test.ts
@@ -30,12 +30,13 @@ describe('AragonBackendServiceError class', () => {
         it('generates a default error instance on parse response error', async () => {
             const response = generateResponse({
                 status: 500,
+                url: 'http://test.com',
                 headers: new Headers({ 'content-type': 'application/json' }),
                 json: () => Promise.reject(new Error('Invalid JSON')),
             });
             const aragonError = await AragonBackendServiceError.fromResponse(response);
             expect(aragonError.code).toEqual(AragonBackendServiceError.parseErrorCode);
-            expect(aragonError.description).toEqual(AragonBackendServiceError.parseErrorDescription);
+            expect(aragonError.description).toEqual('Error parsing response (status=500, url=http://test.com)');
         });
     });
 

--- a/src/shared/api/aragonBackendService/aragonBackendServiceError.ts
+++ b/src/shared/api/aragonBackendService/aragonBackendServiceError.ts
@@ -20,25 +20,25 @@ export class AragonBackendServiceError extends Error {
     }
 
     static fromResponse = async (response: Response): Promise<AragonBackendServiceError> => {
-        try {
-            const parsedData = await responseUtils.safeJsonParse(response);
+        const parsedData = await responseUtils.safeJsonParse(response);
 
-            const isIErrorResponse = (value: unknown): value is IErrorResponse =>
-                value != null &&
-                typeof value === 'object' &&
-                'code' in (value as Record<string, unknown>) &&
-                typeof (value as Record<string, unknown>).code === 'string' &&
-                'description' in (value as Record<string, unknown>) &&
-                typeof (value as Record<string, unknown>).description === 'string';
+        const isIErrorResponse = (value: unknown): value is IErrorResponse =>
+            value != null &&
+            typeof value === 'object' &&
+            'code' in (value as Record<string, unknown>) &&
+            typeof (value as Record<string, unknown>).code === 'string' &&
+            'description' in (value as Record<string, unknown>) &&
+            typeof (value as Record<string, unknown>).description === 'string';
 
-            if (isIErrorResponse(parsedData)) {
-                return new AragonBackendServiceError(parsedData.code, parsedData.description, response.status);
-            }
-
-            return new AragonBackendServiceError(this.parseErrorCode, this.parseErrorDescription, response.status);
-        } catch {
-            return new AragonBackendServiceError(this.parseErrorCode, this.parseErrorDescription, response.status);
+        if (isIErrorResponse(parsedData)) {
+            return new AragonBackendServiceError(parsedData.code, parsedData.description, response.status);
         }
+
+        return new AragonBackendServiceError(
+            this.parseErrorCode,
+            `${this.parseErrorDescription} (status=${response.status}, url=${response.url})`,
+            response.status,
+        );
     };
 
     static isNotFoundError = (error: unknown) =>

--- a/src/shared/api/aragonBackendService/aragonBackendServiceError.ts
+++ b/src/shared/api/aragonBackendService/aragonBackendServiceError.ts
@@ -36,7 +36,7 @@ export class AragonBackendServiceError extends Error {
 
         return new AragonBackendServiceError(
             this.parseErrorCode,
-            `${this.parseErrorDescription} (status=${response.status}, url=${response.url})`,
+            `${this.parseErrorDescription} (status=${String(response.status)}, url=${response.url})`,
             response.status,
         );
     };

--- a/src/shared/api/daoService/daoService.ts
+++ b/src/shared/api/daoService/daoService.ts
@@ -1,3 +1,4 @@
+import { monitoringUtils } from '@/shared/utils/monitoringUtils';
 import { AragonBackendService, type IPaginatedResponse } from '../aragonBackendService';
 import { pluginsService } from '../pluginsService';
 import type { IGetDaoByEnsParams, IGetDaoParams, IGetDaoPermissionsParams } from './daoService.api';
@@ -40,10 +41,15 @@ class DaoService extends AragonBackendService {
             return dao as IDao;
         }
 
-        const { network, address } = this.parseDaoId(dao.id);
-        const plugins = await pluginsService.getPluginsByDao({ urlParams: { network, address } });
+        try {
+            const { network, address } = this.parseDaoId(dao.id);
+            const plugins = await pluginsService.getPluginsByDao({ urlParams: { network, address } });
 
-        return { ...dao, plugins };
+            return { ...dao, plugins };
+        } catch (error) {
+            monitoringUtils.logError(error);
+            return dao as IDao;
+        }
     };
 
     getDao = async (params: IGetDaoParams): Promise<IDao> => {


### PR DESCRIPTION


# Description

The `/v2/plugins/by-dao/:network/:address/details` endpoint was returning 404 while being called as part of DAO loading, which surfaced as a parsing/backend error and caused DAO pages to fail instead of simply treating that situation as “this DAO has no plugins.”

- Improves `AragonBackendServiceError` to handle bare 404 responses from the backend.
- Updates error handling logic.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
