### PR TITLE
fix(APP-375): Add plugin metadata to prepare installation calls

### DIFF
--- a/.changeset/some-squids-slide.md
+++ b/.changeset/some-squids-slide.md
@@ -1,0 +1,5 @@
+---
+'@aragon/app': patch
+---
+
+Fix policy plugin metadata setup

--- a/src/modules/capitalFlow/constants/capitalFlowAddresses.ts
+++ b/src/modules/capitalFlow/constants/capitalFlowAddresses.ts
@@ -64,6 +64,7 @@ export const capitalFlowAddresses: Record<Network, Record<string, Hex>> = {
         burnRouterPluginRepo: '0x918C92BcA068112ee294c46Ea7F96daa1414e6b8',
         cowSwapRouterPluginRepo: '0x4647f76D043513ab46AF300c0B42Ed7de6A42912',
         multiDispatchRouterPluginRepo: '0xAa1dD29e1e093C59708EDd8090878fF4f4b1Aa41',
+        uniswapRouterPluginRepo: '0x73059fB7D743567B5699fe214c5D0CcDCb42d362',
     },
     [Network.POLYGON_MAINNET]: {
         // model factories

--- a/src/modules/capitalFlow/constants/capitalFlowAddresses.ts
+++ b/src/modules/capitalFlow/constants/capitalFlowAddresses.ts
@@ -56,7 +56,7 @@ export const capitalFlowAddresses: Record<Network, Record<string, Hex>> = {
         claimerSourceFactory: '0x1134703E2a6713c1bC43DF35A08d82A8A1e59b11',
         omniSourceFactory: '0xEB9e27056cBfD6E1a22ee051a44787Cf2FBbe911',
         // plugin repos
-        routerPluginRepo: '0x1bd5970DCEB7168c65b1A226ED71Fb632c3Def47',
+        routerPluginRepo: '0xb2dA3445C77251CfcA8C0EBcF8eeb3EdB63277DD',
         claimerPluginRepo: '0x70f636D481898E897FceDB182074eF61e05FbbD0',
         burnRouterPluginRepo: '0x42718AB262073EFFB1AC6d538a4BD6717039d4b3',
         cowSwapRouterPluginRepo: '0x7B87891e796Ee908c2F6bC95e678A3e546E3099E',

--- a/src/modules/capitalFlow/constants/capitalFlowAddresses.ts
+++ b/src/modules/capitalFlow/constants/capitalFlowAddresses.ts
@@ -56,11 +56,11 @@ export const capitalFlowAddresses: Record<Network, Record<string, Hex>> = {
         claimerSourceFactory: '0x1134703E2a6713c1bC43DF35A08d82A8A1e59b11',
         omniSourceFactory: '0xEB9e27056cBfD6E1a22ee051a44787Cf2FBbe911',
         // plugin repos
-        routerPluginRepo: '0xb2dA3445C77251CfcA8C0EBcF8eeb3EdB63277DD',
-        claimerPluginRepo: '0x70f636D481898E897FceDB182074eF61e05FbbD0',
-        burnRouterPluginRepo: '0x42718AB262073EFFB1AC6d538a4BD6717039d4b3',
-        cowSwapRouterPluginRepo: '0x7B87891e796Ee908c2F6bC95e678A3e546E3099E',
-        multiDispatchRouterPluginRepo: '0x96eEb45FA090378265e3A3645D48e190F9c165b5',
+        routerPluginRepo: '0x4bC521AE26F41ee92A5D5D07B104fb467502a8Ee',
+        claimerPluginRepo: '0x237440E03441D0F0Ca6e8163595DA4bB8c1625A7',
+        burnRouterPluginRepo: '0x918C92BcA068112ee294c46Ea7F96daa1414e6b8',
+        cowSwapRouterPluginRepo: '0x4647f76D043513ab46AF300c0B42Ed7de6A42912',
+        multiDispatchRouterPluginRepo: '0xAa1dD29e1e093C59708EDd8090878fF4f4b1Aa41',
     },
     [Network.POLYGON_MAINNET]: {
         // model factories

--- a/src/modules/capitalFlow/dialogs/preparePolicyDialog/preparePolicyDialogUtils.ts
+++ b/src/modules/capitalFlow/dialogs/preparePolicyDialog/preparePolicyDialogUtils.ts
@@ -338,6 +338,7 @@ class PreparePolicyDialogUtils {
                     isStreamingSource,
                     targetTokenAddress as Hex,
                     uniswapRouterAddress as Hex,
+                    pluginMetadataHex,
                 ]);
                 pluginRepo = uniswapRouterPluginRepo;
                 break;

--- a/src/modules/capitalFlow/dialogs/preparePolicyDialog/routerPluginSetupAbi.ts
+++ b/src/modules/capitalFlow/dialogs/preparePolicyDialog/routerPluginSetupAbi.ts
@@ -29,4 +29,5 @@ export const uniswapRouterPluginSetupAbi = [
     { name: '_isStreamingSource', type: 'bool' },
     { name: '_targetToken', type: 'address' },
     { name: '_uniswapRouter', type: 'address' },
+    { name: '_pluginMetadata', type: 'bytes' },
 ] as const;

--- a/src/modules/capitalFlow/dialogs/preparePolicyDialog/routerPluginSetupAbi.ts
+++ b/src/modules/capitalFlow/dialogs/preparePolicyDialog/routerPluginSetupAbi.ts
@@ -2,11 +2,13 @@ export const routerPluginSetupAbi = [
     { name: '_routerSource', type: 'address' },
     { name: '_isStreamingSource', type: 'bool' },
     { name: '_routerModel', type: 'address' },
+    { name: '_pluginMetadata', type: 'bytes' },
 ] as const;
 
 export const burnRouterPluginSetupAbi = [
     { name: '_routerSource', type: 'address' },
     { name: '_isStreamingSource', type: 'bool' },
+    { name: '_pluginMetadata', type: 'bytes' },
 ] as const;
 
 export const cowSwapRouterPluginSetupAbi = [
@@ -14,6 +16,10 @@ export const cowSwapRouterPluginSetupAbi = [
     { name: '_isStreamingSource', type: 'bool' },
     { name: '_targetToken', type: 'address' },
     { name: '_cowSwapSettlement', type: 'address' },
+    { name: '_pluginMetadata', type: 'bytes' },
 ] as const;
 
-export const multiDispatchPluginSetupAbi = [{ name: '_subrouters', type: 'address[]' }] as const;
+export const multiDispatchPluginSetupAbi = [
+    { name: '_subrouters', type: 'address[]' },
+    { name: '_pluginMetadata', type: 'bytes' },
+] as const;


### PR DESCRIPTION
# Description

Add missing plugin metadata to prepare installation calls.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
