### PR TITLE
fix: Correct includeLinkedAccounts param mistakenly named includeSubPlugins

### DIFF
--- a/.changeset/great-memes-create.md
+++ b/.changeset/great-memes-create.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix includeLinkedAccounts param mistakenly named includeSubPlugins in getDaoPlugins calls

--- a/src/actions/capitalDistributor/components/capitalDistributorCreateCampaignActionCreate/capitalDistributorCampaignPayoutField.tsx
+++ b/src/actions/capitalDistributor/components/capitalDistributorCreateCampaignActionCreate/capitalDistributorCampaignPayoutField.tsx
@@ -37,7 +37,7 @@ export const CapitalDistributorCampaignPayoutField: React.FC<
     const gaugeVoterPlugins = useDaoPlugins({
         daoId,
         interfaceType: PluginInterfaceType.GAUGE_VOTER,
-        includeSubPlugins: false,
+        includeLinkedAccounts: false,
     });
 
     const { onChange, ...payoutTypeField } = useFormField<

--- a/src/actions/capitalDistributor/components/capitalDistributorCreateCampaignActionCreate/capitalDistributorCreateCampaignActionCreate.tsx
+++ b/src/actions/capitalDistributor/components/capitalDistributorCreateCampaignActionCreate/capitalDistributorCreateCampaignActionCreate.tsx
@@ -54,7 +54,7 @@ export const CapitalDistributorCreateCampaignActionCreate: React.FC<
     const gaugeVoterPlugins = useDaoPlugins({
         daoId,
         interfaceType: PluginInterfaceType.GAUGE_VOTER,
-        includeSubPlugins: false,
+        includeLinkedAccounts: false,
     });
     const gaugePlugin = gaugeVoterPlugins?.[0]?.meta as
         | IGaugeVoterPlugin

