### PR TITLE
docs: fix typos in documentation and code comments

### DIFF
--- a/docs/codingGuidelines/namingConventions.md
+++ b/docs/codingGuidelines/namingConventions.md
@@ -5,7 +5,7 @@ these conventions enhances code readability, maintainability, and consistency ac
 
 ## Components
 
-- Use Camel Case and `.tsx` file extention for component file names (e.g. `daoList.tsx`).
+- Use Camel Case and `.tsx` file extension for component file names (e.g. `daoList.tsx`).
 - Use Pascal Case for component names (e.g. `DaoList`).
 - Ensure the file name always matches the component name.
 - Add `page` suffix to page components (e.g. `ExploreDaosPage`)

--- a/src/modules/finance/components/assetInput/assetInput.tsx
+++ b/src/modules/finance/components/assetInput/assetInput.tsx
@@ -44,7 +44,7 @@ export interface IAssetInputFormData {
      */
     amount?: string;
     /**
-     * The token to be transfered.
+     * The token to be transferred.
      */
     asset?: IAsset;
 }

--- a/src/shared/hooks/useFormField/useFormField.api.ts
+++ b/src/shared/hooks/useFormField/useFormField.api.ts
@@ -41,7 +41,7 @@ export interface IUseFormFieldOptions<
      */
     control?: UseControllerProps<TFieldValues, TName>['control'];
     /**
-     * Value to be forwarded to the translation function when definining custom error messages.
+     * Value to be forwarded to the translation function when defining custom error messages.
      */
     alertValue?: ITFuncOptions;
     /**


### PR DESCRIPTION

### Changes
- `docs/codingGuidelines/namingConventions.md`: `extention` → `extension`
- `src/modules/finance/components/assetInput/assetInput.tsx`: `transfered` → `transferred`
- `src/shared/hooks/useFormField/useFormField.api.ts`: `definining` → `defining`

