### PR TITLE
Release v1.23.1

### DIFF
--- a/.changeset/client-links-change.md
+++ b/.changeset/client-links-change.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Update DAO header link for XMAQUINA

--- a/.changeset/great-memes-create.md
+++ b/.changeset/great-memes-create.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Fix includeLinkedAccounts param mistakenly named includeSubPlugins in getDaoPlugins calls

--- a/.changeset/wacky-points-say.md
+++ b/.changeset/wacky-points-say.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Update dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aragon/app
 
+## 1.23.1
+
+### Patch Changes
+
+- [#1017](https://github.com/aragon/app/pull/1017) [`31d8531`](https://github.com/aragon/app/commit/31d85310325cbdf15834b8597b74d11ee5ceeee1) Thanks [@evanaronson](https://github.com/evanaronson)! - Update DAO header link for XMAQUINA
+
+- [#1020](https://github.com/aragon/app/pull/1020) [`c5467c1`](https://github.com/aragon/app/commit/c5467c108e7669128f2816bf4f7c7acdffc6eb2c) Thanks [@milosh86](https://github.com/milosh86)! - Fix includeLinkedAccounts param mistakenly named includeSubPlugins in getDaoPlugins calls
+
+- [#1023](https://github.com/aragon/app/pull/1023) [`0c6b1c3`](https://github.com/aragon/app/commit/0c6b1c3ebda229bd8f423b58463cfd695ad74778) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Update dependencies
+
 ## 1.23.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/app",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Human-centered DAO infrastructure",
   "author": "Aragon Association",
   "homepage": "https://github.com/aragon/app#readme",


### PR DESCRIPTION
## Fixes
- Correct includeLinkedAccounts param mistakenly named includeSubPlugins ([#1020](https://github.com/aragon/app/pull/1020))
- Update XMAQUINA DAO header link ([#1017](https://github.com/aragon/app/pull/1017))

## Other Changes
- Release v1.23.1
- сhore: deps update gov UI kit; fix release notifications ([#1025](https://github.com/aragon/app/pull/1025))
- Update dependencies and .gitignore ([#1023](https://github.com/aragon/app/pull/1023))
- Bump 1password/load-secrets-action ([#1018](https://github.com/aragon/app/pull/1018))
- Release v1.23.0 ([#1016](https://github.com/aragon/app/pull/1016))



<!-- slack_ts: 1773317185.924389 -->