--- a/src/actions/capitalDistributor/hooks/useCapitalDistributorCampaignUpload/useCapitalDistributorCampaignUpload.ts
+++ b/src/actions/capitalDistributor/hooks/useCapitalDistributorCampaignUpload/useCapitalDistributorCampaignUpload.ts
@@ -31,7 +31,7 @@ export const useCapitalDistributorCampaignUpload = (
     const capitalDistributorPlugins = useDaoPlugins({
         daoId,
         interfaceType: PluginInterfaceType.CAPITAL_DISTRIBUTOR,
-        includeSubPlugins: false,
+        includeLinkedAccounts: false,
     });
     const capitalDistributorAddress =
         capitalDistributorPlugins?.[0]?.meta.address;

--- a/src/actions/gaugeRegistrar/components/gaugeRegistrarUnregisterGaugeActionDetails/gaugeRegistrarUnregisterGaugeActionDetails.tsx
+++ b/src/actions/gaugeRegistrar/components/gaugeRegistrarUnregisterGaugeActionDetails/gaugeRegistrarUnregisterGaugeActionDetails.tsx
@@ -60,7 +60,7 @@ export const GaugeRegistrarUnregisterGaugeActionDetails: React.FC<
         useDaoPlugins({
             daoId: action.daoId,
             interfaceType: PluginInterfaceType.GAUGE_VOTER,
-            includeSubPlugins: false,
+            includeLinkedAccounts: false,
         }) ?? [];
     const { t } = useTranslations();
 

--- a/src/actions/gaugeRegistrar/dialogs/gaugeRegistrarSelectGaugeDialog/gaugeRegistrarSelectGaugeDialog.tsx
+++ b/src/actions/gaugeRegistrar/dialogs/gaugeRegistrarSelectGaugeDialog/gaugeRegistrarSelectGaugeDialog.tsx
@@ -50,7 +50,7 @@ export const GaugeRegistrarSelectGaugeDialog: React.FC<
         useDaoPlugins({
             daoId: dao.id,
             interfaceType: PluginInterfaceType.GAUGE_VOTER,
-            includeSubPlugins: false,
+            includeLinkedAccounts: false,
         }) ?? [];
     const { data: gauges, isLoading } = useGaugeRegistrarGauges({
         pluginAddress,

--- a/src/daos/capitalDistributorTest/components/capitalDistributorTestMembersFileDownload.tsx
+++ b/src/daos/capitalDistributorTest/components/capitalDistributorTestMembersFileDownload.tsx
@@ -37,8 +37,9 @@ export const CapitalDistributorTestMembersFileDownload: React.FC<
     const gaugePlugins = useDaoPlugins({
         daoId: dao.id,
         interfaceType: PluginInterfaceType.GAUGE_VOTER,
-        includeSubPlugins: false,
+        includeLinkedAccounts: false,
     });
+
     const gaugePlugin = gaugePlugins?.[0]?.meta as IGaugeVoterPlugin;
 
     const handleClick = () => {

--- a/src/modules/application/components/navigations/navigationDao/navigationDaoUtils.ts
+++ b/src/modules/application/components/navigations/navigationDao/navigationDaoUtils.ts
@@ -89,7 +89,7 @@ class NavigationDaoUtils {
         context: NavigationDaoContext,
     ) => {
         const plugins =
-            daoUtils.getDaoPlugins(dao, { includeSubPlugins: false }) ?? [];
+            daoUtils.getDaoPlugins(dao, { includeLinkedAccounts: false }) ?? [];
         const pluginLinks = plugins.reduce<{
             left: INavigationLink[];
             right: INavigationLink[];

--- a/src/plugins/adminPlugin/components/adminSettingsPanel/components/adminManageMembers/adminManageMembers.tsx
+++ b/src/plugins/adminPlugin/components/adminSettingsPanel/components/adminManageMembers/adminManageMembers.tsx
@@ -26,7 +26,7 @@ export const AdminManageMembers: React.FC<IAdminMangeMembersProps> = (
     const [adminPlugin] = useDaoPlugins({
         daoId,
         interfaceType: PluginInterfaceType.ADMIN,
-        includeSubPlugins: false,
+        includeLinkedAccounts: false,
     })!;
 
     const openManageMembersDialog = () => {

--- a/src/plugins/adminPlugin/components/adminSettingsPanel/components/adminUninstallPlugin/adminUninstallPlugin.tsx
+++ b/src/plugins/adminPlugin/components/adminSettingsPanel/components/adminUninstallPlugin/adminUninstallPlugin.tsx
@@ -27,12 +27,12 @@ export const AdminUninstallPlugin: React.FC<IAdminUninstallPluginProps> = (
         daoId,
         type: PluginType.PROCESS,
         hasExecute: true,
-        includeSubPlugins: false,
+        includeLinkedAccounts: false,
     })!;
     const adminPlugin = useDaoPlugins({
         daoId,
         interfaceType: PluginInterfaceType.ADMIN,
-        includeSubPlugins: false,
+        includeLinkedAccounts: false,
     })![0]?.meta;
 
     const handleOpenDialog = () => {

--- a/src/plugins/adminPlugin/dialogs/adminManageMembersDialog/adminManageMembersDialog.tsx
+++ b/src/plugins/adminPlugin/dialogs/adminManageMembersDialog/adminManageMembersDialog.tsx
@@ -70,7 +70,7 @@ export const AdminManageMembersDialog: React.FC<
         useDaoPlugins({
             daoId,
             interfaceType: PluginInterfaceType.ADMIN,
-            includeSubPlugins: false,
+            includeLinkedAccounts: false,
         }) ?? [];
 
     const currentAdmins = useMemo(

--- a/src/plugins/capitalDistributorPlugin/pages/capitalDistributorRewardsPage/capitalDistributorRewardsPage.tsx
+++ b/src/plugins/capitalDistributorPlugin/pages/capitalDistributorRewardsPage/capitalDistributorRewardsPage.tsx
@@ -49,7 +49,7 @@ export const CapitalDistributorRewardsPage: React.FC<
 
     const plugin: ICapitalDistributorPlugin = daoUtils.getDaoPlugins(dao, {
         interfaceType: PluginInterfaceType.CAPITAL_DISTRIBUTOR,
-        includeSubPlugins: false,
+        includeLinkedAccounts: false,
     })![0];
 
     const defaultQueryParams = {

--- a/src/plugins/gaugeVoterPlugin/pages/gaugeVoterGaugesPage/gaugeVoterGaugesPage.tsx
+++ b/src/plugins/gaugeVoterPlugin/pages/gaugeVoterGaugesPage/gaugeVoterGaugesPage.tsx
@@ -21,7 +21,7 @@ export const GaugeVoterGaugesPage: React.FC<
 
     const plugins = daoUtils.getDaoPlugins(dao, {
         interfaceType: PluginInterfaceType.GAUGE_VOTER,
-        includeSubPlugins: false,
+        includeLinkedAccounts: false,
     });
     const plugin = plugins?.[0];
 

--- a/src/plugins/gaugeVoterPlugin/pages/gaugeVoterGaugesPage/gaugeVoterGaugesPageClient.tsx
+++ b/src/plugins/gaugeVoterPlugin/pages/gaugeVoterGaugesPage/gaugeVoterGaugesPageClient.tsx
@@ -62,7 +62,7 @@ export const GaugeVoterGaugesPageClient: React.FC<
     const plugins = useDaoPlugins({
         daoId: dao.id,
         interfaceType: PluginInterfaceType.GAUGE_VOTER,
-        includeSubPlugins: false,
+        includeLinkedAccounts: false,
     }) as IFilterComponentPlugin<IGaugeVoterPlugin>[];
     const plugin = plugins[0];
 


### PR DESCRIPTION
## Description

Fixes a mistake introduced in feat(APP-485) (#996) where calls to `getDaoPlugins` / `useDaoPlugins` used `includeSubPlugins: false` instead of `includeLinkedAccounts: false` when the intent was to exclude plugins from linked accounts.

`includeSubPlugins` and `includeLinkedAccounts` are two separate options on `IDaoPluginsOptions` — this fix ensures the correct one is used in all 13 affected call sites from that commit.

## Type of Change

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project