### PR TITLE
Release v1.21.0

### DIFF
--- a/.changeset/busy-trains-learn.md
+++ b/.changeset/busy-trains-learn.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Only show admin panel if current DAO has admin plugin

--- a/.changeset/fair-wasps-sniff.md
+++ b/.changeset/fair-wasps-sniff.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Implement policy uninstall functionality

--- a/.changeset/late-deserts-hunt.md
+++ b/.changeset/late-deserts-hunt.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Implement DAO Policy Details Page

--- a/.changeset/pretty-rooms-cheer.md
+++ b/.changeset/pretty-rooms-cheer.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Improve plugin targeting indicators throughout the app

--- a/.changeset/quick-stars-tickle.md
+++ b/.changeset/quick-stars-tickle.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Fix transfer and raw_calldata actions issues in action composer

--- a/.changeset/quiet-hoops-cheer.md
+++ b/.changeset/quiet-hoops-cheer.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Update package dependencies

--- a/.changeset/shaggy-things-bathe.md
+++ b/.changeset/shaggy-things-bathe.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Re-enable locking in token member panel

--- a/.changeset/small-gifts-rest.md
+++ b/.changeset/small-gifts-rest.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Show subDAOs' proposals and members

--- a/.changeset/small-worms-ring.md
+++ b/.changeset/small-worms-ring.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Filter action builder actions by target DAO permissions

--- a/.changeset/wicked-deer-talk.md
+++ b/.changeset/wicked-deer-talk.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Remove plugin toggle from settings page

--- a/.changeset/yummy-boats-shout.md
+++ b/.changeset/yummy-boats-shout.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Add token panel to gauge voting page

--- a/.changeset/yummy-waves-allow.md
+++ b/.changeset/yummy-waves-allow.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Update dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @aragon/app
 
