### PR TITLE
chore(APP-542): Add Katana vKAT Management DAO slot configuration

### DIFF
--- a/.changeset/app-542-katana-vkat-management-dao.md
+++ b/.changeset/app-542-katana-vkat-management-dao.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Add Katana vKAT Management DAO slot configuration with the real Katana deployment address

--- a/src/daos/index.ts
+++ b/src/daos/index.ts
@@ -5,6 +5,7 @@ import { initialiseCapitalDistributorTest } from './capitalDistributorTest';
 import { initialiseCryptex } from './cryptex';
 import { initialiseKatanaCDDemo } from './katanaCDDemo';
 import { initialiseKatanaEmissionsTest } from './katanaEmissionsTest';
+import { initialiseKatanaVKatManagement } from './katanaVKatManagement';
 import { initialiseXmaquina } from './xmaquina';
 
 export const initialiseDaos = () => {
@@ -16,4 +17,5 @@ export const initialiseDaos = () => {
     initialiseCapitalDistributorTest();
     initialiseKatanaCDDemo();
     initialiseKatanaEmissionsTest();
+    initialiseKatanaVKatManagement();
 };

--- a/src/daos/katanaVKatManagement/constants/katanaVKatManagement.ts
+++ b/src/daos/katanaVKatManagement/constants/katanaVKatManagement.ts
@@ -1,0 +1,4 @@
+export const katanaVKatManagement = {
+    id: 'katana-mainnet-0xb72291652f15cF73651357383c0A86FBba29B675',
+    name: 'katanaVKatManagement',
+};

--- a/src/daos/katanaVKatManagement/index.ts
+++ b/src/daos/katanaVKatManagement/index.ts
@@ -1,0 +1,15 @@
+import { CapitalFlowDaoSlotId } from '@/modules/capitalFlow/constants/moduleDaoSlots';
+import { pluginRegistryUtils } from '@/shared/utils/pluginRegistryUtils';
+import { CapitalDistributorTestMembersFileDownload } from '../capitalDistributorTest/components/capitalDistributorTestMembersFileDownload';
+import { katanaVKatManagement } from './constants/katanaVKatManagement';
+
+export const initialiseKatanaVKatManagement = () => {
+    pluginRegistryUtils
+        .registerPlugin(katanaVKatManagement)
+
+        .registerSlotComponent({
+            slotId: CapitalFlowDaoSlotId.CAPITAL_DISTRIBUTOR_MEMBERS_FILE_DOWNLOAD,
+            pluginId: katanaVKatManagement.id,
+            component: CapitalDistributorTestMembersFileDownload,
+        });
+};


### PR DESCRIPTION
# Description

Adds the Katana vKAT Management DAO slot configuration using the real Katana mainnet deployment address (`0xb72291652f15cF73651357383c0A86FBba29B675`). Registers the `CAPITAL_DISTRIBUTOR_MEMBERS_FILE_DOWNLOAD` slot component for this DAO.

## Type of Change

- [x] Patch: Enhancement (non-breaking change to an existing feature)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project