### PR TITLE
fix(APP-565): Fix info text alignment in lock, wrap and delegate forms

### DIFF
--- a/.changeset/app-565-fix-info-text-alignment.md
+++ b/.changeset/app-565-fix-info-text-alignment.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix info text alignment in lock, wrap and delegate forms

--- a/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockForm/gaugeVoterLockForm.tsx
+++ b/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockForm/gaugeVoterLockForm.tsx
@@ -1,5 +1,4 @@
 import { Button, IconType, invariant } from '@aragon/gov-ui-kit';
-import classNames from 'classnames';
 import { useEffect, useMemo } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { formatUnits, parseUnits } from 'viem';
@@ -16,6 +15,7 @@ import { useOpenDelegationOnboardingIfNeeded } from '@/plugins/tokenPlugin/hooks
 import { useTokenCheckTokenAllowance } from '@/plugins/tokenPlugin/hooks/useTokenCheckTokenAllowance';
 import { useDao } from '@/shared/api/daoService';
 import { useDialogContext } from '@/shared/components/dialogProvider';
+import { FooterInfo } from '@/shared/components/footerInfo';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useIsMounted } from '@/shared/hooks/useIsMounted';
 import { GaugeVoterPluginDialogId } from '../../constants/gaugeVoterPluginDialogId';
@@ -235,17 +235,10 @@ export const GaugeVoterLockForm: React.FC<IGaugeVoterLockFormProps> = (
     );
 
     const footerInfo = (
-        <p
-            className={classNames(
-                'font-normal text-neutral-500 text-sm leading-normal',
-                {
-                    'text-center': mode === 'panel',
-                    'text-left': mode === 'dialog',
-                },
-            )}
-        >
-            {t('app.plugins.gaugeVoter.gaugeVoterLockForm.footerInfo')}
-        </p>
+        <FooterInfo
+            mode={mode}
+            text={t('app.plugins.gaugeVoter.gaugeVoterLockForm.footerInfo')}
+        />
     );
 
     return (

--- a/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockForm/gaugeVoterLockForm.tsx
+++ b/src/plugins/gaugeVoterPlugin/components/gaugeVoterLockForm/gaugeVoterLockForm.tsx
@@ -1,4 +1,5 @@
 import { Button, IconType, invariant } from '@aragon/gov-ui-kit';
+import classNames from 'classnames';
 import { useEffect, useMemo } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { formatUnits, parseUnits } from 'viem';
@@ -234,7 +235,15 @@ export const GaugeVoterLockForm: React.FC<IGaugeVoterLockFormProps> = (
     );
 
     const footerInfo = (
-        <p className="font-normal text-neutral-500 text-sm leading-normal">
+        <p
+            className={classNames(
+                'font-normal text-neutral-500 text-sm leading-normal',
+                {
+                    'text-center': mode === 'panel',
+                    'text-left': mode === 'dialog',
+                },
+            )}
+        >
             {t('app.plugins.gaugeVoter.gaugeVoterLockForm.footerInfo')}
         </p>
     );

--- a/src/plugins/lockToVotePlugin/components/lockToVoteMemberPanel/lockToVoteLockForm/lockToVoteLockForm.tsx
+++ b/src/plugins/lockToVotePlugin/components/lockToVoteMemberPanel/lockToVoteLockForm/lockToVoteLockForm.tsx
@@ -4,6 +4,7 @@ import {
     IconType,
     NumberFormat,
 } from '@aragon/gov-ui-kit';
+import classNames from 'classnames';
 import { useCallback } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { formatUnits, parseUnits } from 'viem';
@@ -102,7 +103,15 @@ export const LockToVoteLockForm: React.FC<ILockToVoteLockFormProps> = (
     );
 
     const footerInfo = (
-        <p className="text-center font-normal text-neutral-500 text-sm leading-normal">
+        <p
+            className={classNames(
+                'font-normal text-neutral-500 text-sm leading-normal',
+                {
+                    'text-center': mode === 'panel',
+                    'text-left': mode === 'dialog',
+                },
+            )}
+        >
             {t('app.plugins.lockToVote.lockToVoteLockForm.footerInfo')}
         </p>
     );

--- a/src/plugins/lockToVotePlugin/components/lockToVoteMemberPanel/lockToVoteLockForm/lockToVoteLockForm.tsx
+++ b/src/plugins/lockToVotePlugin/components/lockToVoteMemberPanel/lockToVoteLockForm/lockToVoteLockForm.tsx
@@ -4,7 +4,6 @@ import {
     IconType,
     NumberFormat,
 } from '@aragon/gov-ui-kit';
-import classNames from 'classnames';
 import { useCallback } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { formatUnits, parseUnits } from 'viem';
@@ -13,6 +12,7 @@ import {
     AssetInput,
     type IAssetInputFormData,
 } from '@/modules/finance/components/assetInput';
+import { FooterInfo } from '@/shared/components/footerInfo';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useLockToVoteData } from '../../../hooks/useLockToVoteData';
 import type { ILockToVoteMemberPanelProps } from '../lockToVoteMemberPanel';
