### PR TITLE
feat(APP-456): Re-enable locking in token member panel

### DIFF
--- a/.changeset/shaggy-things-bathe.md
+++ b/.changeset/shaggy-things-bathe.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Re-enable locking in token member panel

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "engines": {
     "node": ">=24.13.0"
   },
-  "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
   "pnpm": {
     "overrides": {
       "@reown/appkit": "^1.8.16",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -1899,6 +1899,114 @@
           "voteOnSelected": "Vote on selected",
           "yourVotes": "Your votes"
         },
+        "gaugeVoterLockForm": {
+          "approveTransactionInfoTitle": "Approve {{symbol}}",
+          "chart": {
+            "now": "Now",
+            "votingPower": "Voting power"
+          },
+          "footerInfo": "Locking tokens will transfer them out of your wallet to the locking contract, where they can be withdrawn back to your wallet after the minimum locktime.",
+          "locks": "View {{count}} locks",
+          "submit": {
+            "approve": "Approve {{symbol}}",
+            "lock": "Lock {{symbol}}"
+          }
+        },
+        "gaugeVoterExitQueue": {
+          "feeCalculation": {
+            "lockedTokens": "Locked tokens",
+            "receiveNow": "Receive now",
+            "withdrawFee": "Withdraw fee"
+          },
+          "feeChart": {
+            "exit": "Exit",
+            "fee": "Fee",
+            "now": "Now",
+            "timeUnit": {
+              "day": "d",
+              "hour": "h",
+              "minute": "m",
+              "year": "y"
+            }
+          },
+          "withdrawDialog": {
+            "a11y": {
+              "description": "Dialog for withdrawing tokens with dynamic fee calculation"
+            },
+            "back": "Back",
+            "helpText": "Withdrawing early comes with a fee that decreases over time. The chart above shows how your waiting time affects how much you’ll receive when you withdraw.",
+            "submit": "Withdraw tokens",
+            "title": "Withdraw {{symbol}}"
+          },
+          "withdrawTransactionDialog": {
+            "a11y": {
+              "description": "Transaction dialog for confirming token withdrawal"
+            },
+            "description": "To withdraw your {{symbol}}, confirm the onchain transactions in your wallet.",
+            "submit": "Withdraw",
+            "success": "View Transaction",
+            "title": "Withdraw {{symbol}}"
+          }
+        },
+        "gaugeVoterLockList": {
+          "empty": {
+            "description": "This will show relevant locks when available.",
+            "title": "No locks found"
+          },
+          "entity": "veLocks",
+          "error": {
+            "description": "There was an error loading the locks. Try again later.",
+            "title": "Error loading locks"
+          },
+          "item": {
+            "actions": {
+              "unlock": "Unlock {{symbol}}",
+              "withdraw": "Withdraw {{symbol}}"
+            },
+            "approveTransactionInfoTitle": "Approve NFT #{{tokenId}}",
+            "metrics": {
+              "locked": "Locked",
+              "multiplier": "Multiplier",
+              "votingPower": "Voting power"
+            },
+            "minLockTimeLeftSuffix": "left until unlockable",
+            "statusLabel": {
+              "active": "Active",
+              "available": "Available",
+              "cooldown": "In cooldown",
+              "warmup": "In warmup"
+            },
+            "timeLeftSuffix": "left",
+            "withdrawTimeLeftSuffix": "until withdraw"
+          }
+        },
+        "gaugeVoterLockUnlockDialog": {
+          "lock": {
+            "description": "To lock your {{symbol}}, confirm the onchain transaction in your wallet.",
+            "submit": "Lock",
+            "success": "View your veLock",
+            "title": "Lock {{symbol}}",
+            "transactionInfoTitle": "Lock {{symbol}}"
+          },
+          "unlock": {
+            "description": "To unlock your {{symbol}}, confirm the onchain transaction in your wallet.",
+            "submit": "Unlock",
+            "success": "View locks",
+            "title": "Unlock {{symbol}}",
+            "transactionInfoTitle": "Unlock {{symbol}}"
+          },
+          "withdraw": {
+            "description": "To withdraw your {{symbol}}, confirm the onchain transactions in your wallet.",
+            "submit": "Withdraw",
+            "success": "View locks",
+            "title": "Withdraw {{symbol}}",
+            "transactionInfoTitle": "Withdraw {{symbol}}"
+          }
+        },
+        "gaugeVoterLocksDialog": {
+          "description": "Unlock or withdraw your {{symbol}} tokens",
+          "title": "Your locks"
+        },
         "meta": {
           "link": {
             "gauges": "Gauges"
@@ -2382,78 +2490,6 @@
           "voteChange": "Vote change",
           "yes": "Enabled"
         },
-        "tokenLockForm": {
-          "approveTransactionInfoTitle": "Approve {{symbol}}",
-          "chart": {
-            "now": "Now",
-            "votingPower": "Voting power"
-          },
-          "footerInfo": "Locking tokens will transfer them out of your wallet to the locking contract, where they can be withdrawn back to your wallet after the minimum locktime.",
-          "locks": "View {{count}} locks",
-          "submit": {
-            "approve": "Approve {{symbol}}",
-            "lock": "Lock {{symbol}}"
-          }
-        },
-        "tokenLockList": {
-          "empty": {
-            "description": "This will show relevant locks when available.",
-            "title": "No locks found"
-          },
-          "entity": "veLocks",
-          "error": {
-            "description": "There was an error loading the locks. Try again later.",
-            "title": "Error loading locks"
-          },
-          "item": {
-            "actions": {
-              "unlock": "Unlock {{symbol}}",
-              "withdraw": "Withdraw {{symbol}}"
-            },
-            "approveTransactionInfoTitle": "Approve NFT #{{tokenId}}",
-            "metrics": {
-              "locked": "Locked",
-              "multiplier": "Multiplier",
-              "votingPower": "Voting power"
-            },
-            "minLockTimeLeftSuffix": "left until unlockable",
-            "statusLabel": {
-              "active": "Active",
-              "available": "Available",
-              "cooldown": "In cooldown",
-              "warmup": "In warmup"
-            },
-            "timeLeftSuffix": "left",
-            "withdrawTimeLeftSuffix": "until withdraw"
-          }
-        },
-        "tokenLockUnlockDialog": {
-          "lock": {
-            "description": "To lock your {{symbol}}, confirm the onchain transaction in your wallet.",
-            "submit": "Lock",
-            "success": "View your veLock",
-            "title": "Lock {{symbol}}",
-            "transactionInfoTitle": "Lock {{symbol}}"
-          },
-          "unlock": {
-            "description": "To unlock your {{symbol}}, confirm the onchain transaction in your wallet.",
-            "submit": "Unlock",
-            "success": "View locks",
-            "title": "Unlock {{symbol}}",
-            "transactionInfoTitle": "Unlock {{symbol}}"
-          },
-          "withdraw": {
-            "description": "To withdraw your {{symbol}}, confirm the onchain transactions in your wallet.",
-            "submit": "Withdraw",
-            "success": "View locks",
-            "title": "Withdraw {{symbol}}",
-            "transactionInfoTitle": "Withdraw {{symbol}}"
-          }
-        },
-        "tokenLocksDialog": {
-          "description": "Unlock or withdraw your {{symbol}} tokens",
-          "title": "Your locks"
-        },
         "tokenMemberInfo": {
           "distribution": "Members",
           "eligibleVoters": "Eligible voters",
@@ -2471,7 +2507,8 @@
         "tokenMemberPanel": {
           "tabs": {
             "delegate": "Delegate",
-            "wrap": "Wrap"
+            "wrap": "Wrap",
+            "lock": "Lock"
           }
         },
         "tokenMemberStats": {
@@ -2699,42 +2736,6 @@
             "title": "Wrap tokens",
             "transactionInfoTitle": "Wrap {{symbol}}"
           }
-        }
-      },
-      "tokenExitQueue": {
-        "feeCalculation": {
-          "lockedTokens": "Locked tokens",
-          "receiveNow": "Receive now",
-          "withdrawFee": "Withdraw fee"
-        },
-        "feeChart": {
-          "exit": "Exit",
-          "fee": "Fee",
-          "now": "Now",
-          "timeUnit": {
-            "day": "d",
-            "hour": "h",
-            "minute": "m",
-            "year": "y"
-          }
-        },
-        "withdrawDialog": {
-          "a11y": {
-            "description": "Dialog for withdrawing tokens with dynamic fee calculation"
-          },
-          "back": "Back",
-          "helpText": "Withdrawing early comes with a fee that decreases over time. The chart above shows how your waiting time affects how much you’ll receive when you withdraw.",
-          "submit": "Withdraw tokens",
-          "title": "Withdraw {{symbol}}"
-        },
-        "withdrawTransactionDialog": {
-          "a11y": {
-            "description": "Transaction dialog for confirming token withdrawal"
-          },
-          "description": "To withdraw your {{symbol}}, confirm the onchain transactions in your wallet.",
-          "submit": "Withdraw",
-          "success": "View Transaction",
-          "title": "Withdraw {{symbol}}"
         }
       }
     },

