### PR TITLE
fix(APP-377): Allow for spaces when typing on ActionComposer input

### DIFF
--- a/.changeset/tidy-doors-pick.md
+++ b/.changeset/tidy-doors-pick.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Allow for spaces when typing on ActionComposer input

--- a/src/modules/governance/components/actionComposer/actionComposer/actionComposer.test.tsx
+++ b/src/modules/governance/components/actionComposer/actionComposer/actionComposer.test.tsx
@@ -1,5 +1,6 @@
 import { GukModulesProvider } from '@aragon/gov-ui-kit';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as daoService from '@/shared/api/daoService';
 import { DialogProvider } from '@/shared/components/dialogProvider';
 import {
@@ -50,5 +51,21 @@ describe('ActionComposer', () => {
         expect(
             screen.queryByRole('button', { name: /walletConnect/i }),
         ).not.toBeInTheDocument();
+    });
+
+    it('allows spaces while typing in the action search input', async () => {
+        const user = userEvent.setup();
+        render(createTestComponent());
+
+        await user.click(
+            screen.getByRole('button', {
+                name: 'app.governance.actionComposer.addAction.default',
+            }),
+        );
+
+        const input = screen.getByRole('combobox');
+        await user.type(input, 'Set metadata');
+
+        expect(input).toHaveValue('Set metadata');
     });
 });

--- a/src/shared/components/forms/autocompleteInput/autocompleteInput.test.tsx
+++ b/src/shared/components/forms/autocompleteInput/autocompleteInput.test.tsx
@@ -285,7 +285,7 @@ describe('<AutocompleteInput /> component', () => {
         const input = screen.getByRole('combobox');
         // includes control char and potential html - use paste to input all at once
         await userEvent.click(input);
-        await userEvent.paste('\u0000<script>alert(1)</script> one ');
+        await userEvent.paste('\u0000<script>alert(1)</script> one');
         // Verify input value is sanitized
         expect(input).toHaveValue('alert(1) one');
         // pick the visible option

--- a/src/shared/components/forms/autocompleteInput/autocompleteInput.tsx
+++ b/src/shared/components/forms/autocompleteInput/autocompleteInput.tsx
@@ -74,7 +74,13 @@ export const AutocompleteInput = forwardRef<
     } = autocompleteInputProps;
 
     const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-        setInputValue(sanitizePlainText(event.target.value));
+        const rawValue = event.target.value;
+        const sanitizedValue = sanitizePlainText(rawValue);
+        const shouldPreserveTrailingSpace =
+            sanitizedValue.length > 0 && /\s$/.test(rawValue);
+        setInputValue(
+            shouldPreserveTrailingSpace ? `${sanitizedValue} ` : sanitizedValue,
+        );
         setActiveIndex(0);
     };
 


### PR DESCRIPTION
# Description

Adjust sensitization logic within onChange handler

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [x] Patch: Enhancement (non-breaking change to an existing feature)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [x] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [x] Confirmed that changes follow the code style guidelines of this project
