### PR TITLE
App 564 fix sentry samlerates and release notifications

### DIFF
--- a/.changeset/true-hands-go.md
+++ b/.changeset/true-hands-go.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Reduce Sentry sample and replay rates. Fix production release notifications.

--- a/.github/workflows/app-production.yml
+++ b/.github/workflows/app-production.yml
@@ -97,6 +97,7 @@ jobs:
 
   e2e:
     needs: deploy
+    if: ${{ !cancelled() && needs.deploy.result == 'success' }}
     uses: ./.github/workflows/shared-e2e.yml
     secrets: inherit
     with:
@@ -139,6 +140,7 @@ jobs:
 
   notify:
     needs: [notify-start, deploy]
+    if: ${{ !cancelled() && needs.deploy.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Load secrets

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -14,8 +14,8 @@ Sentry.init({
         }),
     ],
 
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 0.5,
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 0.05,
 });
 
 // eslint-disable-next-line import/namespace

--- a/src/shared/utils/monitoringUtils/monitoringUtils.ts
+++ b/src/shared/utils/monitoringUtils/monitoringUtils.ts
@@ -32,7 +32,7 @@ class MonitoringUtils {
     > => ({
         enabled: this.isEnabled(),
         dsn: process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN,
-        tracesSampleRate: 1.0,
+        tracesSampleRate: 0.1,
         environment: process.env.NEXT_PUBLIC_ENV,
         release: process.env.version,
     });


### PR DESCRIPTION
1. `tracesSampleRate` 100% -> 10% - we don't need so many traces for regular sessions (20+ million traces)
2. `replaysSessionSampleRate` -> 0% - we don't need replays for sessions without errors
3. `replaysOnErrorSampleRate` 50% -> 5% - we need only handful replays for errors (just 1 or 2)

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
