### PR TITLE
fix(APP-438: UpdateGaugeMetadata action fails to add new resources

### DIFF
--- a/.changeset/afraid-stars-camp.md
+++ b/.changeset/afraid-stars-camp.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix updateGaugeMetadata form initialization

--- a/src/actions/gaugeVoter/components/gaugeVoterUpdateGaugeMetadataActionCreate/gaugeVoterUpdateGaugeMetadataActionCreate.tsx
+++ b/src/actions/gaugeVoter/components/gaugeVoterUpdateGaugeMetadataActionCreate/gaugeVoterUpdateGaugeMetadataActionCreate.tsx
@@ -8,7 +8,7 @@ import {
     invariant,
 } from '@aragon/gov-ui-kit';
 import { useCallback, useEffect } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { encodeFunctionData } from 'viem';
 import type { IProposalAction } from '@/modules/governance/api/governanceService';
 import {
@@ -63,16 +63,22 @@ export const GaugeVoterUpdateGaugeMetadataActionCreate: React.FC<
         unregister(`${actionFieldName}.gaugeDetails`);
     };
 
-    const { value: selectedGauge, alert } = useFormField<
-        Record<string, IGauge | undefined>,
-        string
-    >(selectedGaugeFieldName, {
-        label: t(
-            'app.actions.gaugeVoter.gaugeVoterUpdateGaugeMetadataActionCreate.emptyCard.heading',
-        ),
-        rules: {
-            required: true,
+    // Use useFormField for validation and alert handling
+    const { alert } = useFormField<Record<string, IGauge | undefined>, string>(
+        selectedGaugeFieldName,
+        {
+            label: t(
+                'app.actions.gaugeVoter.gaugeVoterUpdateGaugeMetadataActionCreate.emptyCard.heading',
+            ),
+            rules: {
+                required: true,
+            },
         },
+    );
+
+    // Use useWatch for reactive value updates when setValue is called
+    const selectedGauge = useWatch<Record<string, IGauge | undefined>>({
+        name: selectedGaugeFieldName,
     });
 
     const handleOpenGaugeSelectDialog = () => {

--- a/src/shared/components/forms/resourcesInput/resourcesInput.tsx
+++ b/src/shared/components/forms/resourcesInput/resourcesInput.tsx
@@ -1,7 +1,7 @@
 import { Button, IconType, InputContainer } from '@aragon/gov-ui-kit';
-import { useEffect } from 'react';
 import { useFieldArray } from 'react-hook-form';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { useFormField } from '@/shared/hooks/useFormField';
 import type {
     IResourcesInputProps,
     IResourcesInputResource,
@@ -16,15 +16,16 @@ export const ResourcesInput: React.FC<IResourcesInputProps> = (props) => {
     const fieldName = fieldPrefix ? `${fieldPrefix}.${name}` : name;
 
     const { t } = useTranslations();
-    const { fields, append, remove, replace } =
-        useFieldArray<ResourcesInputBaseForm>({ name: fieldName });
 
-    useEffect(() => {
-        if (defaultValue) {
-            replace(defaultValue);
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [replace, defaultValue]);
+    // To properly init with defaultValue if provided
+    useFormField<ResourcesInputBaseForm, typeof name>(name, {
+        fieldPrefix,
+        defaultValue: defaultValue ?? [],
+    });
+
+    const { fields, append, remove } = useFieldArray<ResourcesInputBaseForm>({
+        name: fieldName,
+    });
 
     return (
         <div className="flex flex-col gap-2 md:gap-3">


### PR DESCRIPTION
# Description

Fixes APP-438 - UpdateGaugeMetadata action was failing when adding new resource links because the field values were being reset when navigating between wizard steps.

## Root Cause
The `ResourcesInput` component was using a `useEffect` with `defaultValue` in the dependency array, causing it to re-run and call `replace(defaultValue)` whenever the component re-rendered. This reset all user input including newly added resource items.

## Solution
1. **Moved default value registration into `ResourcesInput`**: The component now uses `useFormField` internally to register the field with its default value, making it work correctly across all forms.

2. **Fixed reactive value updates in parent component**: Used `useWatch` instead of relying solely on `useFormField`'s value to ensure the selected gauge value updates immediately when `setValue` is called (e.g., when removing a gauge).

### Files Changed
- `src/shared/components/forms/resourcesInput/resourcesInput.tsx` - Added `useFormField` to register field with default value internally
- `src/actions/gaugeVoter/components/gaugeVoterUpdateGaugeMetadataActionCreate/gaugeVoterUpdateGaugeMetadataActionCreate.tsx` - Used `useWatch` for reactive value updates

## Type of Change

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project