### PR TITLE
fix: Include sub-plugins when fetching plugins for onboarding

### DIFF
--- a/.changeset/fix-onboarding-trigger.md
+++ b/.changeset/fix-onboarding-trigger.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Include sub-plugins when fetching plugins for onboarding watchers

--- a/src/plugins/lockToVotePlugin/components/lockToVoteLockOnboardingWatcher/lockToVoteLockOnboardingWatcher.tsx
+++ b/src/plugins/lockToVotePlugin/components/lockToVoteLockOnboardingWatcher/lockToVoteLockOnboardingWatcher.tsx
@@ -25,6 +25,7 @@ export const LockToVoteLockOnboardingWatcher: React.FC<
 
     const daoPlugins = daoUtils.getDaoPlugins(dao, {
         interfaceType: PluginInterfaceType.LOCK_TO_VOTE,
+        includeSubPlugins: true,
         includeLinkedAccounts: false,
     });
 

--- a/src/plugins/tokenPlugin/components/tokenDelegationOnboardingWatcher/tokenDelegationOnboardingWatcher.tsx
+++ b/src/plugins/tokenPlugin/components/tokenDelegationOnboardingWatcher/tokenDelegationOnboardingWatcher.tsx
@@ -26,6 +26,7 @@ export const TokenDelegationOnboardingWatcher: React.FC<
 
     const daoPlugins =
         daoUtils.getDaoPlugins(dao, {
+            includeSubPlugins: true,
             includeLinkedAccounts: false,
         }) ?? [];
 

--- a/src/plugins/tokenPlugin/components/tokenLockAndWrapOnboardingWatcher/tokenLockAndWrapOnboardingWatcher.tsx
+++ b/src/plugins/tokenPlugin/components/tokenLockAndWrapOnboardingWatcher/tokenLockAndWrapOnboardingWatcher.tsx
@@ -29,6 +29,7 @@ export const TokenLockAndWrapOnboardingWatcher: React.FC<
 
     const daoPlugins =
         daoUtils.getDaoPlugins(dao, {
+            includeSubPlugins: true,
             includeLinkedAccounts: false,
         }) ?? [];
 


### PR DESCRIPTION
# Description

Include sub-plugins when fetching DAO plugins in onboarding watcher components. Previously, sub-plugins were not included in the plugin lookup, which caused onboarding triggers to not fire correctly for DAOs using sub-plugins.

Affected components:
- `LockToVoteLockOnboardingWatcher`
- `TokenDelegationOnboardingWatcher`
- `TokenLockAndWrapOnboardingWatcher`

## Type of Change

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project