### PR TITLE
feat(APP-293): filter action builder actions by target DAO permissions

### DIFF
--- a/.changeset/small-worms-ring.md
+++ b/.changeset/small-worms-ring.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Filter action builder actions by target DAO permissions

--- a/src/modules/finance/components/transferAssetForm/transferAssetForm.tsx
+++ b/src/modules/finance/components/transferAssetForm/transferAssetForm.tsx
@@ -27,10 +27,16 @@ export interface ITransferAssetFormProps
      * Network of the asset to be transferred.
      */
     network: Network;
+    /**
+     * When true, returns only the parent DAO's assets (excludes SubDAOs).
+     * Used when transferring from parent DAO to show only parent's assets.
+     */
+    onlyParentAssets?: boolean;
 }
 
 export const TransferAssetForm: React.FC<ITransferAssetFormProps> = (props) => {
-    const { daoId, network, fieldPrefix, disableAssetField } = props;
+    const { daoId, network, fieldPrefix, disableAssetField, onlyParentAssets } =
+        props;
 
     const { t } = useTranslations();
 
@@ -57,7 +63,9 @@ export const TransferAssetForm: React.FC<ITransferAssetFormProps> = (props) => {
         value?.address,
     );
 
-    const fetchAssetsParams = { queryParams: { daoId } };
+    const fetchAssetsParams = {
+        queryParams: { daoId, onlyParent: onlyParentAssets },
+    };
     const { id: chainId } = networkDefinitions[network];
 
     return (


### PR DESCRIPTION
# Description

When creating proposals for plugins targeting subDAOs, actions are now filtered based on the target DAO's permissions instead of the main DAO.

- Determine target DAO from plugin.daoAddress (subDAO) or dao.address (main)
- Fetch permissions for target DAO in createProposalFormActions
- Pass targetDaoAddress through ActionComposer to ActionComposerInput
- Update native action groups to use target DAO address
- Update WalletConnect dialog to use target DAO address

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [x] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
