### PR TITLE
Release v1.23.0

### DIFF
--- a/.changeset/empty-parks-push.md
+++ b/.changeset/empty-parks-push.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Add Playwright E2E infrastructure and smoke tests with CI and Slack notifications.

--- a/.changeset/fine-parts-go.md
+++ b/.changeset/fine-parts-go.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Rename SubDAO to linked account across the frontend and add API compatibility layer.

--- a/.changeset/giant-dancers-divide.md
+++ b/.changeset/giant-dancers-divide.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Implement custom DAO header for Cryptex

--- a/.changeset/giant-rabbits-jam.md
+++ b/.changeset/giant-rabbits-jam.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Add pause, resume, and end campaign basic actions for Capital Distributor

--- a/.changeset/many-rocks-rescue.md
+++ b/.changeset/many-rocks-rescue.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Implement Katana rewards calculation in campaign creation

--- a/.changeset/safe-bigint-utils.md
+++ b/.changeset/safe-bigint-utils.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Fix runtime crash on BigInt conversion of floating-point strings from APIs (e.g. `"10000000000000000000000000.0"`). Add `bigIntUtils.safeParse()` utility that handles decimal suffixes, scientific notation, and non-finite numbers across all token and lock-to-vote plugin components.

--- a/.changeset/small-ducks-sell.md
+++ b/.changeset/small-ducks-sell.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Remove platform ping in slack during release

--- a/.changeset/sweet-lizards-throw.md
+++ b/.changeset/sweet-lizards-throw.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Fix misaligned add/remove members UI and update to latest spec

--- a/.changeset/upset-doodles-visit.md
+++ b/.changeset/upset-doodles-visit.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Upgrade to Next.js 16 with React Compiler and Turbopack

--- a/.changeset/vast-hornets-shake.md
+++ b/.changeset/vast-hornets-shake.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Implement fallback behavior for partial decoded actions

--- a/.github/workflows/app-preview.yml
+++ b/.github/workflows/app-preview.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   deploy:
+    if: ${{ !startsWith(github.head_ref, 'release/') && !startsWith(github.head_ref, 'hotfix/') }}
     uses: ./.github/workflows/shared-deploy.yml
     secrets: inherit
     with:

--- a/.github/workflows/app-production.yml
+++ b/.github/workflows/app-production.yml
@@ -32,6 +32,8 @@ jobs:
 
   notify-start:
     runs-on: ubuntu-latest
+    outputs:
+      slack-ts: ${{ steps.ts.outputs.ts }}
     steps:
       - name: Load secrets
         id: secrets
@@ -88,7 +90,7 @@ jobs:
       environment: production
 
   e2e-notify:
-    needs: e2e
+    needs: [notify-start, e2e]
     if: ${{ always() && needs.e2e.result != 'skipped' }}
     runs-on: ubuntu-latest
     steps:
@@ -108,14 +110,7 @@ jobs:
           fetch-depth: 1
           sparse-checkout: |
             .github/workflows/scripts/slackNotify.js
-            .github/actions/extract-slack-ts
             .github/actions/slack-notify
-
-      - name: Extract Slack TS from release body
-        id: ts
-        uses: ./.github/actions/extract-slack-ts
-        with:
-          body: ${{ github.event.release.body }}
 
       - name: Notify Slack — E2E results
         if: steps.secrets.outputs.SLACK_BOT_TOKEN
@@ -123,13 +118,13 @@ jobs:
         with:
           slack_bot_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
           slack_channel_id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
-          thread_ts: ${{ steps.ts.outputs.ts }}
+          thread_ts: ${{ needs.notify-start.outputs.slack-ts }}
           message: |
             ${{ needs.e2e.result == 'success' && '✅ Smoke tests on *production* passed' || '❌ Smoke tests on *production* failed' }}
             <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View report>
 
   notify:
-    needs: deploy
+    needs: [notify-start, deploy]
     runs-on: ubuntu-latest
     steps:
       - name: Load secrets
@@ -142,28 +137,21 @@ jobs:
           SLACK_BOT_TOKEN: op://kv_app_infra/SLACK_BOT_TOKEN/credential
           SLACK_CHANNEL_ID: op://kv_app_infra/SLACK_CHANNEL_ID/credential
 
-      - name: Checkout (for slackNotify script)
+      - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
           sparse-checkout: |
             .github/workflows/scripts/slackNotify.js
-            .github/actions/extract-slack-ts
             .github/actions/slack-notify
 
-      - name: Extract Slack TS from release body
-        id: ts
-        uses: ./.github/actions/extract-slack-ts
-        with:
-          body: ${{ github.event.release.body }}
-
       - name: Notify Slack
-        if: steps.secrets.outputs.SLACK_BOT_TOKEN && steps.ts.outputs.ts
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN && needs.notify-start.outputs.slack-ts
         uses: ./.github/actions/slack-notify
         with:
           slack_bot_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
           slack_channel_id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
-          thread_ts: ${{ steps.ts.outputs.ts }}
+          thread_ts: ${{ needs.notify-start.outputs.slack-ts }}
           message: |
             🎉 *Production Deployed!*
 