@@ -103,17 +103,10 @@ export const LockToVoteLockForm: React.FC<ILockToVoteLockFormProps> = (
     );
 
     const footerInfo = (
-        <p
-            className={classNames(
-                'font-normal text-neutral-500 text-sm leading-normal',
-                {
-                    'text-center': mode === 'panel',
-                    'text-left': mode === 'dialog',
-                },
-            )}
-        >
-            {t('app.plugins.lockToVote.lockToVoteLockForm.footerInfo')}
-        </p>
+        <FooterInfo
+            mode={mode}
+            text={t('app.plugins.lockToVote.lockToVoteLockForm.footerInfo')}
+        />
     );
 
     return (

--- a/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenDelegation/tokenDelegationForm.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenDelegation/tokenDelegationForm.tsx
@@ -140,6 +140,20 @@ export const TokenDelegationForm: React.FC<ITokenDelegationFormProps> = (
     // multiple button state changes during page refresh
     const isSubmitDisabled = isCurrentDelegateLoading || isDelegateUnchanged;
 
+    const footerInfo = (
+        <p
+            className={classNames(
+                'font-normal text-neutral-500 text-sm leading-normal',
+                {
+                    'text-center': mode === 'panel',
+                    'text-left': mode === 'dialog',
+                },
+            )}
+        >
+            {t('app.plugins.token.tokenDelegationForm.info')}
+        </p>
+    );
+
     return (
         <form
             className="flex flex-col gap-4"
@@ -179,9 +193,7 @@ export const TokenDelegationForm: React.FC<ITokenDelegationFormProps> = (
             />
             {mode === 'dialog' ? (
                 <div className="flex flex-col gap-9">
-                    <p className="font-normal text-neutral-500 text-sm leading-normal">
-                        {t('app.plugins.token.tokenDelegationForm.info')}
-                    </p>
+                    {footerInfo}
                     <div
                         className={classNames(
                             'flex gap-3',
@@ -225,9 +237,7 @@ export const TokenDelegationForm: React.FC<ITokenDelegationFormProps> = (
                     >
                         {t('app.plugins.token.tokenDelegationForm.submit')}
                     </Button>
-                    <p className="text-center font-normal text-neutral-500 text-sm leading-normal">
-                        {t('app.plugins.token.tokenDelegationForm.info')}
-                    </p>
+                    {footerInfo}
                 </div>
             )}
         </form>

--- a/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenDelegation/tokenDelegationForm.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenDelegation/tokenDelegationForm.tsx
@@ -18,6 +18,7 @@ import type { ITokenDelegationDialogParams } from '@/plugins/tokenPlugin/dialogs
 import { useTokenCurrentDelegate } from '@/plugins/tokenPlugin/hooks/useTokenCurrentDelegate';
 import { useDao } from '@/shared/api/daoService';
 import { useDialogContext } from '@/shared/components/dialogProvider';
+import { FooterInfo } from '@/shared/components/footerInfo';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useFormField } from '@/shared/hooks/useFormField';
@@ -141,17 +142,10 @@ export const TokenDelegationForm: React.FC<ITokenDelegationFormProps> = (
     const isSubmitDisabled = isCurrentDelegateLoading || isDelegateUnchanged;
 
     const footerInfo = (
-        <p
-            className={classNames(
-                'font-normal text-neutral-500 text-sm leading-normal',
-                {
-                    'text-center': mode === 'panel',
-                    'text-left': mode === 'dialog',
-                },
-            )}
-        >
-            {t('app.plugins.token.tokenDelegationForm.info')}
-        </p>
+        <FooterInfo
+            mode={mode}
+            text={t('app.plugins.token.tokenDelegationForm.info')}
+        />
     );
 
     return (

--- a/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenWrap/tokenWrapForm.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenWrap/tokenWrapForm.tsx
@@ -4,7 +4,6 @@ import {
     IconType,
     NumberFormat,
 } from '@aragon/gov-ui-kit';
-import classNames from 'classnames';
 import { useEffect, useMemo } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { formatUnits, parseUnits } from 'viem';
@@ -24,6 +23,7 @@ import { useWrappedTokenBalance } from '@/plugins/tokenPlugin/hooks/useWrappedTo
 import type { ITokenPluginSettingsToken } from '@/plugins/tokenPlugin/types';
 import { useDao } from '@/shared/api/daoService';
 import { useDialogContext } from '@/shared/components/dialogProvider';
+import { FooterInfo } from '@/shared/components/footerInfo';
 import { useTranslations } from '@/shared/components/translationsProvider';
 
 export interface ITokenWrapFormProps {
@@ -208,17 +208,10 @@ export const TokenWrapForm: React.FC<ITokenWrapFormProps> = (props) => {
     );
 
     const footerInfo = (
-        <p
-            className={classNames(
-                'font-normal text-neutral-500 text-sm leading-normal',
-                {
-                    'text-center': mode === 'panel',
-                    'text-left': mode === 'dialog',
-                },
-            )}
-        >
-            {t('app.plugins.token.tokenWrapForm.footerInfo')}
-        </p>
+        <FooterInfo
+            mode={mode}
+            text={t('app.plugins.token.tokenWrapForm.footerInfo')}
+        />
     );
 
     return (

--- a/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenWrap/tokenWrapForm.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberPanel/tokenWrap/tokenWrapForm.tsx
@@ -4,6 +4,7 @@ import {
     IconType,
     NumberFormat,
 } from '@aragon/gov-ui-kit';
+import classNames from 'classnames';
 import { useEffect, useMemo } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { formatUnits, parseUnits } from 'viem';
@@ -207,7 +208,15 @@ export const TokenWrapForm: React.FC<ITokenWrapFormProps> = (props) => {
     );
 
     const footerInfo = (
-        <p className="font-normal text-neutral-500 text-sm leading-normal">
+        <p
+            className={classNames(
+                'font-normal text-neutral-500 text-sm leading-normal',
+                {
+                    'text-center': mode === 'panel',
+                    'text-left': mode === 'dialog',
+                },
+            )}
+        >
             {t('app.plugins.token.tokenWrapForm.footerInfo')}
         </p>
     );

--- a/src/shared/components/footerInfo/footerInfo.tsx
+++ b/src/shared/components/footerInfo/footerInfo.tsx
@@ -1,0 +1,34 @@
+import classNames from 'classnames';
+
+/**
+ * Props for the FooterInfo component.
+ */
+export interface IFooterInfoProps {
+    /**
+     * The informational text to display.
+     */
+    text: string;
+    /**
+     * Rendering mode: 'panel' (default) or 'dialog'.
+     * Controls text alignment — centered in panel, left-aligned in dialog.
+     */
+    mode?: 'panel' | 'dialog';
+}
+
+export const FooterInfo: React.FC<IFooterInfoProps> = (props) => {
+    const { text, mode = 'panel' } = props;
+
+    return (
+        <p
+            className={classNames(
+                'font-normal text-neutral-500 text-sm leading-normal',
+                {
+                    'text-center': mode === 'panel',
+                    'text-left': mode === 'dialog',
+                },
+            )}
+        >
+            {text}
+        </p>
+    );
+};

--- a/src/shared/components/footerInfo/index.ts
+++ b/src/shared/components/footerInfo/index.ts
@@ -1,0 +1,1 @@
+export { FooterInfo, type IFooterInfoProps } from './footerInfo';


### PR DESCRIPTION
# Description

Fix info text alignment in lock, wrap, and delegate forms. The footer info text now uses `text-center` when rendered in panel mode and `text-left` when rendered in dialog mode.

Affected components:
- `GaugeVoterLockForm`
- `LockToVoteLockForm`
- `TokenDelegationForm`
- `TokenWrapForm`

## Type of Change

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project