### PR TITLE
Release v1.19.0

### DIFF
--- a/.changeset/afraid-stars-camp.md
+++ b/.changeset/afraid-stars-camp.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Fix updateGaugeMetadata form initialization

--- a/.changeset/nine-bees-poke.md
+++ b/.changeset/nine-bees-poke.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Implement debounced IPFS background pinning on metadata actions in composer

--- a/.changeset/public-otters-itch.md
+++ b/.changeset/public-otters-itch.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Implement decoding of uploaded actions

--- a/.changeset/smart-carrots-tan.md
+++ b/.changeset/smart-carrots-tan.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Fix infinite loop issue on create proposal page reload

--- a/.changeset/spotty-carrots-raise.md
+++ b/.changeset/spotty-carrots-raise.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Dependency update

--- a/.changeset/tidy-doors-pick.md
+++ b/.changeset/tidy-doors-pick.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Allow for spaces when typing on ActionComposer input

--- a/.changeset/violet-cameras-wait.md
+++ b/.changeset/violet-cameras-wait.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Improve multi-dispatch router UX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @aragon/app
 
+## 1.19.0
+
+### Minor Changes
+
+- [#931](https://github.com/aragon/app/pull/931) [`fc28a5c`](https://github.com/aragon/app/commit/fc28a5ccb4d5028466226ed771e537e340aaf7e2) Thanks [@thekidnamedkd](https://github.com/thekidnamedkd)! - Implement debounced IPFS background pinning on metadata actions in composer
+
+- [#932](https://github.com/aragon/app/pull/932) [`10f9f05`](https://github.com/aragon/app/commit/10f9f055c5a5f0bb1741c788d10089fb5dd49567) Thanks [@milosh86](https://github.com/milosh86)! - Implement decoding of uploaded actions
+
+- [#942](https://github.com/aragon/app/pull/942) [`c2af304`](https://github.com/aragon/app/commit/c2af30440b7e6000505c0cbefd6c21e00bdd6c95) Thanks [@milosh86](https://github.com/milosh86)! - Improve multi-dispatch router UX
+
+### Patch Changes
+
+- [#946](https://github.com/aragon/app/pull/946) [`a9c9f32`](https://github.com/aragon/app/commit/a9c9f324a81c8f1a20a34d0e48bbe4efd33b59ab) Thanks [@milosh86](https://github.com/milosh86)! - Fix updateGaugeMetadata form initialization
+
+- [#943](https://github.com/aragon/app/pull/943) [`a4b3942`](https://github.com/aragon/app/commit/a4b3942b3a84b4aacba94be8a9741fb8af9b7356) Thanks [@milosh86](https://github.com/milosh86)! - Fix infinite loop issue on create proposal page reload
+
+- [#929](https://github.com/aragon/app/pull/929) [`ea5464c`](https://github.com/aragon/app/commit/ea5464c9b31ea89428dcf4422a33ebeefab1c977) Thanks [@dependabot](https://github.com/apps/dependabot)! - Dependency update
+
+- [#939](https://github.com/aragon/app/pull/939) [`1cada4e`](https://github.com/aragon/app/commit/1cada4e3dd1bdae43917d07b93b2e54289825d39) Thanks [@thekidnamedkd](https://github.com/thekidnamedkd)! - Allow for spaces when typing on ActionComposer input
+
 ## 1.18.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/app",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Human-centered DAO infrastructure",
   "author": "Aragon Association",
   "homepage": "https://github.com/aragon/app#readme",


### PR DESCRIPTION
## Features
- Implement new GitHub Actions for release management ([#944](https://github.com/aragon/app/pull/944)) — [APP-437: Improve release automation](https://linear.app/aragon/issue/APP-437/improve-release-automation)
- Improve multi-dispatch router UX ([#942](https://github.com/aragon/app/pull/942)) — [APP-415: Improved multidispatch router UX](https://linear.app/aragon/issue/APP-415/improved-multidispatch-router-ux)
- Implement IPFS pinning on download in proposal action composition ([#931](https://github.com/aragon/app/pull/931)) — [APP-385: Additional action builder options in dropdown](https://linear.app/aragon/issue/APP-385/additional-action-builder-options-in-dropdown)
- Introduce new workflows for app release ([#933](https://github.com/aragon/app/pull/933))
- Migrate feature flags to latest pattern ([#930](https://github.com/aragon/app/pull/930)) — [APP-51: Move existing feature flags to the debug menu](https://linear.app/aragon/issue/APP-51/move-existing-feature-flags-to-the-debug-menu)
- Implement dropdown for download, remove all actions on proposal creation ([#921](https://github.com/aragon/app/pull/921))
- Add basic actions for gaugeVoter contract ([#904](https://github.com/aragon/app/pull/904)) — [APP-314: Basic action UI for gauge management](https://linear.app/aragon/issue/APP-314/basic-action-ui-for-gauge-management)

## Fixes
- fix(APP-438: UpdateGaugeMetadata action fails to add new resources ([#946](https://github.com/aragon/app/pull/946)) — [APP-438: UpdateGaugeMetadata action fails to add new resources](https://linear.app/aragon/issue/APP-438/updategaugemetadata-action-fails-to-add-new-resources)
- Fix infinite loop issue on create proposal page reload  ([#943](https://github.com/aragon/app/pull/943)) — [APP-446: Create proposal page breaks on reload](https://linear.app/aragon/issue/APP-446/create-proposal-page-breaks-on-reload)
- Allow for spaces when typing on ActionComposer input ([#939](https://github.com/aragon/app/pull/939)) — [APP-377: Action composer search don't allow spaces](https://linear.app/aragon/issue/APP-377/action-composer-search-dont-allow-spaces)
- downgrade jsdom to version 26.1.0 to get rid of esmodule resolution error ([#941](https://github.com/aragon/app/pull/941))
- Use prettier for changelog formatting; change codeowners ([#934](https://github.com/aragon/app/pull/934)) — [APP-371: Release automation](https://linear.app/aragon/issue/APP-371/release-automation)

## Other Changes
- Release v1.19.0
- Move heavy checks from pre-commit to pre-push hook ([#945](https://github.com/aragon/app/pull/945)) — [APP-447: Update husky/git hooks logic in the app repo](https://linear.app/aragon/issue/APP-447/update-huskygit-hooks-logic-in-the-app-repo)
- APP-42: Decode uploaded actions ([#932](https://github.com/aragon/app/pull/932)) — [APP-42: Decode entered raw calldata and update action name when we have the ABI](https://linear.app/aragon/issue/APP-42/decode-entered-raw-calldata-and-update-action-name-when-we-have-the)
- Release v1.18.0 ([#935](https://github.com/aragon/app/pull/935))
- Update Node.js version to 24.13.0 ([#940](https://github.com/aragon/app/pull/940))
- Bump the minor-and-patch group across 1 directory with 18 updates ([#929](https://github.com/aragon/app/pull/929))
- Update biome configuration and package manager version ([#922](https://github.com/aragon/app/pull/922))
- Bump 1password/load-secrets-action ([#926](https://github.com/aragon/app/pull/926))
- Implement Biome toolchain ([#920](https://github.com/aragon/app/pull/920)) — [APP-315: Migrate from ESLint and Prettier to Biome](https://linear.app/aragon/issue/APP-315/migrate-from-eslint-and-prettier-to-biome)
- Bump actions/download-artifact from 6.0.0 to 7.0.0 ([#915](https://github.com/aragon/app/pull/915))
- Bump actions/upload-artifact from 5.0.0 to 6.0.0 ([#914](https://github.com/aragon/app/pull/914))
- Bump actions/cache from 4.3.0 to 5.0.1 ([#913](https://github.com/aragon/app/pull/913))



<!-- slack_ts: 1768837983.385259 -->