--- a/src/plugins/gaugeVoterPlugin/components/gaugeVoterExitQueue/gaugeVoterExistQueueFeeChart/gaugeVoterExitQueueFeeChart.tsx
+++ b/src/plugins/gaugeVoterPlugin/components/gaugeVoterExitQueue/gaugeVoterExistQueueFeeChart/gaugeVoterExitQueueFeeChart.tsx
@@ -131,7 +131,9 @@ export const GaugeVoterExitQueueFeeChart: React.FC<
         ticket,
     });
 
-    const nowLabel = t('app.plugins.tokenExitQueue.feeChart.now');
+    const nowLabel = t(
+        'app.plugins.gaugeVoter.gaugeVoterExitQueue.feeChart.now',
+    );
 
     // Generate nice round ticks that will format cleanly
     const generateTicks = () => {
@@ -211,22 +213,22 @@ export const GaugeVoterExitQueueFeeChart: React.FC<
                 1,
                 Math.round(elapsedSeconds / secondsPerYear),
             );
-            formatted = `${String(years)}${t('app.plugins.tokenExitQueue.feeChart.timeUnit.year')}`;
+            formatted = `${String(years)}${t('app.plugins.gaugeVoter.gaugeVoterExitQueue.feeChart.timeUnit.year')}`;
         } else if (elapsedSeconds >= secondsPerDay) {
             const days = Math.max(
                 1,
                 Math.round(elapsedSeconds / secondsPerDay),
             );
-            formatted = `${String(days)}${t('app.plugins.tokenExitQueue.feeChart.timeUnit.day')}`;
+            formatted = `${String(days)}${t('app.plugins.gaugeVoter.gaugeVoterExitQueue.feeChart.timeUnit.day')}`;
         } else if (elapsedSeconds >= secondsPerHour) {
             const hours = Math.max(
                 1,
                 Math.round(elapsedSeconds / secondsPerHour),
             );
-            formatted = `${String(hours)}${t('app.plugins.tokenExitQueue.feeChart.timeUnit.hour')}`;
+            formatted = `${String(hours)}${t('app.plugins.gaugeVoter.gaugeVoterExitQueue.feeChart.timeUnit.hour')}`;
         } else {
             const minutes = Math.max(0, Math.round(elapsedSeconds / 60));
-            formatted = `${String(minutes)}${t('app.plugins.tokenExitQueue.feeChart.timeUnit.minute')}`;
+            formatted = `${String(minutes)}${t('app.plugins.gaugeVoter.gaugeVoterExitQueue.feeChart.timeUnit.minute')}`;
         }
 
         return isLastTick ? `>${formatted}` : formatted;

