### PR TITLE
fix(APP-531): add safe BigInt parsing to prevent runtime crashes

### DIFF
--- a/.changeset/safe-bigint-utils.md
+++ b/.changeset/safe-bigint-utils.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix runtime crash on BigInt conversion of floating-point strings from APIs (e.g. `"10000000000000000000000000.0"`). Add `bigIntUtils.safeParse()` utility that handles decimal suffixes, scientific notation, and non-finite numbers across all token and lock-to-vote plugin components.

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
@@ -18,6 +18,7 @@ import type { IPageHeaderStat } from '@/shared/components/page/pageHeader/pageHe
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useSlotSingleFunction } from '@/shared/hooks/useSlotSingleFunction';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { networkUtils } from '@/shared/utils/networkUtils';
 import EfpLogo from '../../../../assets/images/efp-logo.svg';
 import { daoUtils } from '../../../../shared/utils/daoUtils';
@@ -78,9 +79,11 @@ export const DaoMemberDetailsPageClient: React.FC<
     const { chainId, buildEntityUrl } = useDaoChain({ daoId });
 
     const firstBlockNumber =
-        firstActivity != null ? BigInt(firstActivity) : undefined;
+        firstActivity != null
+            ? bigIntUtils.safeParse(firstActivity)
+            : undefined;
     const lastBlockNumber =
