### PR TITLE
fix(APP-495): Remove avatar definition list item if no avatar set

### DIFF
--- a/.changeset/pretty-crews-search.md
+++ b/.changeset/pretty-crews-search.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Remove empty avatar definition list items when no avatar is set

--- a/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionDetails/gaugeRegistrarRegisterGaugeActionDetails.tsx
+++ b/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionDetails/gaugeRegistrarRegisterGaugeActionDetails.tsx
@@ -79,7 +79,7 @@ export const GaugeRegistrarRegisterGaugeActionDetails: React.FC<
             >
                 {name}
             </DefinitionList.Item>
-            {avatarSrc && (
+            {avatar && (
                 <DefinitionList.Item
                     term={t(
                         'app.actions.gaugeRegistrar.gaugeRegistrarRegisterGaugeActionDetails.avatarTerm',

--- a/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionDetails/gaugeRegistrarRegisterGaugeActionDetails.tsx
+++ b/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionDetails/gaugeRegistrarRegisterGaugeActionDetails.tsx
@@ -79,13 +79,15 @@ export const GaugeRegistrarRegisterGaugeActionDetails: React.FC<
             >
                 {name}
             </DefinitionList.Item>
-            <DefinitionList.Item
-                term={t(
-                    'app.actions.gaugeRegistrar.gaugeRegistrarRegisterGaugeActionDetails.avatarTerm',
-                )}
-            >
-                <Avatar size="md" src={avatarSrc} />
-            </DefinitionList.Item>
+            {avatarSrc && (
+                <DefinitionList.Item
+                    term={t(
+                        'app.actions.gaugeRegistrar.gaugeRegistrarRegisterGaugeActionDetails.avatarTerm',
+                    )}
+                >
+                    <Avatar size="md" src={avatarSrc} />
+                </DefinitionList.Item>
+            )}
             <DefinitionList.Item
                 term={t(
                     'app.actions.gaugeRegistrar.gaugeRegistrarRegisterGaugeActionDetails.descriptionTerm',

--- a/src/actions/gaugeVoter/components/gaugeVoterCreateGaugeActionDetails/gaugeVoterCreateGaugeActionDetails.tsx
+++ b/src/actions/gaugeVoter/components/gaugeVoterCreateGaugeActionDetails/gaugeVoterCreateGaugeActionDetails.tsx
@@ -62,13 +62,15 @@ export const GaugeVoterCreateGaugeActionDetails: React.FC<
             >
                 {name}
             </DefinitionList.Item>
-            <DefinitionList.Item
-                term={t(
-                    'app.actions.gaugeVoter.gaugeVoterCreateGaugeActionDetails.avatarTerm',
-                )}
-            >
-                <Avatar size="md" src={avatarSrc} />
-            </DefinitionList.Item>
+            {avatarSrc && (
+                <DefinitionList.Item
+                    term={t(
+                        'app.actions.gaugeVoter.gaugeVoterCreateGaugeActionDetails.avatarTerm',
+                    )}
+                >
+                    <Avatar size="md" src={avatarSrc} />
+                </DefinitionList.Item>
+            )}
             <DefinitionList.Item
                 term={t(
                     'app.actions.gaugeVoter.gaugeVoterCreateGaugeActionDetails.descriptionTerm',

--- a/src/actions/gaugeVoter/components/gaugeVoterCreateGaugeActionDetails/gaugeVoterCreateGaugeActionDetails.tsx
+++ b/src/actions/gaugeVoter/components/gaugeVoterCreateGaugeActionDetails/gaugeVoterCreateGaugeActionDetails.tsx
@@ -62,7 +62,7 @@ export const GaugeVoterCreateGaugeActionDetails: React.FC<
             >
                 {name}
             </DefinitionList.Item>
-            {avatarSrc && (
+            {avatar && (
                 <DefinitionList.Item
                     term={t(
                         'app.actions.gaugeVoter.gaugeVoterCreateGaugeActionDetails.avatarTerm',

--- a/src/actions/gaugeVoter/components/gaugeVoterUpdateGaugeMetadataActionDetails/gaugeVoterUpdateGaugeMetadataActionDetails.tsx
+++ b/src/actions/gaugeVoter/components/gaugeVoterUpdateGaugeMetadataActionDetails/gaugeVoterUpdateGaugeMetadataActionDetails.tsx
@@ -62,7 +62,7 @@ export const GaugeVoterUpdateGaugeMetadataActionDetails: React.FC<
             >
                 {name}
             </DefinitionList.Item>
-            {avatarSrc && (
+            {avatar && (
                 <DefinitionList.Item
                     term={t(
                         'app.actions.gaugeVoter.gaugeVoterUpdateGaugeMetadataActionDetails.avatarTerm',

--- a/src/actions/gaugeVoter/components/gaugeVoterUpdateGaugeMetadataActionDetails/gaugeVoterUpdateGaugeMetadataActionDetails.tsx
+++ b/src/actions/gaugeVoter/components/gaugeVoterUpdateGaugeMetadataActionDetails/gaugeVoterUpdateGaugeMetadataActionDetails.tsx
@@ -62,13 +62,15 @@ export const GaugeVoterUpdateGaugeMetadataActionDetails: React.FC<
             >
                 {name}
             </DefinitionList.Item>
-            <DefinitionList.Item
-                term={t(
-                    'app.actions.gaugeVoter.gaugeVoterUpdateGaugeMetadataActionDetails.avatarTerm',
-                )}
-            >
-                <Avatar size="md" src={avatarSrc} />
-            </DefinitionList.Item>
+            {avatarSrc && (
+                <DefinitionList.Item
+                    term={t(
+                        'app.actions.gaugeVoter.gaugeVoterUpdateGaugeMetadataActionDetails.avatarTerm',
+                    )}
+                >
+                    <Avatar size="md" src={avatarSrc} />
+                </DefinitionList.Item>
+            )}
             <DefinitionList.Item
                 term={t(
                     'app.actions.gaugeVoter.gaugeVoterUpdateGaugeMetadataActionDetails.descriptionTerm',


### PR DESCRIPTION
# Description

This PR fixes APP-495 by conditionally rendering avatar definition list items in ActionDetails components. Previously, when no avatar was set, a confusing gray circle was displayed as an avatar fallback. This change prevents the avatar field from appearing when no avatar source is available.

## Changes Made

- Updated `gaugeVoterCreateGaugeActionDetails.tsx` to conditionally render avatar if `avatar` is set
- Updated `gaugeVoterUpdateGaugeMetadataActionDetails.tsx` to conditionally render avatar if `avatar` is set  
- Updated `gaugeRegistrarRegisterGaugeActionDetails.tsx` to conditionally render avatar if `avatar` is set

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Confirmed that changes follow the code style guidelines of this project