--- a/src/plugins/gaugeVoterPlugin/components/gaugeVoterExitQueue/gaugeVoterExitQueueFeeCalculation/gaugeVoterExitQueueFeeCalculation.tsx
+++ b/src/plugins/gaugeVoterPlugin/components/gaugeVoterExitQueue/gaugeVoterExitQueueFeeCalculation/gaugeVoterExitQueueFeeCalculation.tsx
@@ -33,7 +33,7 @@ export const GaugeVoterExitQueueFeeCalculation: React.FC<
             <div className="flex items-baseline justify-between font-normal text-base text-neutral-500 leading-tight">
                 <span>
                     {t(
-                        'app.plugins.tokenExitQueue.feeCalculation.lockedTokens',
+                        'app.plugins.gaugeVoter.gaugeVoterExitQueue.feeCalculation.lockedTokens',
                     )}
                 </span>
                 <span className="text-right">
@@ -44,7 +44,9 @@ export const GaugeVoterExitQueueFeeCalculation: React.FC<
             {/* Withdraw fee row */}
             <div className="flex items-baseline justify-between font-normal text-base text-primary-400 leading-tight">
                 <span>
-                    {t('app.plugins.tokenExitQueue.feeCalculation.withdrawFee')}
+                    {t(
+                        'app.plugins.gaugeVoter.gaugeVoterExitQueue.feeCalculation.withdrawFee',
+                    )}
                 </span>
                 <span className="text-right">
                     - {formattedFeeAmount} {token.symbol}
@@ -57,7 +59,9 @@ export const GaugeVoterExitQueueFeeCalculation: React.FC<
             {/* Receive now row */}
             <div className="flex items-baseline justify-between font-normal text-base text-neutral-800 leading-tight">
                 <span>
-                    {t('app.plugins.tokenExitQueue.feeCalculation.receiveNow')}
+                    {t(
+                        'app.plugins.gaugeVoter.gaugeVoterExitQueue.feeCalculation.receiveNow',
+                    )}
                 </span>
                 <span className="text-right">
                     {formattedReceiveAmount} {token.symbol}