-        lastActivity != null ? BigInt(lastActivity) : undefined;
+        lastActivity != null ? bigIntUtils.safeParse(lastActivity) : undefined;
 
     const { data: firstBlock } = useBlock({
         chainId,

--- a/src/plugins/lockToVotePlugin/components/lockToVoteProcessBodyField/lockToVoteProcessBodyField.tsx
+++ b/src/plugins/lockToVotePlugin/components/lockToVoteProcessBodyField/lockToVoteProcessBodyField.tsx
@@ -22,6 +22,7 @@ import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDaoPluginInfo } from '@/shared/hooks/useDaoPluginInfo';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { dateUtils } from '@/shared/utils/dateUtils';
 import { DaoLockToVoteVotingMode } from '../../types';
@@ -91,7 +92,8 @@ export const LockToVoteProcessBodyField = (
         governance;
 
     const parsedTotalSupply =
-        totalSupply && formatUnits(BigInt(totalSupply), tokenDecimals);
+        totalSupply &&
+        formatUnits(bigIntUtils.safeParse(totalSupply), tokenDecimals);
     const formattedSupply = formatterUtils.formatNumber(parsedTotalSupply, {
         format: NumberFormat.TOKEN_AMOUNT_LONG,
         fallback: '0',

--- a/src/plugins/lockToVotePlugin/components/lockToVoteProposalVotingBreakdown/lockToVoteProposalVotingBreakdown.tsx
+++ b/src/plugins/lockToVotePlugin/components/lockToVoteProposalVotingBreakdown/lockToVoteProposalVotingBreakdown.tsx
@@ -3,6 +3,7 @@
 import { ProposalVoting } from '@aragon/gov-ui-kit';
 import type { ReactNode } from 'react';
 import { formatUnits } from 'viem';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { VoteOption } from '../../../tokenPlugin/types';
 import { tokenSettingsUtils } from '../../../tokenPlugin/utils/tokenSettingsUtils';
 import type { ILockToVoteProposal } from '../../types';
@@ -56,7 +57,10 @@ export const LockToVoteProposalVotingBreakdown: React.FC<
                 supportThreshold,
             )}
             tokenSymbol={symbol}
-            tokenTotalSupply={formatUnits(BigInt(totalSupply ?? 0), decimals)}
+            tokenTotalSupply={formatUnits(
+                bigIntUtils.safeParse(totalSupply),
+                decimals,
+            )}
             totalAbstain={abstainVotes}
             totalNo={noVotes}
             totalYes={yesVotes}

--- a/src/plugins/lockToVotePlugin/components/lockToVoteProposalVotingSummary/lockToVoteProposalVotingSummary.tsx
+++ b/src/plugins/lockToVotePlugin/components/lockToVoteProposalVotingSummary/lockToVoteProposalVotingSummary.tsx
@@ -9,6 +9,7 @@ import {
 } from '@aragon/gov-ui-kit';
 import { formatUnits } from 'viem';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { VoteOption } from '../../../tokenPlugin/types';
 import { tokenSettingsUtils } from '../../../tokenPlugin/utils/tokenSettingsUtils';
 import type { ILockToVoteProposal } from '../../types';
@@ -67,7 +68,7 @@ export const LockToVoteProposalVotingSummary: React.FC<
     );
 
     const tokenTotalSupply = formatUnits(
-        BigInt(historicalTotalSupply!),
+        bigIntUtils.safeParse(historicalTotalSupply),
         decimals,
     );
     const totalSupplyNumber = Number(tokenTotalSupply);

--- a/src/plugins/lockToVotePlugin/hooks/useLockToVotePermissionCheckProposalCreation/useLockToVotePermissionCheckProposalCreation.ts
+++ b/src/plugins/lockToVotePlugin/hooks/useLockToVotePermissionCheckProposalCreation/useLockToVotePermissionCheckProposalCreation.ts
@@ -10,6 +10,7 @@ import type {
 import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import type { ILockToVotePlugin } from '../../types';
 import { useLockToVoteData } from '../useLockToVoteData';
@@ -107,7 +108,8 @@ export const useLockToVotePermissionCheckProposalCreation = (
 
     const hasPermission =
         !isLoadingRequiredLockAmount && lockedAmount >= requiredLockAmount;
-    const isRestricted = BigInt(minProposerVotingPower) > 0;
+    const isRestricted =
+        bigIntUtils.safeParse(minProposerVotingPower) > BigInt(0);
 
     return {
         hasPermission,

--- a/src/plugins/lockToVotePlugin/utils/lockToVoteProposalUtils/lockToVoteProposalUtils.ts
+++ b/src/plugins/lockToVotePlugin/utils/lockToVoteProposalUtils/lockToVoteProposalUtils.ts
@@ -1,6 +1,7 @@
 import type { ProposalStatus } from '@aragon/gov-ui-kit';
 import { formatUnits } from 'viem';
 import { tokenSettingsUtils } from '@/plugins/tokenPlugin/utils/tokenSettingsUtils';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { proposalStatusUtils } from '@/shared/utils/proposalStatusUtils';
 import {
     type ITokenProposalOptionVotes,
@@ -53,11 +54,9 @@ class LockToVoteProposalUtils {
     isMinParticipationReached = (proposal: ILockToVoteProposal): boolean => {
         const { minParticipation } = proposal.settings;
 
-        // Don't do the ratio-to-percentage conversion here as the minParticipation can be a value with decimals and
-        // the BigInt constructor does not support such values.
-        const parsedMinParticipation = BigInt(minParticipation);
-        const parsedTotalSupply = BigInt(
-            this.getProposalTokenTotalSupply(proposal) ?? 0,
+        const parsedMinParticipation = bigIntUtils.safeParse(minParticipation);
+        const parsedTotalSupply = bigIntUtils.safeParse(
+            this.getProposalTokenTotalSupply(proposal),
         );
 
         if (parsedTotalSupply === BigInt(0)) {
@@ -83,9 +82,10 @@ class LockToVoteProposalUtils {
         const noVotesComparator = noVotesCurrent;
 
         return (
-            (tokenSettingsUtils.ratioBase - BigInt(supportThreshold)) *
+            (tokenSettingsUtils.ratioBase -
+                bigIntUtils.safeParse(supportThreshold)) *
                 yesVotes >
-            BigInt(supportThreshold) * noVotesComparator
+            bigIntUtils.safeParse(supportThreshold) * noVotesComparator
         );
     };
 
@@ -100,7 +100,9 @@ class LockToVoteProposalUtils {
                 return accumulator;
             }
 
-            return accumulator + BigInt(current.totalVotingPower);
+            return (
+                accumulator + bigIntUtils.safeParse(current.totalVotingPower)
+            );
         }, BigInt(0));
 
         return totalVotes;
@@ -112,7 +114,7 @@ class LockToVoteProposalUtils {
     ): bigint => {
         const optionVotes = votes.find((option) => option.type === type);
 
-        return BigInt(optionVotes?.totalVotingPower ?? 0);
+        return bigIntUtils.safeParse(optionVotes?.totalVotingPower);
     };
 
     getOptionVotingPower = (
@@ -123,7 +125,7 @@ class LockToVoteProposalUtils {
             (vote) => vote.type === option,
         );
         const parsedVotingPower = formatUnits(
-            BigInt(votes?.totalVotingPower ?? 0),
+            bigIntUtils.safeParse(votes?.totalVotingPower),
             proposal.settings.token.decimals,
         );
 

--- a/src/plugins/lockToVotePlugin/utils/lockToVoteSettingsUtils/lockToVoteSettingsUtils.tsx
+++ b/src/plugins/lockToVotePlugin/utils/lockToVoteSettingsUtils/lockToVoteSettingsUtils.tsx
@@ -5,6 +5,7 @@ import {
 } from '@aragon/gov-ui-kit';
 import { formatUnits } from 'viem';
 import type { TranslationFunction } from '@/shared/components/translationsProvider';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { dateUtils } from '@/shared/utils/dateUtils';
 import { tokenSettingsUtils } from '../../../tokenPlugin/utils/tokenSettingsUtils';
 import {
@@ -72,7 +73,7 @@ class LockToVoteSettingsUtils {
             (Number(processedTotalSupply) * parsedMinParticipation) / 100,
         );
         const parsedMinParticipationToken = formatUnits(
-            BigInt(minParticipationToken),
+            bigIntUtils.safeParse(minParticipationToken),
             decimals,
         );
         const formattedMinParticipationToken = formatterUtils.formatNumber(
@@ -93,7 +94,7 @@ class LockToVoteSettingsUtils {
         );
 
         const parsedMinVotingPower = formatUnits(
-            BigInt(minProposerVotingPower),
+            bigIntUtils.safeParse(minProposerVotingPower),
             decimals,
         );
         const formattedProposerVotingPower = formatterUtils.formatNumber(

--- a/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.tsx
@@ -5,6 +5,7 @@ import type {
     ITokenPluginSettings,
 } from '@/plugins/tokenPlugin/types';
 import { type IDaoPlugin, useDao } from '@/shared/api/daoService';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { daoUtils } from '@/shared/utils/daoUtils';
 
 export interface ITokenMemberListItemProps {
@@ -29,7 +30,7 @@ export const TokenMemberListItem: React.FC<ITokenMemberListItemProps> = (
 
     const tokenDecimals = plugin.settings.token.decimals;
     const parsedVotingPower = formatUnits(
-        BigInt(member.votingPower ?? '0'),
+        bigIntUtils.safeParse(member.votingPower),
         tokenDecimals,
     );
     const { data: dao } = useDao({ urlParams: { id: daoId } });

--- a/src/plugins/tokenPlugin/components/tokenProcessBodyField/tokenProcessBodyField.tsx
+++ b/src/plugins/tokenPlugin/components/tokenProcessBodyField/tokenProcessBodyField.tsx
@@ -18,6 +18,7 @@ import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useDaoPluginInfo } from '@/shared/hooks/useDaoPluginInfo';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { dateUtils } from '@/shared/utils/dateUtils';
 import { DaoTokenVotingMode } from '../../types';
@@ -81,7 +82,8 @@ export const TokenProcessBodyField = (props: ITokenProcessBodyFieldProps) => {
         governance;
 
     const parsedTotalSupply =
-        totalSupply && formatUnits(BigInt(totalSupply), tokenDecimals);
+        totalSupply &&
+        formatUnits(bigIntUtils.safeParse(totalSupply), tokenDecimals);
     const formattedSupply = formatterUtils.formatNumber(parsedTotalSupply, {
         format: NumberFormat.TOKEN_AMOUNT_LONG,
         fallback: '0',

--- a/src/plugins/tokenPlugin/components/tokenProposalVotingBreakdown/tokenProposalVotingBreakdown.tsx
+++ b/src/plugins/tokenPlugin/components/tokenProposalVotingBreakdown/tokenProposalVotingBreakdown.tsx
@@ -3,6 +3,7 @@
 import { ProposalVoting } from '@aragon/gov-ui-kit';
 import type { ReactNode } from 'react';
 import { formatUnits } from 'viem';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import type { ITokenProposal } from '../../types';
 import { VoteOption } from '../../types/enum/voteOption';
 import { tokenProposalUtils } from '../../utils/tokenProposalUtils';
@@ -56,7 +57,7 @@ export const TokenProposalVotingBreakdown: React.FC<
             )}
             tokenSymbol={symbol}
             tokenTotalSupply={formatUnits(
-                BigInt(historicalTotalSupply!),
+                bigIntUtils.safeParse(historicalTotalSupply),
                 decimals,
             )}
             totalAbstain={abstainVotes}

--- a/src/plugins/tokenPlugin/components/tokenProposalVotingSummary/tokenProposalVotingSummary.tsx
+++ b/src/plugins/tokenPlugin/components/tokenProposalVotingSummary/tokenProposalVotingSummary.tsx
@@ -9,6 +9,7 @@ import {
 } from '@aragon/gov-ui-kit';
 import { formatUnits } from 'viem';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { type ITokenProposal, VoteOption } from '../../types';
 import { tokenProposalUtils } from '../../utils/tokenProposalUtils';
 import { tokenSettingsUtils } from '../../utils/tokenSettingsUtils';
@@ -63,7 +64,7 @@ export const TokenProposalVotingSummary: React.FC<
     );
 
     const tokenTotalSupply = formatUnits(
-        BigInt(historicalTotalSupply!),
+        bigIntUtils.safeParse(historicalTotalSupply),
         decimals,
     );
     const totalSupplyNumber = Number(tokenTotalSupply);

--- a/src/plugins/tokenPlugin/hooks/useTokenPermissionCheckProposalCreation/useTokenPermissionCheckProposalCreation.ts
+++ b/src/plugins/tokenPlugin/hooks/useTokenPermissionCheckProposalCreation/useTokenPermissionCheckProposalCreation.ts
@@ -13,6 +13,7 @@ import type {
 } from '@/plugins/tokenPlugin/types';
 import { type IDaoPlugin, type Network, useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { useWrappedTokenBalance } from '../useWrappedTokenBalance';
 
@@ -34,7 +35,7 @@ export const useTokenPermissionCheckProposalCreation = (
     const { decimals: tokenDecimals, symbol: tokenSymbol } = token;
 
     const parsedMinVotingPower = formatUnits(
-        BigInt(minProposerVotingPower),
+        bigIntUtils.safeParse(minProposerVotingPower),
         tokenDecimals,
     );
     const formattedMinVotingPower = formatterUtils.formatNumber(
@@ -71,7 +72,7 @@ export const useTokenPermissionCheckProposalCreation = (
         token,
     });
 
-    const userVotingPower = BigInt(member?.votingPower ?? '0');
+    const userVotingPower = bigIntUtils.safeParse(member?.votingPower);
 
     const parsedMemberVotingPower = formatUnits(userVotingPower, tokenDecimals);
     const formattedMemberVotingPower = formatterUtils.formatNumber(
@@ -123,7 +124,8 @@ export const useTokenPermissionCheckProposalCreation = (
         ? defaultSettings.concat(connectedUserSettings)
         : defaultSettings;
 
-    const isRestricted = BigInt(minProposerVotingPower) > 0;
+    const isRestricted =
+        bigIntUtils.safeParse(minProposerVotingPower) > BigInt(0);
 
     return {
         hasPermission: canCreateProposal?.status === true,

--- a/src/plugins/tokenPlugin/utils/tokenProposalUtils/tokenProposalUtils.test.ts
+++ b/src/plugins/tokenPlugin/utils/tokenProposalUtils/tokenProposalUtils.test.ts
@@ -500,6 +500,42 @@ describe('tokenProposal utils', () => {
                 tokenProposalUtils.isSupportReached(proposal, true),
             ).toBeFalsy();
         });
+
+        it('returns false when early param is true and historicalTotalSupply is undefined', () => {
+            const settings = generateTokenPluginSettings({
+                supportThreshold: 500_000,
+                historicalTotalSupply: undefined,
+            });
+            const votesByOption = [
+                { type: VoteOption.YES, totalVotingPower: '510' },
+                { type: VoteOption.NO, totalVotingPower: '490' },
+            ];
+            const proposal = generateTokenProposal({
+                settings,
+                metrics: { votesByOption },
+            });
+            expect(
+                tokenProposalUtils.isSupportReached(proposal, true),
+            ).toBeFalsy();
+        });
+
+        it('returns false when early param is true and historicalTotalSupply is zero', () => {
+            const settings = generateTokenPluginSettings({
+                supportThreshold: 500_000,
+                historicalTotalSupply: '0',
+            });
+            const votesByOption = [
+                { type: VoteOption.YES, totalVotingPower: '510' },
+                { type: VoteOption.NO, totalVotingPower: '490' },
+            ];
+            const proposal = generateTokenProposal({
+                settings,
+                metrics: { votesByOption },
+            });
+            expect(
+                tokenProposalUtils.isSupportReached(proposal, true),
+            ).toBeFalsy();
+        });
     });
 
     describe('getTotalVotes', () => {

--- a/src/plugins/tokenPlugin/utils/tokenProposalUtils/tokenProposalUtils.ts
+++ b/src/plugins/tokenPlugin/utils/tokenProposalUtils/tokenProposalUtils.ts
@@ -1,6 +1,7 @@
 import type { ProposalStatus } from '@aragon/gov-ui-kit';
 import { DateTime } from 'luxon';
 import { formatUnits } from 'viem';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { proposalStatusUtils } from '@/shared/utils/proposalStatusUtils';
 import {
     DaoTokenVotingMode,
@@ -77,10 +78,8 @@ class TokenProposalUtils {
     isMinParticipationReached = (proposal: ITokenProposal): boolean => {
         const { minParticipation, historicalTotalSupply } = proposal.settings;
 
-        // Don't do the ratio-to-percentage conversion here as the minParticipation can be a value with decimals and
-        // the BigInt contructor does not support such values.
-        const parsedMinParticipation = BigInt(minParticipation);
-        const parsedTotalSupply = BigInt(historicalTotalSupply!);
+        const parsedMinParticipation = bigIntUtils.safeParse(minParticipation);
+        const parsedTotalSupply = bigIntUtils.safeParse(historicalTotalSupply);
 
         if (parsedTotalSupply === BigInt(0)) {
             return false;
@@ -106,15 +105,18 @@ class TokenProposalUtils {
 
         const noVotesCurrent = this.getVoteByType(votesByOption, VoteOption.NO);
         const noVotesWorstCase =
-            BigInt(historicalTotalSupply!) - yesVotes - abstainVotes;
+            bigIntUtils.safeParse(historicalTotalSupply) -
+            yesVotes -
+            abstainVotes;
 
         // For early-execution, check that the support threshold is met even if all remaining votes are no votes.
         const noVotesComparator = early ? noVotesWorstCase : noVotesCurrent;
 
         return (
-            (tokenSettingsUtils.ratioBase - BigInt(supportThreshold)) *
+            (tokenSettingsUtils.ratioBase -
+                bigIntUtils.safeParse(supportThreshold)) *
                 yesVotes >
-            BigInt(supportThreshold) * noVotesComparator
+            bigIntUtils.safeParse(supportThreshold) * noVotesComparator
         );
     };
 
@@ -129,7 +131,9 @@ class TokenProposalUtils {
                 return accumulator;
             }
 
-            return accumulator + BigInt(current.totalVotingPower);
+            return (
+                accumulator + bigIntUtils.safeParse(current.totalVotingPower)
+            );
         }, BigInt(0));
 
         return totalVotes;
@@ -141,7 +145,7 @@ class TokenProposalUtils {
     ): bigint => {
         const optionVotes = votes.find((option) => option.type === type);
 
-        return BigInt(optionVotes?.totalVotingPower ?? 0);
+        return bigIntUtils.safeParse(optionVotes?.totalVotingPower);
     };
 
     getOptionVotingPower = (proposal: ITokenProposal, option: VoteOption) => {
@@ -149,7 +153,7 @@ class TokenProposalUtils {
             (vote) => vote.type === option,
         );
         const parsedVotingPower = formatUnits(
-            BigInt(votes?.totalVotingPower ?? 0),
+            bigIntUtils.safeParse(votes?.totalVotingPower),
             proposal.settings.token.decimals,
         );
 

--- a/src/plugins/tokenPlugin/utils/tokenProposalUtils/tokenProposalUtils.ts
+++ b/src/plugins/tokenPlugin/utils/tokenProposalUtils/tokenProposalUtils.ts
@@ -98,19 +98,26 @@ class TokenProposalUtils {
         const { votesByOption } = proposal.metrics;
 
         const yesVotes = this.getVoteByType(votesByOption, VoteOption.YES);
-        const abstainVotes = this.getVoteByType(
-            votesByOption,
-            VoteOption.ABSTAIN,
-        );
-
         const noVotesCurrent = this.getVoteByType(votesByOption, VoteOption.NO);
-        const noVotesWorstCase =
-            bigIntUtils.safeParse(historicalTotalSupply) -
-            yesVotes -
-            abstainVotes;
 
-        // For early-execution, check that the support threshold is met even if all remaining votes are no votes.
-        const noVotesComparator = early ? noVotesWorstCase : noVotesCurrent;
+        let noVotesComparator = noVotesCurrent;
+
+        if (early) {
+            const parsedTotalSupply = bigIntUtils.safeParse(
+                historicalTotalSupply,
+            );
+
+            if (parsedTotalSupply === BigInt(0)) {
+                return false;
+            }
+
+            const abstainVotes = this.getVoteByType(
+                votesByOption,
+                VoteOption.ABSTAIN,
+            );
+
+            noVotesComparator = parsedTotalSupply - yesVotes - abstainVotes;
+        }
 
         return (
             (tokenSettingsUtils.ratioBase -

--- a/src/plugins/tokenPlugin/utils/tokenSettingsUtils/tokenSettingsUtils.tsx
+++ b/src/plugins/tokenPlugin/utils/tokenSettingsUtils/tokenSettingsUtils.tsx
@@ -9,6 +9,7 @@ import {
     type ITokenPluginSettings,
 } from '@/plugins/tokenPlugin/types';
 import type { TranslationFunction } from '@/shared/components/translationsProvider';
+import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { dateUtils } from '@/shared/utils/dateUtils';
 
 export interface IParseTokenSettingsParams {
@@ -84,7 +85,7 @@ class TokenSettingsUtils {
             (Number(processedTotalSupply) * parsedMinParticipation) / 100,
         );
         const parsedMinParticipationToken = formatUnits(
-            BigInt(minParticipationToken),
+            bigIntUtils.safeParse(minParticipationToken),
             decimals,
         );
         const formattedMinParticipationToken = formatterUtils.formatNumber(
@@ -105,7 +106,7 @@ class TokenSettingsUtils {
         );
 
         const parsedMinVotingPower = formatUnits(
-            BigInt(minProposerVotingPower),
+            bigIntUtils.safeParse(minProposerVotingPower),
             decimals,
         );
         const formattedProposerVotingPower = formatterUtils.formatNumber(

--- a/src/shared/utils/bigIntUtils/bigIntUtils.test.ts
+++ b/src/shared/utils/bigIntUtils/bigIntUtils.test.ts
@@ -1,0 +1,152 @@
+import { bigIntUtils } from './bigIntUtils';
+
+describe('bigIntUtils', () => {
+    describe('safeParse', () => {
+        // --- Basic conversions ---
+
+        it('converts a plain integer string', () => {
+            expect(bigIntUtils.safeParse('123')).toBe(BigInt(123));
+        });
+
+        it('converts a large integer string with full precision', () => {
+            expect(bigIntUtils.safeParse('10000000000000000000000000')).toBe(
+                BigInt('10000000000000000000000000'),
+            );
+        });
+
+        it('converts a number type', () => {
+            expect(bigIntUtils.safeParse(42)).toBe(BigInt(42));
+        });
+
+        it('passes through existing bigint', () => {
+            expect(bigIntUtils.safeParse(BigInt(100))).toBe(BigInt(100));
+        });
+
+        it('converts zero from all types', () => {
+            expect(bigIntUtils.safeParse('0')).toBe(BigInt(0));
+            expect(bigIntUtils.safeParse(0)).toBe(BigInt(0));
+            expect(bigIntUtils.safeParse(BigInt(0))).toBe(BigInt(0));
+        });
+
+        it('handles hex strings', () => {
+            expect(bigIntUtils.safeParse('0xff')).toBe(BigInt(255));
+        });
+
+        // --- Floating-point strings (the original bug) ---
+
+        it('handles ".0" suffix from APIs', () => {
+            expect(bigIntUtils.safeParse('10000000000000000000000000.0')).toBe(
+                BigInt('10000000000000000000000000'),
+            );
+        });
+
+        it('truncates fractional digits', () => {
+            expect(bigIntUtils.safeParse('999.999')).toBe(BigInt(999));
+        });
+
+        // --- Scientific notation strings (precision-preserving) ---
+
+        it('parses positive scientific notation string', () => {
+            expect(bigIntUtils.safeParse('1e+25')).toBe(
+                BigInt('10000000000000000000000000'),
+            );
+        });
+
+        it('parses scientific notation with fractional mantissa', () => {
+            expect(bigIntUtils.safeParse('1.5e3')).toBe(BigInt(1500));
+        });
+
+        it('parses negative scientific notation string', () => {
+            expect(bigIntUtils.safeParse('-3e10')).toBe(
+                BigInt(-30_000_000_000),
+            );
+        });
+
+        it('truncates scientific notation that results in a fraction', () => {
+            expect(bigIntUtils.safeParse('1.5e0')).toBe(BigInt(1));
+        });
+
+        it('handles scientific notation with uppercase E', () => {
+            expect(bigIntUtils.safeParse('5E3')).toBe(BigInt(5000));
+        });
+
+        // --- Number type: large values (scientific notation internally) ---
+
+        it('converts a large number (>= 1e21) via Math.trunc', () => {
+            const result = bigIntUtils.safeParse(1e25);
+            expect(result > BigInt(0)).toBe(true);
+            expect(result).toBe(BigInt(Math.trunc(1e25)));
+        });
+
+        it('handles negative large number', () => {
+            expect(bigIntUtils.safeParse(-1e25)).toBe(
+                BigInt(Math.trunc(-1e25)),
+            );
+        });
+
+        // --- Number edge cases ---
+
+        it('returns fallback for NaN', () => {
+            expect(bigIntUtils.safeParse(Number.NaN)).toBe(BigInt(0));
+        });
+
+        it('returns fallback for Infinity', () => {
+            expect(bigIntUtils.safeParse(Number.POSITIVE_INFINITY)).toBe(
+                BigInt(0),
+            );
+        });
+
+        it('returns fallback for -Infinity', () => {
+            expect(bigIntUtils.safeParse(Number.NEGATIVE_INFINITY)).toBe(
+                BigInt(0),
+            );
+        });
+
+        it('truncates fractional number towards zero', () => {
+            expect(bigIntUtils.safeParse(3.7)).toBe(BigInt(3));
+            expect(bigIntUtils.safeParse(-3.7)).toBe(BigInt(-3));
+        });
+
+        // --- Null / undefined / empty ---
+
+        it('returns fallback for null', () => {
+            expect(bigIntUtils.safeParse(null)).toBe(BigInt(0));
+        });
+
+        it('returns fallback for undefined', () => {
+            expect(bigIntUtils.safeParse(undefined)).toBe(BigInt(0));
+        });
+
+        it('returns fallback for empty string', () => {
+            expect(bigIntUtils.safeParse('')).toBe(BigInt(0));
+        });
+
+        it('returns fallback for whitespace-only string', () => {
+            expect(bigIntUtils.safeParse('   ')).toBe(BigInt(0));
+        });
+
+        it('returns custom fallback', () => {
+            expect(bigIntUtils.safeParse(null, BigInt(999))).toBe(BigInt(999));
+        });
+
+        // --- Negative and whitespace ---
+
+        it('handles negative string', () => {
+            expect(bigIntUtils.safeParse('-100')).toBe(BigInt(-100));
+        });
+
+        it('trims whitespace', () => {
+            expect(bigIntUtils.safeParse('  500  ')).toBe(BigInt(500));
+        });
+
+        // --- Invalid input ---
+
+        it('returns fallback for non-numeric strings', () => {
+            expect(bigIntUtils.safeParse('abc')).toBe(BigInt(0));
+        });
+
+        it('returns fallback for malformed scientific notation', () => {
+            expect(bigIntUtils.safeParse('1.2.3e5')).toBe(BigInt(0));
+        });
+    });
+});

--- a/src/shared/utils/bigIntUtils/bigIntUtils.test.ts
+++ b/src/shared/utils/bigIntUtils/bigIntUtils.test.ts
@@ -32,6 +32,10 @@ describe('bigIntUtils', () => {
             expect(bigIntUtils.safeParse('0xff')).toBe(BigInt(255));
         });
 
+        it('handles hex strings that contain "e"', () => {
+            expect(bigIntUtils.safeParse('0x1e')).toBe(BigInt(30));
+        });
+
         // --- Floating-point strings (the original bug) ---
 
         it('handles ".0" suffix from APIs', () => {

--- a/src/shared/utils/bigIntUtils/bigIntUtils.ts
+++ b/src/shared/utils/bigIntUtils/bigIntUtils.ts
@@ -1,4 +1,8 @@
 class BigIntUtils {
+    private readonly scientificNotationRegex =
+        /^([+-]?)(\d+\.?\d*)[eE]([+-]?\d+)$/;
+    private readonly hexNotationRegex = /^0[xX][0-9a-fA-F]+$/;
+
     /**
      * Safely converts a value to BigInt, handling floating-point representations
      * (e.g. "10000000000000000000000000.0") and scientific notation (e.g. "1e+25")
@@ -30,8 +34,12 @@ class BigIntUtils {
             return fallback;
         }
 
-        if (/[eE]/.test(str)) {
-            return this.parseScientificString(str) ?? fallback;
+        const scientificValue = this.parseScientificString(str);
+        if (scientificValue != null) {
+            return scientificValue;
+        }
+        if (/[eE]/.test(str) && !this.hexNotationRegex.test(str)) {
+            return fallback;
         }
 
         const integerPart = str.split('.')[0];
@@ -48,7 +56,7 @@ class BigIntUtils {
      * without going through Number, preserving full precision for the significant digits.
      */
     private parseScientificString = (str: string): bigint | null => {
-        const match = str.match(/^([+-]?)(\d+\.?\d*)[eE]([+-]?\d+)$/);
+        const match = str.match(this.scientificNotationRegex);
         if (!match) {
             return null;
         }

--- a/src/shared/utils/bigIntUtils/bigIntUtils.ts
+++ b/src/shared/utils/bigIntUtils/bigIntUtils.ts
@@ -1,0 +1,81 @@
+class BigIntUtils {
+    /**
+     * Safely converts a value to BigInt, handling floating-point representations
+     * (e.g. "10000000000000000000000000.0") and scientific notation (e.g. "1e+25")
+     * that can come from external APIs like CoinGecko or EVM explorers.
+     *
+     * On-chain values (token supply, voting power, block numbers, etc.) are always
+     * integers, so any fractional part is truncated towards zero.
+     */
+    safeParse = (
+        value: string | number | bigint | null | undefined,
+        fallback: bigint = BigInt(0),
+    ): bigint => {
+        if (value == null) {
+            return fallback;
+        }
+        if (typeof value === 'bigint') {
+            return value;
+        }
+
+        if (typeof value === 'number') {
+            if (!Number.isFinite(value)) {
+                return fallback;
+            }
+            return BigInt(Math.trunc(value));
+        }
+
+        const str = value.trim();
+        if (str === '') {
+            return fallback;
+        }
+
+        if (/[eE]/.test(str)) {
+            return this.parseScientificString(str) ?? fallback;
+        }
+
+        const integerPart = str.split('.')[0];
+
+        try {
+            return BigInt(integerPart);
+        } catch {
+            return fallback;
+        }
+    };
+
+    /**
+     * Parses a scientific notation string (e.g. "1.5e+25", "-3e10") directly into BigInt
+     * without going through Number, preserving full precision for the significant digits.
+     */
+    private parseScientificString = (str: string): bigint | null => {
+        const match = str.match(/^([+-]?)(\d+\.?\d*)[eE]([+-]?\d+)$/);
+        if (!match) {
+            return null;
+        }
+
+        const [, sign, mantissa, expStr] = match;
+        const exp = Number(expStr);
+
+        const dotIndex = mantissa.indexOf('.');
+        const fracLength = dotIndex >= 0 ? mantissa.length - dotIndex - 1 : 0;
+        const digits = mantissa.replace('.', '');
+
+        const adjustedExp = exp - fracLength;
+
+        try {
+            const significand = BigInt((sign === '-' ? '-' : '') + digits);
+
+            if (adjustedExp >= 0) {
+                return significand * BigInt(10) ** BigInt(adjustedExp);
+            }
+
+            // Fractional result — truncate towards zero
+            const divisor = BigInt(10) ** BigInt(-adjustedExp);
+            return significand / divisor;
+        } catch {
+            return null;
+        }
+    };
+}
+
+export const bigIntUtils = new BigIntUtils();

--- a/src/shared/utils/bigIntUtils/index.ts
+++ b/src/shared/utils/bigIntUtils/index.ts
@@ -1,0 +1,1 @@
+export { bigIntUtils } from './bigIntUtils';


### PR DESCRIPTION

# Description

- Replace all raw BigInt() calls that take external API data with bigIntUtils.safeParse()
- Fixes crash where totalSupply arrived as "10000000000000000000000000.0" from causing "Cannot convert to a BigInt" runtime error.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
