### PR TITLE
chore(deps): set @walletconnect/types version to the same as @walletc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/node": "^24.10.9",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",
-    "@walletconnect/types": "2.23.1",
+    "@walletconnect/types": "2.23.3",
     "cross-env": "^10.1.0",
     "husky": "^9.1.7",
     "jest": "^30.2.0",


### PR DESCRIPTION
…onnect/core

# Description

The WalletConnect integration stopped working working at some point after Oct 1st 2025.

Reported the bug here: https://discord.com/channels/672466989217873929/1464379536711090246

Not sure if the file change in this PR will fix the bug, but I guess the `@walletconnect/types` version should match the version of the other Wallet Connect dependencies.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