--- a/.github/workflows/release-pr-deploy.yml
+++ b/.github/workflows/release-pr-deploy.yml
@@ -17,6 +17,8 @@ jobs:
   notify-start:
     if: startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/')
     runs-on: ubuntu-latest
+    outputs:
+      slack-ts: ${{ steps.ts.outputs.ts }}
     steps:
       - name: Load secrets
         id: secrets
@@ -99,7 +101,7 @@ jobs:
 
   notify:
     if: startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/')
-    needs: deploy
+    needs: [notify-start, deploy]
     runs-on: ubuntu-latest
     steps:
       - name: Load secrets
@@ -127,19 +129,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Read PR body
-        id: pr
-        uses: ./.github/actions/gh-pr-get-body
-        with:
-          pr_number: ${{ github.event.pull_request.number }}
-          token: ${{ github.token }}
-
-      - name: Extract Slack TS from PR body
-        id: ts
-        uses: ./.github/actions/extract-slack-ts
-        with:
-          body: ${{ steps.pr.outputs.body }}
-
       - name: Generate Release Summary
         id: summary
         uses: ./.github/actions/generate-release-summary
@@ -154,15 +143,15 @@ jobs:
           body: |
             ${{ steps.summary.outputs.summary }}
 
-            <!-- slack_ts: ${{ steps.ts.outputs.ts }} -->
+            <!-- slack_ts: ${{ needs.notify-start.outputs.slack-ts }} -->
 
       - name: Notify Slack
-        if: steps.ts.outputs.ts && steps.secrets.outputs.SLACK_BOT_TOKEN
+        if: needs.notify-start.outputs.slack-ts && steps.secrets.outputs.SLACK_BOT_TOKEN
         uses: ./.github/actions/slack-notify
         with:
           slack_bot_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
           slack_channel_id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
-          thread_ts: ${{ steps.ts.outputs.ts }}
+          thread_ts: ${{ needs.notify-start.outputs.slack-ts }}
           message: |
             ✅ *Staging Deployed*
 
@@ -172,3 +161,46 @@ jobs:
             Ready for testing! 🧪
             • Found bugs? Create a PR with fixes to <https://github.com/aragon/app/tree/${{ github.event.pull_request.head.ref }}|${{ github.event.pull_request.head.ref }}>
             • All good? Approve the PR and add label `release:ready` → <${{ github.event.pull_request.html_url }}|PR>
