### PR TITLE
enhancement: Rearrange explore page elements to highlight servces

### DIFF
--- a/.changeset/helpful-businesses-greet.md
+++ b/.changeset/helpful-businesses-greet.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Rearrange content on the DAO explore page

--- a/src/modules/explore/components/ctaCard/ctaCard.tsx
+++ b/src/modules/explore/components/ctaCard/ctaCard.tsx
@@ -25,6 +25,10 @@ export interface ICtaCardProps {
      */
     actionLabel: string;
     /**
+     * Flag to determine if the action points to an external destination.
+     */
+    isExternal?: boolean;
+    /**
      * Path to navigate to when the action button is clicked.
      */
     actionHref?: string;
@@ -47,6 +51,7 @@ export const CtaCard: React.FC<ICtaCardProps> = (props) => {
         title,
         subtitle,
         isPrimary,
+        isExternal = false,
         actionHref,
         actionLabel,
         actionOnClick,
@@ -82,10 +87,10 @@ export const CtaCard: React.FC<ICtaCardProps> = (props) => {
             <Button
                 className="self-stretch md:self-start"
                 href={actionHref}
-                iconRight={isPrimary ? undefined : IconType.LINK_EXTERNAL}
+                iconRight={isExternal ? IconType.LINK_EXTERNAL : undefined}
                 onClick={actionOnClick}
                 size="md"
-                target={isPrimary ? '_self' : '_blank'}
+                target={isExternal ? '_blank' : '_self'}
                 variant={isPrimary ? 'primary' : 'secondary'}
             >
                 {actionLabel}

--- a/src/modules/explore/components/exploreDaos/exploreDaos.tsx
+++ b/src/modules/explore/components/exploreDaos/exploreDaos.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { Button, Toggle, ToggleGroup } from '@aragon/gov-ui-kit';
+import { Toggle, ToggleGroup } from '@aragon/gov-ui-kit';
 import { useEffect } from 'react';
 import { useConnection } from 'wagmi';
-import { CreateDaoDialogId } from '@/modules/createDao/constants/createDaoDialogId';
-import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useFilterUrlParam } from '@/shared/hooks/useFilterUrlParam';
 import { networkUtils } from '@/shared/utils/networkUtils';
@@ -25,7 +23,6 @@ export const ExploreDaos: React.FC<IExploreDaosProps> = (props) => {
 
     const { t } = useTranslations();
     const { address } = useConnection();
-    const { open } = useDialogContext();
 
     const [daoFilter, setDaoFilter] = useFilterUrlParam({
         name: exploreDaoFilterParam,
@@ -77,14 +74,6 @@ export const ExploreDaos: React.FC<IExploreDaosProps> = (props) => {
                         value="member"
                     />
                 </ToggleGroup>
-                <Button
-                    className="shrink-0"
-                    onClick={() => open(CreateDaoDialogId.CREATE_DAO_DETAILS)}
-                    size="md"
-                    variant="primary"
-                >
-                    {t('app.explore.exploreDao.createDao')}
-                </Button>
             </div>
             <DaoList
                 initialParams={initialParams}

--- a/src/modules/explore/pages/exploreDaosPage/exploreDaosPageClient.tsx
+++ b/src/modules/explore/pages/exploreDaosPage/exploreDaosPageClient.tsx
@@ -94,16 +94,23 @@ export const ExploreDaosPageClient: React.FC<IExploreDaosPageClientProps> = (
             <Container className="py-10 pb-16 md:px-6 md:py-20">
                 <main className="flex flex-col gap-10 md:gap-20">
                     <ExploreSection
-                        title={t('app.explore.exploreDaosPage.section.daos')}
-                    >
-                        <Suspense fallback={null}>
-                            <ExploreDaos initialParams={initialParams} />
-                        </Suspense>
-                    </ExploreSection>
-                    <ExploreSection
                         title={t('app.explore.exploreDaosPage.section.cta')}
                     >
                         <div className="flex flex-col items-start gap-4 self-stretch md:flex-row md:gap-4 lg:gap-8">
+                            <CtaCard
+                                actionHref="https://www.aragon.org/get-assistance-form"
+                                actionLabel={t(
+                                    'app.explore.exploreDaosPage.enterpriseService.actionLabel',
+                                )}
+                                imgSrc={enterpriseServiceIcon as string}
+                                isPrimary={true}
+                                subtitle={t(
+                                    'app.explore.exploreDaosPage.enterpriseService.subtitle',
+                                )}
+                                title={t(
+                                    'app.explore.exploreDaosPage.enterpriseService.title',
+                                )}
+                            />
                             <CtaCard
                                 actionLabel={t(
                                     'app.explore.exploreDaosPage.noCodeSetup.actionLabel',
@@ -112,26 +119,12 @@ export const ExploreDaosPageClient: React.FC<IExploreDaosPageClientProps> = (
                                     open(CreateDaoDialogId.CREATE_DAO_DETAILS)
                                 }
                                 imgSrc={noCodeSetupIcon as string}
-                                isPrimary={true}
+                                isPrimary={false}
                                 subtitle={t(
                                     'app.explore.exploreDaosPage.noCodeSetup.subtitle',
                                 )}
                                 title={t(
                                     'app.explore.exploreDaosPage.noCodeSetup.title',
-                                )}
-                            />
-                            <CtaCard
-                                actionHref="https://www.aragon.org/get-assistance-form"
-                                actionLabel={t(
-                                    'app.explore.exploreDaosPage.enterpriseService.actionLabel',
-                                )}
-                                imgSrc={enterpriseServiceIcon as string}
-                                isPrimary={false}
-                                subtitle={t(
-                                    'app.explore.exploreDaosPage.enterpriseService.subtitle',
-                                )}
-                                title={t(
-                                    'app.explore.exploreDaosPage.enterpriseService.title',
                                 )}
                             />
                             <CtaCard
@@ -149,6 +142,13 @@ export const ExploreDaosPageClient: React.FC<IExploreDaosPageClientProps> = (
                                 )}
                             />
                         </div>
+                    </ExploreSection>
+                    <ExploreSection
+                        title={t('app.explore.exploreDaosPage.section.daos')}
+                    >
+                        <Suspense fallback={null}>
+                            <ExploreDaos initialParams={initialParams} />
+                        </Suspense>
                     </ExploreSection>
                 </main>
             </Container>

--- a/src/modules/explore/pages/exploreDaosPage/exploreDaosPageClient.tsx
+++ b/src/modules/explore/pages/exploreDaosPage/exploreDaosPageClient.tsx
@@ -103,6 +103,7 @@ export const ExploreDaosPageClient: React.FC<IExploreDaosPageClientProps> = (
                                     'app.explore.exploreDaosPage.enterpriseService.actionLabel',
                                 )}
                                 imgSrc={enterpriseServiceIcon as string}
+                                isExternal={true}
                                 isPrimary={true}
                                 subtitle={t(
                                     'app.explore.exploreDaosPage.enterpriseService.subtitle',
@@ -119,6 +120,7 @@ export const ExploreDaosPageClient: React.FC<IExploreDaosPageClientProps> = (
                                     open(CreateDaoDialogId.CREATE_DAO_DETAILS)
                                 }
                                 imgSrc={noCodeSetupIcon as string}
+                                isExternal={false}
                                 isPrimary={false}
                                 subtitle={t(
                                     'app.explore.exploreDaosPage.noCodeSetup.subtitle',
@@ -133,6 +135,7 @@ export const ExploreDaosPageClient: React.FC<IExploreDaosPageClientProps> = (
                                     'app.explore.exploreDaosPage.doItYourself.actionLabel',
                                 )}
                                 imgSrc={doItYourselfIcon as string}
+                                isExternal={true}
                                 isPrimary={false}
                                 subtitle={t(
                                     'app.explore.exploreDaosPage.doItYourself.subtitle',


### PR DESCRIPTION
# Description

- Removed Create DAO CTA from DAO data list on Explore page
- Moved Getting Started CTAs above DAO list
- Reordered CTAs in Getting started
- Made Enterprise service primary
- Updated CTA card component to allow you to manually specify if it's an external link. Before it was falsely coupled with whether or not it was a primary button.
 
## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [X] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