+## 1.21.0
+
+### Minor Changes
+
+- [#967](https://github.com/aragon/app/pull/967) [`df6b7b2`](https://github.com/aragon/app/commit/df6b7b2ab2b9918b45e621d0db68501e0e32e0d1) Thanks [@asciiman](https://github.com/asciiman)! - Only show admin panel if current DAO has admin plugin
+
+- [#982](https://github.com/aragon/app/pull/982) [`c66e810`](https://github.com/aragon/app/commit/c66e81001e3b2a2f7e3bd6c99d7f1203cbda85b4) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Implement policy uninstall functionality
+
+- [#970](https://github.com/aragon/app/pull/970) [`c1f5531`](https://github.com/aragon/app/commit/c1f55313686fa37223f02abbb637981d751e00c0) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Implement DAO Policy Details Page
+
+- [#960](https://github.com/aragon/app/pull/960) [`e305fbb`](https://github.com/aragon/app/commit/e305fbb9da8819372faf71df49e6437939cccd85) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Improve plugin targeting indicators throughout the app
+
+- [#974](https://github.com/aragon/app/pull/974) [`e5378cd`](https://github.com/aragon/app/commit/e5378cd42330356f013e01247f761b30389923b9) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Update package dependencies
+
+- [#983](https://github.com/aragon/app/pull/983) [`558012e`](https://github.com/aragon/app/commit/558012e24e8ae613a638f384160d1c5b88f191bb) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Show subDAOs' proposals and members
+
+- [#968](https://github.com/aragon/app/pull/968) [`b65c8d6`](https://github.com/aragon/app/commit/b65c8d6e75bbb30995d9e46edb24479ca7a91cb9) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Filter action builder actions by target DAO permissions
+
+- [#956](https://github.com/aragon/app/pull/956) [`df05b5f`](https://github.com/aragon/app/commit/df05b5f8c8a4c3b3962a40edda4542ea79a240f1) Thanks [@milosh86](https://github.com/milosh86)! - Add token panel to gauge voting page
+
+### Patch Changes
+
+- [#975](https://github.com/aragon/app/pull/975) [`64dc64b`](https://github.com/aragon/app/commit/64dc64b6710745940a0ccab54aed466ac5536a80) Thanks [@milosh86](https://github.com/milosh86)! - Fix transfer and raw_calldata actions issues in action composer
+
+- [#964](https://github.com/aragon/app/pull/964) [`9bafdff`](https://github.com/aragon/app/commit/9bafdff3349705c1e6578776bab60e9f5267f688) Thanks [@milosh86](https://github.com/milosh86)! - Re-enable locking in token member panel
+
+- [#976](https://github.com/aragon/app/pull/976) [`012805c`](https://github.com/aragon/app/commit/012805c08e7ce6aa1a9f801757b96850a4c6a712) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Remove plugin toggle from settings page
+
+- [#977](https://github.com/aragon/app/pull/977) [`7d34ef4`](https://github.com/aragon/app/commit/7d34ef4562d8a16b36baa6fdc9b1f458e62c123f) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+
 ## 1.20.0
 
 ### Minor Changes

--- a/config/.env.production
+++ b/config/.env.production
@@ -11,4 +11,4 @@ NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=33951d0c4045078ce2d8bd06506174c7
 NEXT_PUBLIC_API_ALLOWED_DOMAIN=https://app.aragon.org
 
 # API version for Aragon backend service (v2 for production, v3 for dev/sandbox)
-NEXT_PUBLIC_API_VERSION=v2
+NEXT_PUBLIC_API_VERSION=v3

--- a/config/.env.staging
+++ b/config/.env.staging
@@ -11,4 +11,4 @@ NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=64b75866f42573712948d2ff731051a6
 NEXT_PUBLIC_API_ALLOWED_DOMAIN=https://stg.app.aragon.org
 
 # API version for Aragon backend service (v2 for production, v3 for dev/sandbox)
-NEXT_PUBLIC_API_VERSION=v2
+NEXT_PUBLIC_API_VERSION=v3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/app",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Human-centered DAO infrastructure",
   "author": "Aragon Association",
   "homepage": "https://github.com/aragon/app#readme",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -3013,7 +3013,7 @@
         "message": "If you leave this process, you'll lose all the information you've entered so far."
       },
       "daoPluginInfo": {
-        "launchedAt": "Plugin launched",
+        "launchedAt": "Launched",
         "plugin": "Plugin address",
         "pluginVersionInfo": "{{name}} v{{release}}.{{build}}"
       },

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -296,8 +296,8 @@
           "label": "Gauge ratio"
         },
         "MULTI_DISPATCH": {
-          "description": "Choose several routers to dispatch them sequentially.",
-          "label": "Multi dispatch"
+          "description": "Dispatches several other routers sequentially within a single transaction.",
+          "label": "Multi-dispatch"
         },
         "STREAM": {
           "description": "Transfer a fixed quantity of an available asset over time to recipients.",
@@ -2787,7 +2787,7 @@
         "gaugeVoter": "Gauge voter",
         "uninstall": {
           "action": "Uninstall policy",
-          "info": "Policies of this type can't be executed once this policy is uninstalled."
+          "info": "This policy can't be dispatched once it's uninstalled."
         }
       },
       "daoPolicyDetailsPage": {
@@ -2857,7 +2857,7 @@
           "daoAction": "SubDAO",
           "governanceAction": "Process",
           "governanceInfoTitle": "Governance",
-          "settingsInfoTitle": "DAO",
+          "settingsInfoTitle": "Account",
           "title": "Settings"
         }
       },
@@ -3018,8 +3018,8 @@
         "pluginVersionInfo": "{{name}} v{{release}}.{{build}}"
       },
       "daoTypeTag": {
-        "mainLabel": "Main DAO",
-        "subLabel": "SubDAO"
+        "mainLabel": "Primary account",
+        "subLabel": "Linked account"
       },
       "errorFeedback": {
         "description": "If you'd like to help, you can report the issue to our team.",

--- a/src/modules/finance/pages/daoTransactionsPage/daoTransactionsPageClient.tsx
+++ b/src/modules/finance/pages/daoTransactionsPage/daoTransactionsPageClient.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/modules/finance/api/financeService';
 import { DaoFilterAsideCard } from '@/modules/finance/components/daoFilterAsideCard';
 import { useDao } from '@/shared/api/daoService';
+import { useFeatureFlags } from '@/shared/components/featureFlagsProvider';
 import { Page } from '@/shared/components/page';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoFilterUrlParam } from '@/shared/hooks/useDaoFilterUrlParam';
@@ -33,6 +34,8 @@ export const DaoTransactionsPageClient: React.FC<
 > = (props) => {
     const { id, initialParams } = props;
     const { t } = useTranslations();
+    const { isEnabled } = useFeatureFlags();
+    const isAutomationEnabled = isEnabled('capitalFlowAutomation');
 
     const { activeOption } = useDaoFilterUrlParam({
         daoId: id,
@@ -90,7 +93,12 @@ export const DaoTransactionsPageClient: React.FC<
                     selectedMetadata={selectedTransactionsMetadata?.pages[0]}
                     statsType="transactions"
                 />
-                <DispatchPanel daoAddress={dao.address} network={dao.network} />
+                {isAutomationEnabled && (
+                    <DispatchPanel
+                        daoAddress={dao.address}
+                        network={dao.network}
+                    />
+                )}
             </Page.Aside>
         </Page.Content>
     );

--- a/src/modules/governance/api/governanceService/governanceService.api.ts
+++ b/src/modules/governance/api/governanceService/governanceService.api.ts
@@ -36,6 +36,10 @@ export interface IGetProposalListQueryParams
      * Filter proposals only from currently installed plugins.
      */
     onlyActive?: boolean;
+    /**
+     * Include proposals from SubDAOs when set to true.
+     */
+    includeSubDaos?: boolean;
 }
 
 export interface IGetProposalListParams

--- a/src/modules/governance/components/daoProposalList/daoProposalList.test.tsx
+++ b/src/modules/governance/components/daoProposalList/daoProposalList.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { FeatureFlagsProvider } from '@/shared/components/featureFlagsProvider';
 import type { IFilterComponentPlugin } from '@/shared/components/pluginFilterComponent';
+import type { FeatureFlagSnapshot } from '@/shared/featureFlags';
 import * as useDaoPlugins from '@/shared/hooks/useDaoPlugins';
+import { pluginGroupFilter } from '@/shared/hooks/useDaoPlugins';
 import {
     generateDaoPlugin,
     generateFilterComponentPlugin,
@@ -8,13 +12,28 @@ import {
 import { GovernanceSlotId } from '../../constants/moduleSlots';
 import { DaoProposalList, type IDaoProposalListProps } from './daoProposalList';
 
+interface IPluginMockProps {
+    initialParams?: {
+        queryParams?: {
+            includeSubDaos?: boolean;
+        };
+    };
+}
+
 jest.mock('@/shared/components/pluginFilterComponent', () => ({
     PluginFilterComponent: (props: {
         slotId: string;
         plugins: IFilterComponentPlugin[];
     }) => (
         <div
-            data-plugins={props.plugins[0].id}
+            data-plugins={JSON.stringify(
+                props.plugins.map((plugin) => ({
+                    id: plugin.id,
+                    includeSubDaos: (
+                        plugin.props as IPluginMockProps | undefined
+                    )?.initialParams?.queryParams?.includeSubDaos,
+                })),
+            )}
             data-slotid={props.slotId}
             data-testid="plugin-component-mock"
         />
@@ -37,20 +56,86 @@ describe('<DaoProposalList /> component', () => {
         return <DaoProposalList {...completeProps} />;
     };
 
+    const createFeatureFlagsSnapshot = (
+        isSubDaoEnabled: boolean,
+    ): FeatureFlagSnapshot[] => [
+        {
+            key: 'subDao',
+            name: 'SubDAO',
+            description: 'Enables subDAO support',
+            enabled: isSubDaoEnabled,
+        },
+    ];
+
+    const renderWithFlags = (
+        isSubDaoEnabled: boolean,
+        component: ReactElement,
+    ) =>
+        render(
+            <FeatureFlagsProvider
+                initialSnapshot={createFeatureFlagsSnapshot(isSubDaoEnabled)}
+            >
+                {component}
+            </FeatureFlagsProvider>,
+        );
+
+    const getRenderedPlugins = () => {
+        const pluginComponent = screen.getByTestId('plugin-component-mock');
+
+        return JSON.parse(pluginComponent.dataset.plugins ?? '[]') as Array<{
+            id: string;
+            includeSubDaos?: boolean;
+        }>;
+    };
+
     it('renders a plugin tab component with the process plugins and the correct slot id', () => {
         const plugins = [
+            pluginGroupFilter,
             generateFilterComponentPlugin({
                 id: 'token',
                 meta: generateDaoPlugin(),
             }),
         ];
         useDaoPluginsSpy.mockReturnValue(plugins);
-        render(createTestComponent());
+        renderWithFlags(false, createTestComponent());
         const pluginComponent = screen.getByTestId('plugin-component-mock');
         expect(pluginComponent).toBeInTheDocument();
         expect(pluginComponent.dataset.slotid).toEqual(
             GovernanceSlotId.GOVERNANCE_DAO_PROPOSAL_LIST,
         );
-        expect(pluginComponent.dataset.plugins).toEqual(plugins[0].id);
+    });
+
+    it('sets includeSubDaos=true only for group tab when subDao feature is enabled', () => {
+        const plugins = [
+            pluginGroupFilter,
+            generateFilterComponentPlugin({
+                id: 'token',
+                meta: generateDaoPlugin({ address: '0x1' }),
+            }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+        renderWithFlags(true, createTestComponent());
+
+        expect(getRenderedPlugins()).toEqual([
+            { id: pluginGroupFilter.id, includeSubDaos: true },
+            { id: 'token', includeSubDaos: false },
+        ]);
+    });
+
+    it('sets includeSubDaos=false for all tabs when subDao feature is disabled', () => {
+        const plugins = [
+            pluginGroupFilter,
+            generateFilterComponentPlugin({
+                id: 'token',
+                meta: generateDaoPlugin({ address: '0x1' }),
+            }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+        renderWithFlags(false, createTestComponent());
+
+        expect(getRenderedPlugins()).toEqual([
+            { id: pluginGroupFilter.id, includeSubDaos: false },
+            { id: 'token', includeSubDaos: false },
+        ]);
     });
 });

--- a/src/modules/governance/components/daoProposalList/daoProposalList.tsx
+++ b/src/modules/governance/components/daoProposalList/daoProposalList.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react';
 import type { IDaoPlugin } from '@/shared/api/daoService';
+import { useFeatureFlags } from '@/shared/components/featureFlagsProvider';
 import {
     type IPluginFilterComponentProps,
     PluginFilterComponent,
@@ -44,6 +45,8 @@ export const DaoProposalList: React.FC<IDaoProposalListProps> = (props) => {
     const { daoId } = initialParams.queryParams;
 
     const { t } = useTranslations();
+    const { isEnabled } = useFeatureFlags();
+    const isSubDaoEnabled = isEnabled('subDao');
     const { activePlugin, setActivePlugin, plugins } =
         useDaoPluginFilterUrlParam({
             daoId,
@@ -68,6 +71,7 @@ export const DaoProposalList: React.FC<IDaoProposalListProps> = (props) => {
                 ...initialParams.queryParams,
                 pluginAddress,
                 onlyActive: isGroupTab,
+                includeSubDaos: isSubDaoEnabled && isGroupTab,
             },
         };
 

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.test.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.test.tsx
@@ -91,6 +91,7 @@ describe('<DaoProposalsPage /> component', () => {
             sort: daoProposalsSort,
             isSubProposal: false,
             onlyActive: false,
+            includeSubDaos: false,
         };
         expect(prefetchInfiniteQuerySpy.mock.calls[0][0].queryKey).toEqual(
             proposalListOptions({ queryParams: memberListParams }).queryKey,

--- a/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.tsx
+++ b/src/modules/governance/pages/daoProposalsPage/daoProposalsPage.tsx
@@ -50,6 +50,7 @@ export const DaoProposalsPage: React.FC<IDaoProposalsPageProps> = async (
         sort: daoProposalsSort,
         isSubProposal: false,
         onlyActive: pluginAddress == null,
+        includeSubDaos: false,
     };
     const proposalListParams = { queryParams: proposalListQueryParams };
 

--- a/src/modules/settings/pages/daoSettingsPage/daoSettingsPage.tsx
+++ b/src/modules/settings/pages/daoSettingsPage/daoSettingsPage.tsx
@@ -25,12 +25,16 @@ export const DaoSettingsPage: React.FC<IDaoSettingsPageProps> = async (
 
     const daoId = await daoUtils.resolveDaoId(daoPageParams);
     const isSubDaoEnabled = await featureFlags.isEnabled('subDao');
+    const isAutomationEnabled = await featureFlags.isEnabled(
+        'capitalFlowAutomation',
+    );
 
     return (
         <Page.Container>
             <Page.Content>
                 <DaoSettingsPageClient
                     daoId={daoId}
+                    isAutomationEnabled={isAutomationEnabled}
                     isSubDaoEnabled={isSubDaoEnabled}
                 />
             </Page.Content>

--- a/src/modules/settings/pages/daoSettingsPage/daoSettingsPageClient.tsx
+++ b/src/modules/settings/pages/daoSettingsPage/daoSettingsPageClient.tsx
@@ -37,6 +37,10 @@ export interface IDaoSettingsPageClientProps {
      */
     daoId: string;
     /**
+     * Whether Automation & Policies feature is enabled.
+     */
+    isAutomationEnabled?: boolean;
+    /**
      * Whether SubDAO feature is enabled.
      */
     isSubDaoEnabled?: boolean;
@@ -45,7 +49,7 @@ export interface IDaoSettingsPageClientProps {
 export const DaoSettingsPageClient: React.FC<IDaoSettingsPageClientProps> = (
     props,
 ) => {
-    const { daoId, isSubDaoEnabled } = props;
+    const { daoId, isAutomationEnabled, isSubDaoEnabled } = props;
 
     const { t } = useTranslations();
     const { open } = useDialogContext();
@@ -63,7 +67,7 @@ export const DaoSettingsPageClient: React.FC<IDaoSettingsPageClientProps> = (
                 daoAddress: dao?.address as string,
             },
         },
-        { enabled: isSubDaoEnabled && dao != null },
+        { enabled: isAutomationEnabled && dao != null },
     );
 
     const hasSupportedPlugins = daoUtils.hasSupportedPlugins(dao);
@@ -226,7 +230,7 @@ export const DaoSettingsPageClient: React.FC<IDaoSettingsPageClientProps> = (
                         ))}
                     </Page.MainSection>
                 )}
-                {isSubDaoEnabled && (
+                {isAutomationEnabled && (
                     <Page.MainSection
                         action={addPolicyAction}
                         className="gap-3"

--- a/src/shared/featureFlags/featureFlags.api.ts
+++ b/src/shared/featureFlags/featureFlags.api.ts
@@ -11,6 +11,7 @@ export type FeatureFlagEnvironment = (typeof FEATURE_FLAG_ENVIRONMENTS)[number];
 export type FeatureFlagKey =
     | 'debugPanel'
     | 'subDao'
+    | 'capitalFlowAutomation'
     | 'governanceDesigner'
     | 'osxUpdates'
     | 'useMocks'

--- a/src/shared/featureFlags/featureFlags.constants.ts
+++ b/src/shared/featureFlags/featureFlags.constants.ts
@@ -51,6 +51,16 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
         },
     },
     {
+        key: 'capitalFlowAutomation',
+        name: 'Capital Flow Automation',
+        description:
+            'Enables automation section in settings and dispatch panel in transactions.',
+        defaultValue: false,
+        environments: {
+            local: true,
+        },
+    },
+    {
         key: 'governanceDesigner',
         name: 'Governance designer',
         description: 'Enables governance designer and admin member features',


### PR DESCRIPTION
## Features
- Add support for subDAOs in DAO proposal components
- Refactor DAO Plugin Info and Process Details components
- Introduce Capital Flow Automation feature flag
- Enhance DAO member and proposal lists to support subDAOs ([#983](https://github.com/aragon/app/pull/983)) — [APP-476: subDAO members and proposals not returning](https://linear.app/aragon/issue/APP-476/subdao-members-and-proposals-not-returning)
- Implement policy uninstall functionality ([#982](https://github.com/aragon/app/pull/982)) — [APP-479: Implement policy uninstall functionality](https://linear.app/aragon/issue/APP-479/implement-policy-uninstall-functionality)
- Remove plugin toggle from settings page and integrate admin settings panel ([#976](https://github.com/aragon/app/pull/976)) — [APP-477: There are unnecessary buttons on settings page with subDAOs](https://linear.app/aragon/issue/APP-477/there-are-unnecessary-buttons-on-settings-page-with-subdaos)
- Filter action builder actions by target DAO permissions ([#968](https://github.com/aragon/app/pull/968)) — [APP-293: Improved plugin targeting indicators throughout the app](https://linear.app/aragon/issue/APP-293/improved-plugin-targeting-indicators-throughout-the-app)
- Implement DAO Policy Details Page ([#970](https://github.com/aragon/app/pull/970)) — [APP-439: Policy details page](https://linear.app/aragon/issue/APP-439/policy-details-page)
- Add the option to enter raw calldata in the action builder ([#975](https://github.com/aragon/app/pull/975)) — [APP-462: The option to enter raw calldata in the action builder is disabled](https://linear.app/aragon/issue/APP-462/the-option-to-enter-raw-calldata-in-the-action-builder-is-disabled)
- Re-enable locking in token member panel ([#964](https://github.com/aragon/app/pull/964)) — [APP-456: Add token panel to gauge voting page](https://linear.app/aragon/issue/APP-456/add-token-panel-to-gauge-voting-page)
- Only show admin panel if current DAO has admin plugin ([#967](https://github.com/aragon/app/pull/967)) — [APP-457: Only show admin banner if parent/current DAO has admin plugin](https://linear.app/aragon/issue/APP-457/only-show-admin-banner-if-parentcurrent-dao-has-admin-plugin)
- Improve plugin targeting indicators throughout the app ([#960](https://github.com/aragon/app/pull/960))
- Add token panel to gauge voting page ([#956](https://github.com/aragon/app/pull/956))

## Other Changes
- Refine multi-dispatch and account labels
- Update API version in production and staging environment files to v3
- Release v1.21.0
- Bump the minor-and-patch group with 3 updates ([#977](https://github.com/aragon/app/pull/977))
- Update package dependencies ([#974](https://github.com/aragon/app/pull/974))
- Bump actions/cache ([#969](https://github.com/aragon/app/pull/969))
- Release v1.20.0 ([#958](https://github.com/aragon/app/pull/958))
- Bump actions/checkout ([#959](https://github.com/aragon/app/pull/959))



<!-- slack_ts: 1770918993.177709 -->