+
+  e2e:
+    if: startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/')
+    needs: deploy
+    uses: ./.github/workflows/shared-e2e.yml
+    secrets: inherit
+    with:
+      deployment-url: https://stg.app.aragon.org
+      environment: staging
+
+  e2e-notify:
+    needs: [notify-start, e2e]
+    if: ${{ always() && needs.e2e.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@v3.1.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: '${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+          SLACK_BOT_TOKEN: op://kv_app_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_app_infra/SLACK_CHANNEL_ID/credential
+
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/workflows/scripts/slackNotify.js
+            .github/actions/slack-notify
+
+      - name: Notify Slack — E2E results
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN
+        uses: ./.github/actions/slack-notify
+        with:
+          slack_bot_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack_channel_id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread_ts: ${{ needs.notify-start.outputs.slack-ts }}
+          message: |
+            ${{ needs.e2e.result == 'success' && '✅ Smoke tests on *staging* passed' || '❌ Smoke tests on *staging* failed' }}
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View report>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @aragon/app
 
+## 1.23.0
+
+### Minor Changes
+
+- [#998](https://github.com/aragon/app/pull/998) [`290856f`](https://github.com/aragon/app/commit/290856fe8ba2e24acb8bdfb50dd54746de1181f6) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Add Playwright E2E infrastructure and smoke tests with CI and Slack notifications.
+
+- [#1014](https://github.com/aragon/app/pull/1014) [`79a6821`](https://github.com/aragon/app/commit/79a6821fbec353d154bb643f94387a4af04be300) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Rename SubDAO to linked account across the frontend and add API compatibility layer.
+
+- [#1003](https://github.com/aragon/app/pull/1003) [`572872c`](https://github.com/aragon/app/commit/572872cbbc8e3f99e87684b1dc345d912a7c391e) Thanks [@thekidnamedkd](https://github.com/thekidnamedkd)! - Implement custom DAO header for Cryptex
+
+- [#1001](https://github.com/aragon/app/pull/1001) [`539232f`](https://github.com/aragon/app/commit/539232fb2e5a0d32d6d0cb0c5a7c4a7c9584b862) Thanks [@milosh86](https://github.com/milosh86)! - Add pause, resume, and end campaign basic actions for Capital Distributor
+
+- [#996](https://github.com/aragon/app/pull/996) [`cf8e4fb`](https://github.com/aragon/app/commit/cf8e4fb191a6f210003fd645808ef1b058af9131) Thanks [@milosh86](https://github.com/milosh86)! - Implement Katana rewards calculation in campaign creation
+
+- [#999](https://github.com/aragon/app/pull/999) [`e480c59`](https://github.com/aragon/app/commit/e480c59abbfd01fc475aae678301b9de684d8933) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Upgrade to Next.js 16 with React Compiler and Turbopack
+
+- [#1000](https://github.com/aragon/app/pull/1000) [`8d66325`](https://github.com/aragon/app/commit/8d66325dfa9da48a597d60ad0b8bb4f70dc39a70) Thanks [@thekidnamedkd](https://github.com/thekidnamedkd)! - Implement fallback behavior for partial decoded actions
+
+### Patch Changes
+
+- [#1006](https://github.com/aragon/app/pull/1006) [`bd4e2d1`](https://github.com/aragon/app/commit/bd4e2d14fddd17e20a3cf0a8e2d67f5264af6cb8) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Fix runtime crash on BigInt conversion of floating-point strings from APIs (e.g. `"10000000000000000000000000.0"`). Add `bigIntUtils.safeParse()` utility that handles decimal suffixes, scientific notation, and non-finite numbers across all token and lock-to-vote plugin components.
+
+- [#1011](https://github.com/aragon/app/pull/1011) [`8fbc8ca`](https://github.com/aragon/app/commit/8fbc8ca14f1aba82ec67336adda260128c730d6e) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Remove platform ping in slack during release
+
+- [#1010](https://github.com/aragon/app/pull/1010) [`61d7011`](https://github.com/aragon/app/commit/61d7011af4d9e65e1278fa39469f5684faf2e4f6) Thanks [@thekidnamedkd](https://github.com/thekidnamedkd)! - Fix misaligned add/remove members UI and update to latest spec
+
 ## 1.22.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/app",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Human-centered DAO infrastructure",
   "author": "Aragon Association",
   "homepage": "https://github.com/aragon/app#readme",


### PR DESCRIPTION
## Features
- Implement Katana rewards calculation in campaign creation ([#996](https://github.com/aragon/app/pull/996)) — [APP-485: Katana rewards calculation in campaign creation](https://linear.app/aragon/issue/APP-485/katana-rewards-calculation-in-campaign-creation)
- Update add/remove members inputs ([#1010](https://github.com/aragon/app/pull/1010)) — [APP-25: Update add multisig member dialog](https://linear.app/aragon/issue/APP-25/update-add-multisig-member-dialog)
- Add pause, resume, and end campaign actions for Capital Distributor ([#1001](https://github.com/aragon/app/pull/1001)) — [APP-500: Add pause, unpause, and end campaign actions](https://linear.app/aragon/issue/APP-500/add-pause-unpause-and-end-campaign-actions)
- Implement custom DAO header for Cryptex ([#1003](https://github.com/aragon/app/pull/1003)) — [APP-491: Cryptex custom DAO header](https://linear.app/aragon/issue/APP-491/cryptex-custom-dao-header)
- upgrade to Next.js 16 with React Compiler and Turbopack ([#999](https://github.com/aragon/app/pull/999)) — [APP-469: Upgrade NextJs to v16](https://linear.app/aragon/issue/APP-469/upgrade-nextjs-to-v16)
- Implement E2E testing infra and smoke tests ([#998](https://github.com/aragon/app/pull/998)) — [APP-512: Phase 1: Playwright E2E infra + smoke suite in `app` repo](https://linear.app/aragon/issue/APP-512/phase-1-playwright-e2e-infra-smoke-suite-in-app-repo)

## Fixes
- add safe BigInt parsing to prevent runtime crashes ([#1006](https://github.com/aragon/app/pull/1006)) — [APP-531: Cryptex governance settings page crashes (bigint issue)](https://linear.app/aragon/issue/APP-531/cryptex-governance-settings-page-crashes-bigint-issue)
- Handle failing or partially decoded proposal actions gracefully ([#1000](https://github.com/aragon/app/pull/1000)) — [APP-501: Proposal actions missing some fields in the decoded view](https://linear.app/aragon/issue/APP-501/proposal-actions-missing-some-fields-in-the-decoded-view)

## Other Changes
- Update GitHub Actions workflows to improve Slack notifications and deployment conditions
- Release v1.23.0
- rename SubDAO to Linked Account ([#1014](https://github.com/aragon/app/pull/1014)) — [APP-536: 1. [Frontend] Rename SubDAO to LinkedAccount with backward-compatible API adapter](https://linear.app/aragon/issue/APP-536/1-frontend-rename-subdao-to-linkedaccount-with-backward-compatible-api)
- Remove Slack platform ping during release notifications ([#1011](https://github.com/aragon/app/pull/1011))
- Bump crazy-max/ghaction-import-gpg from 6.3.0 to 7.0.0 ([#1008](https://github.com/aragon/app/pull/1008))
- Bump actions/upload-artifact from 6.0.0 to 7.0.0 ([#1007](https://github.com/aragon/app/pull/1007))
- update dependencies ([#1005](https://github.com/aragon/app/pull/1005))
- Disable react compiler ([#1004](https://github.com/aragon/app/pull/1004))
- Release v1.22.0 ([#997](https://github.com/aragon/app/pull/997))



<!-- slack_ts: 1772646063.940259 -->
