### PR TITLE
fix: Include sub-plugins when fetching plugins on the member details page

### DIFF
--- a/.changeset/member-details-include-sub-plugins.md
+++ b/.changeset/member-details-include-sub-plugins.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Include sub-plugins when fetching plugins on the member details page

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ next-env.d.ts
 .zed
 .tempor
 .agents
+
+.patches

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
@@ -65,6 +65,7 @@ export const DaoMemberDetailsPageClient: React.FC<
         daoId,
         pluginAddress,
         includeLinkedAccounts: true,
+        includeSubPlugins: true,
     });
     const bodyPlugin = bodyPlugins?.[0]?.meta;
 


### PR DESCRIPTION
# Description

Adds `includeSubPlugins: true` to the `useDaoPlugins` call in `daoMemberDetailsPageClient`. Without this flag, SPP sub-plugins (used for vote submission, member details, and version info) were not included, causing the member details page to not resolve the correct body plugin when the DAO uses a Staged Proposal Pipeline.

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project