--- a/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockForm/gaugeVoterLockForm.tsx
+++ b/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockForm/gaugeVoterLockForm.tsx
@@ -124,7 +124,7 @@ export const GaugeVoterLockForm: React.FC<IGaugeVoterLockFormProps> = (
     const handleApproveTokens = () => {
         const { symbol } = token;
         const transactionInfoTitle = t(
-            'app.plugins.token.tokenLockForm.approveTransactionInfoTitle',
+            'app.plugins.gaugeVoter.gaugeVoterLockForm.approveTransactionInfoTitle',
             { symbol },
         );
         const transactionInfo = {
@@ -222,7 +222,7 @@ export const GaugeVoterLockForm: React.FC<IGaugeVoterLockFormProps> = (
                         variant="primary"
                     >
                         {t(
-                            `app.plugins.token.tokenLockForm.submit.${submitLabel}`,
+                            `app.plugins.gaugeVoter.gaugeVoterLockForm.submit.${submitLabel}`,
                             {
                                 symbol: token.symbol,
                             },
@@ -234,13 +234,18 @@ export const GaugeVoterLockForm: React.FC<IGaugeVoterLockFormProps> = (
                             size="lg"
                             variant="secondary"
                         >
-                            {t('app.plugins.token.tokenLockForm.locks', {
-                                count: locksCount,
-                            })}
+                            {t(
+                                'app.plugins.gaugeVoter.gaugeVoterLockForm.locks',
+                                {
+                                    count: locksCount,
+                                },
+                            )}
                         </Button>
                     )}
                     <p className="text-center font-normal text-neutral-500 text-sm leading-normal">
-                        {t('app.plugins.token.tokenLockForm.footerInfo')}
+                        {t(
+                            'app.plugins.gaugeVoter.gaugeVoterLockForm.footerInfo',
+                        )}
                     </p>
                 </div>
             </form>

--- a/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockForm/gaugeVoterLockFormChart.tsx
+++ b/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockForm/gaugeVoterLockFormChart.tsx
@@ -57,7 +57,7 @@ export const GaugeVoterLockFormChart: React.FC<
     const oneYearInSeconds = 365 * 24 * 60 * 60;
     const chartTimeframe = Math.min(maxTime, oneYearInSeconds);
     const secondsStep = chartTimeframe / (chartPoints - 1);
-    const nowLabel = t('app.plugins.token.tokenLockForm.chart.now');
+    const nowLabel = t('app.plugins.gaugeVoter.gaugeVoterLockForm.chart.now');
 
     const points: IChartPoint[] = Array.from(
         { length: chartPoints },
@@ -171,7 +171,9 @@ export const GaugeVoterLockFormChart: React.FC<
                         format: NumberFormat.TOKEN_AMOUNT_SHORT,
                     })}{' '}
                     <span className="font-normal">
-                        {t('app.plugins.token.tokenLockForm.chart.votingPower')}
+                        {t(
+                            'app.plugins.gaugeVoter.gaugeVoterLockForm.chart.votingPower',
+                        )}
                     </span>
                 </p>
                 <span className="text-neutral-500 text-sm md:text-base">

--- a/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockList/gaugeVoterLockList.tsx
+++ b/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockList/gaugeVoterLockList.tsx
@@ -73,18 +73,22 @@ export const GaugeVoterLockList: React.FC<IGaugeVoterLockListProps> = (
     const itemsCount = data?.pages[0].metadata.totalRecords;
 
     const errorState = {
-        heading: t('app.plugins.token.tokenLockList.error.title'),
-        description: t('app.plugins.token.tokenLockList.error.description'),
+        heading: t('app.plugins.gaugeVoter.gaugeVoterLockList.error.title'),
+        description: t(
+            'app.plugins.gaugeVoter.gaugeVoterLockList.error.description',
+        ),
     };
 
     const emptyState = {
-        heading: t('app.plugins.token.tokenLockList.empty.title'),
-        description: t('app.plugins.token.tokenLockList.empty.description'),
+        heading: t('app.plugins.gaugeVoter.gaugeVoterLockList.empty.title'),
+        description: t(
+            'app.plugins.gaugeVoter.gaugeVoterLockList.empty.description',
+        ),
     };
 
     return (
         <DataListRoot
-            entityLabel={t('app.plugins.token.tokenLockList.entity')}
+            entityLabel={t('app.plugins.gaugeVoter.gaugeVoterLockList.entity')}
             itemsCount={itemsCount}
             onLoadMore={fetchNextPage}
             pageSize={pageSize}

--- a/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockList/gaugeVoterLockListItem.tsx
+++ b/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockList/gaugeVoterLockListItem.tsx
@@ -195,7 +195,7 @@ export const GaugeVoterLockListItem: React.FC<IGaugeVoterLockListItemProps> = (
                 },
                 transactionInfo: {
                     title: t(
-                        'app.plugins.token.tokenLockList.item.approveTransactionInfoTitle',
+                        'app.plugins.gaugeVoter.gaugeVoterLockList.item.approveTransactionInfoTitle',
                         {
                             tokenId: lock.tokenId,
                         },
@@ -289,7 +289,7 @@ export const GaugeVoterLockListItem: React.FC<IGaugeVoterLockListItemProps> = (
 
                 <Tag
                     label={t(
-                        `app.plugins.token.tokenLockList.item.statusLabel.${status}`,
+                        `app.plugins.gaugeVoter.gaugeVoterLockList.item.statusLabel.${status}`,
                     )}
                     variant={statusToVariant[status]}
                 />
@@ -299,7 +299,7 @@ export const GaugeVoterLockListItem: React.FC<IGaugeVoterLockListItemProps> = (
                 <div className="flex flex-col">
                     <div className="text-neutral-500 text-sm md:text-base">
                         {t(
-                            'app.plugins.token.tokenLockList.item.metrics.locked',
+                            'app.plugins.gaugeVoter.gaugeVoterLockList.item.metrics.locked',
                         )}
                     </div>
                     <div className="truncate">{formattedLockedAmount}</div>
@@ -307,7 +307,7 @@ export const GaugeVoterLockListItem: React.FC<IGaugeVoterLockListItemProps> = (
                 <div className="flex flex-col">
                     <div className="text-neutral-500 text-sm md:text-base">
                         {t(
-                            'app.plugins.token.tokenLockList.item.metrics.multiplier',
+                            'app.plugins.gaugeVoter.gaugeVoterLockList.item.metrics.multiplier',
                         )}
                     </div>
                     <div className="truncate">
@@ -317,7 +317,7 @@ export const GaugeVoterLockListItem: React.FC<IGaugeVoterLockListItemProps> = (
                 <div className="flex flex-col">
                     <div className="text-neutral-500 text-sm md:text-base">
                         {t(
-                            'app.plugins.token.tokenLockList.item.metrics.votingPower',
+                            'app.plugins.gaugeVoter.gaugeVoterLockList.item.metrics.votingPower',
                         )}
                     </div>
                     {status === 'active' && (
@@ -353,7 +353,7 @@ export const GaugeVoterLockListItem: React.FC<IGaugeVoterLockListItemProps> = (
                             variant="secondary"
                         >
                             {t(
-                                'app.plugins.token.tokenLockList.item.actions.unlock',
+                                'app.plugins.gaugeVoter.gaugeVoterLockList.item.actions.unlock',
                                 { symbol: token.symbol },
                             )}
                         </Button>
@@ -361,7 +361,7 @@ export const GaugeVoterLockListItem: React.FC<IGaugeVoterLockListItemProps> = (
                             <p className="text-neutral-500 text-sm leading-normal">
                                 {formattedMinLock}{' '}
                                 {t(
-                                    'app.plugins.token.tokenLockList.item.minLockTimeLeftSuffix',
+                                    'app.plugins.gaugeVoter.gaugeVoterLockList.item.minLockTimeLeftSuffix',
                                 )}
                             </p>
                         )}
@@ -382,7 +382,7 @@ export const GaugeVoterLockListItem: React.FC<IGaugeVoterLockListItemProps> = (
                             variant="tertiary"
                         >
                             {t(
-                                'app.plugins.token.tokenLockList.item.actions.withdraw',
+                                'app.plugins.gaugeVoter.gaugeVoterLockList.item.actions.withdraw',
                                 { symbol: token.symbol },
                             )}
                         </Button>
@@ -404,7 +404,7 @@ export const GaugeVoterLockListItem: React.FC<IGaugeVoterLockListItemProps> = (
                                         <p className="text-neutral-500 text-sm leading-normal">
                                             {formattedMinCooldownDate}{' '}
                                             {t(
-                                                'app.plugins.token.tokenLockList.item.withdrawTimeLeftSuffix',
+                                                'app.plugins.gaugeVoter.gaugeVoterLockList.item.withdrawTimeLeftSuffix',
                                             )}
                                         </p>
                                     );

--- a/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterExitQueueWithdrawDialog/gaugeVoterExitQueueWithdrawDialog.tsx
+++ b/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterExitQueueWithdrawDialog/gaugeVoterExitQueueWithdrawDialog.tsx
@@ -88,9 +88,12 @@ export const GaugeVoterExitQueueWithdrawDialog: React.FC<
         <>
             <Dialog.Header
                 onClose={close}
-                title={t('app.plugins.tokenExitQueue.withdrawDialog.title', {
-                    symbol: token.symbol,
-                })}
+                title={t(
+                    'app.plugins.gaugeVoter.gaugeVoterExitQueue.withdrawDialog.title',
+                    {
+                        symbol: token.symbol,
+                    },
+                )}
             />
             <Dialog.Content className="flex flex-col gap-6 pt-4">
                 {shouldShowChart && (
@@ -105,7 +108,7 @@ export const GaugeVoterExitQueueWithdrawDialog: React.FC<
                     helpText={
                         shouldShowChart
                             ? t(
-                                  'app.plugins.tokenExitQueue.withdrawDialog.helpText',
+                                  'app.plugins.gaugeVoter.gaugeVoterExitQueue.withdrawDialog.helpText',
                               )
                             : undefined
                     }
@@ -116,12 +119,14 @@ export const GaugeVoterExitQueueWithdrawDialog: React.FC<
             <Dialog.Footer
                 primaryAction={{
                     label: t(
-                        'app.plugins.tokenExitQueue.withdrawDialog.submit',
+                        'app.plugins.gaugeVoter.gaugeVoterExitQueue.withdrawDialog.submit',
                     ),
                     onClick: handleWithdraw,
                 }}
                 secondaryAction={{
-                    label: t('app.plugins.tokenExitQueue.withdrawDialog.back'),
+                    label: t(
+                        'app.plugins.gaugeVoter.gaugeVoterExitQueue.withdrawDialog.back',
+                    ),
                     onClick: handleBack,
                 }}
                 variant="wizard"

--- a/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterExitQueueWithdrawTransactionDialog/gaugeVoterExitQueueWithdrawTransactionDialog.tsx
+++ b/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterExitQueueWithdrawTransactionDialog/gaugeVoterExitQueueWithdrawTransactionDialog.tsx
@@ -61,7 +61,7 @@ export const GaugeVoterExitQueueWithdrawTransactionDialog: React.FC<
     return (
         <TransactionDialog
             description={t(
-                'app.plugins.tokenExitQueue.withdrawTransactionDialog.description',
+                'app.plugins.gaugeVoter.gaugeVoterExitQueue.withdrawTransactionDialog.description',
                 {
                     symbol: token.symbol,
                 },
@@ -70,11 +70,11 @@ export const GaugeVoterExitQueueWithdrawTransactionDialog: React.FC<
             prepareTransaction={handlePrepareTransaction}
             stepper={stepper}
             submitLabel={t(
-                'app.plugins.tokenExitQueue.withdrawTransactionDialog.submit',
+                'app.plugins.gaugeVoter.gaugeVoterExitQueue.withdrawTransactionDialog.submit',
             )}
             successLink={{
                 label: t(
-                    'app.plugins.tokenExitQueue.withdrawTransactionDialog.success',
+                    'app.plugins.gaugeVoter.gaugeVoterExitQueue.withdrawTransactionDialog.success',
                 ),
                 onClick: () => {
                     router.refresh();
@@ -82,7 +82,7 @@ export const GaugeVoterExitQueueWithdrawTransactionDialog: React.FC<
                 },
             }}
             title={t(
-                'app.plugins.tokenExitQueue.withdrawTransactionDialog.title',
+                'app.plugins.gaugeVoter.gaugeVoterExitQueue.withdrawTransactionDialog.title',
                 { symbol: token.symbol },
             )}
             transactionType={TransactionType.WITHDRAW_CREATE}

--- a/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterLockUnlockDialog/gaugeVoterLockUnlockDialog.tsx
+++ b/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterLockUnlockDialog/gaugeVoterLockUnlockDialog.tsx
@@ -152,7 +152,7 @@ export const GaugeVoterLockUnlockDialog: React.FC<
 
     const { symbol } = token;
     const txInfoTitle = t(
-        `app.plugins.token.tokenLockUnlockDialog.${action}.transactionInfoTitle`,
+        `app.plugins.gaugeVoter.gaugeVoterLockUnlockDialog.${action}.transactionInfoTitle`,
         { symbol },
     );
     const transactionInfo = showTransactionInfo
@@ -168,7 +168,7 @@ export const GaugeVoterLockUnlockDialog: React.FC<
     return (
         <TransactionDialog
             description={t(
-                `app.plugins.token.tokenLockUnlockDialog.${action}.description`,
+                `app.plugins.gaugeVoter.gaugeVoterLockUnlockDialog.${action}.description`,
                 { symbol },
             )}
             indexingFallbackUrl={daoUtils.getDaoUrl(dao, 'members')}
@@ -178,16 +178,16 @@ export const GaugeVoterLockUnlockDialog: React.FC<
             prepareTransaction={handlePrepareTransaction}
             stepper={stepper}
             submitLabel={t(
-                `app.plugins.token.tokenLockUnlockDialog.${action}.submit`,
+                `app.plugins.gaugeVoter.gaugeVoterLockUnlockDialog.${action}.submit`,
             )}
             successLink={{
                 label: t(
-                    `app.plugins.token.tokenLockUnlockDialog.${action}.success`,
+                    `app.plugins.gaugeVoter.gaugeVoterLockUnlockDialog.${action}.success`,
                 ),
                 onClick: handleSuccessClick,
             }}
             title={t(
-                `app.plugins.token.tokenLockUnlockDialog.${action}.title`,
+                `app.plugins.gaugeVoter.gaugeVoterLockUnlockDialog.${action}.title`,
                 { symbol },
             )}
             transactionInfo={transactionInfo}

--- a/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterLocksDialog/gaugeVoterLocksDialog.tsx
+++ b/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterLocksDialog/gaugeVoterLocksDialog.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { Dialog, invariant } from '@aragon/gov-ui-kit';
-import type { IDao, IDaoPlugin } from '@/shared/api/daoService';
+import type { IDao } from '@/shared/api/daoService';
 import {
     type IDialogComponentProps,
     useDialogContext,
 } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { GaugeVoterLockList } from '../../components/gaugeVoterLockList';
-import type { IGaugeVoterPluginSettings } from '../../types/gaugeVoterPlugin';
+import type { IGaugeVoterPlugin } from '../../types/gaugeVoterPlugin';
 
 export interface IGaugeVoterLocksDialogParams {
     /**
@@ -18,7 +18,7 @@ export interface IGaugeVoterLocksDialogParams {
     /**
      * Gauge voter plugin containing voting escrow settings.
      */
-    plugin: IDaoPlugin<IGaugeVoterPluginSettings>;
+    plugin: IGaugeVoterPlugin;
 }
 
 export interface IGaugeVoterLocksDialogProps

--- a/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterLocksDialog/gaugeVoterLocksDialog.tsx
+++ b/src/plugins/gaugeVoterPlugin/dialogs/gaugeVoterLocksDialog/gaugeVoterLocksDialog.tsx
@@ -44,12 +44,12 @@ export const GaugeVoterLocksDialog: React.FC<IGaugeVoterLocksDialogProps> = (
         <>
             <Dialog.Header
                 onClose={close}
-                title={t('app.plugins.token.tokenLocksDialog.title')}
+                title={t('app.plugins.gaugeVoter.gaugeVoterLocksDialog.title')}
             />
             <Dialog.Content
                 className="pb-4 md:pb-6"
                 description={t(
-                    'app.plugins.token.tokenLocksDialog.description',
+                    'app.plugins.gaugeVoter.gaugeVoterLocksDialog.description',
                     { symbol: token.symbol },
                 )}
             >

--- a/src/plugins/gaugeVoterPlugin/types/gaugeVoterPlugin.ts
+++ b/src/plugins/gaugeVoterPlugin/types/gaugeVoterPlugin.ts
@@ -66,35 +66,37 @@ export interface IGaugeVoterPluginSettings extends IPluginSettings {
     token: IGaugeVoterPluginSettingsToken;
 }
 
+export interface IGaugeVoterPluginVotingEscrowAddresses {
+    /**
+     * The address of the curve contract.
+     */
+    curveAddress: string;
+    /**
+     * The address of the exit queue contract.
+     */
+    exitQueueAddress: string;
+    /**
+     * The address of the voting escrow contract.
+     */
+    escrowAddress: string;
+    /**
+     * The address of the clock contract.
+     */
+    clockAddress: string;
+    /**
+     * The address of the NFT lock contract.
+     */
+    nftLockAddress: string;
+    /**
+     * The address of the underlying token contract.
+     */
+    underlying: string;
+}
+
 export interface IGaugeVoterPlugin
     extends IDaoPlugin<IGaugeVoterPluginSettings> {
     /**
-     * The voting escrow settings of the plugin.
+     * The voting escrow contract addresses.
      */
-    votingEscrow?: {
-        /**
-         * The address of the curve contract.
-         */
-        curveAddress: string;
-        /**
-         * The address of the exit queue contract.
-         */
-        exitQueueAddress: string;
-        /**
-         * The address of the voting escrow contract.
-         */
-        escrowAddress: string;
-        /**
-         * The address of the clock contract.
-         */
-        clockAddress: string;
-        /**
-         * The address of the NFT lock contract.
-         */
-        nftLockAddress: string;
-        /**
-         * The address of the underlying token contract.
-         */
-        underlying: string;
-    };
+    votingEscrow: IGaugeVoterPluginVotingEscrowAddresses;
 }

--- a/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenMemberPanel.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenMemberPanel.tsx
@@ -22,13 +22,15 @@ export interface ITokenMemberPanelProps {
 enum TokenMemberPanelTab {
     DELEGATE = 'delegate',
     WRAP = 'wrap',
+    LOCK = 'lock',
 }
 
-const getTabsDefinitions = ({ token }: ITokenPluginSettings) => [
+const getTabsDefinitions = ({ votingEscrow, token }: ITokenPluginSettings) => [
     {
         value: TokenMemberPanelTab.WRAP,
-        hidden: token.underlying == null,
+        hidden: votingEscrow != null || token.underlying == null,
     },
+    { value: TokenMemberPanelTab.LOCK, hidden: votingEscrow == null },
     { value: TokenMemberPanelTab.DELEGATE, hidden: !token.hasDelegate },
 ];
 
@@ -46,8 +48,9 @@ export const TokenMemberPanel: React.FC<ITokenMemberPanelProps> = (props) => {
         (tab) => !tab.hidden,
     );
 
-    const { WRAP, DELEGATE } = TokenMemberPanelTab;
-    const initialSelectedTab = underlying != null ? WRAP : DELEGATE;
+    const { LOCK, WRAP, DELEGATE } = TokenMemberPanelTab;
+    const initialSelectedTab =
+        votingEscrow != null ? LOCK : underlying != null ? WRAP : DELEGATE;
     const [selectedTab, setSelectedTab] = useFilterUrlParam({
         name: tokenMemberPanelFilterParam,
         fallbackValue: initialSelectedTab,
@@ -62,11 +65,11 @@ export const TokenMemberPanel: React.FC<ITokenMemberPanelProps> = (props) => {
         name: name.substring(11),
     };
 
-    const titleToken = underlying != null ? underlyingToken : token;
+    const titleToken =
+        !votingEscrow && underlying != null ? underlyingToken : token;
     const cardTitle = `${titleToken.name} (${titleToken.symbol})`;
 
-    // don't show a members panel if it's a voting escrow type (it's handled in gaugeVoter page)
-    if (votingEscrow || !visibleTabs.length) {
+    if (!visibleTabs.length) {
         return null;
     }
 
@@ -84,6 +87,11 @@ export const TokenMemberPanel: React.FC<ITokenMemberPanelProps> = (props) => {
                         />
                     ))}
                 </Tabs.List>
+                {votingEscrow != null && (
+                    <Tabs.Content value={TokenMemberPanelTab.LOCK}>
+                        <h1>LOCK TOKEN</h1>
+                    </Tabs.Content>
+                )}
                 <Tabs.Content value={TokenMemberPanelTab.WRAP}>
                     <TokenWrapForm
                         daoId={daoId}

--- a/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenMemberPanel.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenMemberPanel.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { Tabs } from '@aragon/gov-ui-kit';
+import { GaugeVoterLockForm } from '@/plugins/gaugeVoterPlugin/components/gaugeVoterLockForm';
+import type { IGaugeVoterPlugin } from '@/plugins/gaugeVoterPlugin/types';
 import { Page } from '@/shared/components/page';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useFilterUrlParam } from '@/shared/hooks/useFilterUrlParam';
-import { GaugeVoterLockForm } from '../../../gaugeVoterPlugin/components/gaugeVoterLockForm';
-import type { IGaugeVoterPlugin } from '../../../gaugeVoterPlugin/types';
 import type { ITokenPlugin, ITokenPluginSettings } from '../../types';
 import { TokenDelegationForm } from './tokenDelegation';
 import { TokenWrapForm } from './tokenWrap';

--- a/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenMemberPanel.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenMemberPanel.tsx
@@ -4,6 +4,8 @@ import { Tabs } from '@aragon/gov-ui-kit';
 import { Page } from '@/shared/components/page';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useFilterUrlParam } from '@/shared/hooks/useFilterUrlParam';
+import { GaugeVoterLockForm } from '../../../gaugeVoterPlugin/components/gaugeVoterLockForm';
+import type { IGaugeVoterPlugin } from '../../../gaugeVoterPlugin/types';
 import type { ITokenPlugin, ITokenPluginSettings } from '../../types';
 import { TokenDelegationForm } from './tokenDelegation';
 import { TokenWrapForm } from './tokenWrap';
@@ -89,7 +91,10 @@ export const TokenMemberPanel: React.FC<ITokenMemberPanelProps> = (props) => {
                 </Tabs.List>
                 {votingEscrow != null && (
                     <Tabs.Content value={TokenMemberPanelTab.LOCK}>
-                        <h1>LOCK TOKEN</h1>
+                        <GaugeVoterLockForm
+                            daoId={daoId}
+                            plugin={plugin as unknown as IGaugeVoterPlugin}
+                        />
                     </Tabs.Content>
                 )}
                 <Tabs.Content value={TokenMemberPanelTab.WRAP}>


### PR DESCRIPTION
## Description

Adds gauge token lock form to the token member panel on the gauge voting page. Token locking should be supported in both token members page and gauges page.

## Type of Change

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [x] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project