### PR TITLE
fix(APP-87): handle missing plugins in vote history slugs and proposal execute guard

### DIFF
--- a/.changeset/long-cougars-yell.md
+++ b/.changeset/long-cougars-yell.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Fix vote history for SPP

--- a/src/modules/governance/components/voteList/voteProposalListItem.tsx
+++ b/src/modules/governance/components/voteList/voteProposalListItem.tsx
@@ -32,6 +32,10 @@ export const VoteProposalListItem: React.FC<IVoteProposalListItemProps> = (
     const slug = proposalUtils.getProposalSlug(proposal, dao);
     const proposalHref = proposalUtils.getProposalUrl(proposal, dao);
 
+    if (slug == null) {
+        return null;
+    }
+
     return (
         <VoteProposalDataListItem.Structure
             date={vote.blockTimestamp * 1000}

--- a/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
+++ b/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
@@ -105,7 +105,11 @@ export const VoteDialog: React.FC<IVoteDialogProps> = (props) => {
     return (
         <TransactionDialog
             description={t('app.governance.voteDialog.description')}
-            indexingFallbackUrl={daoUtils.getDaoUrl(dao, `proposals/${slug}`)}
+            indexingFallbackUrl={
+                slug != null
+                    ? daoUtils.getDaoUrl(dao, `proposals/${slug}`)
+                    : undefined
+            }
             network={proposal.network}
             prepareTransaction={handlePrepareTransaction}
             stepper={stepper}
@@ -119,7 +123,7 @@ export const VoteDialog: React.FC<IVoteDialogProps> = (props) => {
         >
             <VoteProposalDataListItemStructure
                 isVeto={isVeto}
-                proposalId={slug}
+                proposalId={slug ?? ''}
                 proposalTitle={proposal.title}
                 voteIndicator={vote.label}
                 voteIndicatorDescription={vote.labelDescription}

--- a/src/modules/governance/hooks/useProposalExecuteGuard/useProposalExecuteGuard.ts
+++ b/src/modules/governance/hooks/useProposalExecuteGuard/useProposalExecuteGuard.ts
@@ -31,12 +31,14 @@ export const useProposalExecuteGuard = (
     const { daoId, pluginAddress, onSuccess, onError } = params;
 
     const { open } = useDialogContext();
-    const { meta: plugin } = useDaoPlugins({ daoId, pluginAddress })![0];
+    const { meta: plugin } =
+        useDaoPlugins({ daoId, pluginAddress, includeSubPlugins: true })?.[0] ??
+        {};
     const { data: dao } = useDao({ urlParams: { id: daoId } });
 
     const checkUserPermission = useCallback(
         (functionParams?: Partial<IUseProposalExecuteGuardParams>) => {
-            if (!dao) {
+            if (!dao || !plugin) {
                 return;
             }
 

--- a/src/modules/governance/utils/proposalUtils/proposalUtils.test.ts
+++ b/src/modules/governance/utils/proposalUtils/proposalUtils.test.ts
@@ -11,11 +11,10 @@ describe('proposalUtils', () => {
     });
 
     describe('getProposalSlug', () => {
-        it('throws an error when plugin is not found', () => {
+        it('returns undefined when plugin is not found', () => {
             getDaoPluginsSpy.mockReturnValue(undefined);
-            expect(() =>
-                proposalUtils.getProposalSlug(generateProposal()),
-            ).toThrow();
+            const result = proposalUtils.getProposalSlug(generateProposal());
+            expect(result).toBeUndefined();
         });
 
         it('returns the correct proposal slug', () => {

--- a/src/modules/governance/utils/proposalUtils/proposalUtils.ts
+++ b/src/modules/governance/utils/proposalUtils/proposalUtils.ts
@@ -1,4 +1,4 @@
-import { addressUtils, invariant } from '@aragon/gov-ui-kit';
+import { addressUtils } from '@aragon/gov-ui-kit';
 import type { IDao } from '@/shared/api/daoService';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import type { IProposal } from '../../api/governanceService';
@@ -7,14 +7,16 @@ class ProposalUtils {
     getProposalSlug = (
         proposal: Pick<IProposal, 'incrementalId' | 'pluginAddress'>,
         dao?: IDao,
-    ): string => {
+    ): string | undefined => {
         const { incrementalId, pluginAddress } = proposal;
         const plugin = daoUtils.getDaoPlugins(dao, {
             pluginAddress,
             includeSubPlugins: true,
         })?.[0];
 
-        invariant(plugin != null, 'getProposalSlug: proposal plugin not found');
+        if (plugin == null) {
+            return undefined;
+        }
 
         return `${plugin.slug}-${incrementalId.toString()}`.toUpperCase();
     };
@@ -35,6 +37,11 @@ class ProposalUtils {
         dao?: IDao,
     ): string | undefined => {
         const slug = this.getProposalSlug(proposal, dao);
+
+        if (slug == null) {
+            return undefined;
+        }
+
         const proposalPath = `proposals/${slug}`;
 
         // If we have enough information to detect a subDAO proposal, build a

--- a/src/plugins/sppPlugin/dialogs/sppReportProposalResultDialog/sppReportProposalResultDialog.tsx
+++ b/src/plugins/sppPlugin/dialogs/sppReportProposalResultDialog/sppReportProposalResultDialog.tsx
@@ -88,7 +88,11 @@ export const SppReportProposalResultDialog: React.FC<
             description={t(
                 'app.plugins.spp.sppReportProposalResultDialog.description',
             )}
-            indexingFallbackUrl={daoUtils.getDaoUrl(dao, `proposals/${slug}`)}
+            indexingFallbackUrl={
+                slug != null
+                    ? daoUtils.getDaoUrl(dao, `proposals/${slug}`)
+                    : undefined
+            }
             network={proposal.network}
             prepareTransaction={handlePrepareTransaction}
             stepper={stepper}
@@ -105,7 +109,7 @@ export const SppReportProposalResultDialog: React.FC<
             transactionType={TransactionType.PROPOSAL_REPORT_RESULTS}
         >
             <VoteProposalDataListItemStructure
-                proposalId={slug}
+                proposalId={slug ?? ''}
                 proposalTitle={proposal.title}
                 voteIndicator="yes"
                 voteIndicatorDescription={t(


### PR DESCRIPTION
- getProposalSlug returns undefined instead of throwing when the plugin is not found (e.g. upgraded/uninstalled plugins)
- VoteProposalListItem skips rendering when slug can't be resolved
- useProposalExecuteGuard adds includeSubPlugins and defensive access to prevent crash on SPP sub-plugin proposals

# Description

- Make `getProposalSlug` gracefully return `undefined` when the proposal's plugin is not found in the current DAO plugin list
- Skip rendering vote items with unresolvable slugs
- Fix crash in `useProposalExecuteGuard` for SPP sub-plugin proposals

## What was wrong
1. `getProposalSlug` threw an `invariant` error when the plugin wasn't found. This crashes the entire vote list when a vote references an upgraded or uninstalled plugin
2. `useProposalExecuteGuard` used `useDaoPlugins` without `includeSubPlugins: true` and with a non-null assertion (`![0]`). SPP body plugins are sub-plugins and weren't found, crashing the proposal detail page.

## How it works now
- Votes referencing missing plugins are silently skipped (not rendered)
- Proposal detail pages for sub-plugin proposals no longer crash
- Works together with the backend fix that correctly projects `parentProposal.pluginAddress` in the vote API response https://github.com/aragon/app-backend/pull/1162

## Test plan
- [ ] SPP DAO (e.g. `/dao/ethereum-sepolia/0xd0ABabB6C7b248Af5A848A828Ee4A5C19F2c0ba0/members/0x455e3DEFBC6b48D9127CF6acC609F5cEa87cA759` or `/dao/ethereum-sepolia/0xEB4813f79E18bbd62F9222CC98F5049B872F5c04/members/0x3C1BF79559F6543daA510a71E16E58370510C551`): open member profile, check vote history shows correct slugs, click through to proposals
- [ ] Long-lived DAO with upgraded plugins (e.g. `/dao/ethereum-sepolia/0xd0ABabB6C7b248Af5A848A828Ee4A5C19F2c0ba0/members/0x455e3DEFBC6b48D9127CF6acC609F5cEa87cA759`): open member profile, verify no crashes — old votes with removed plugins are hidden, recent votes work correctly
- [ ] Non-SPP DAO with multiple bodies: verify vote history and proposal links work as before

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [x] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
