### PR TITLE
feat(APP-14): centralise ENS resolution on frontend with real-time records

### DIFF
--- a/.changeset/legal-berries-unite.md
+++ b/.changeset/legal-berries-unite.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Centralise ENS resolution on frontend with real-time records.

--- a/biome.json
+++ b/biome.json
@@ -179,7 +179,21 @@
                     }
                 },
                 "noParameterProperties": "off",
-                "useReadonlyClassProperties": "off"
+                "useReadonlyClassProperties": "off",
+                "noRestrictedImports": {
+                    "level": "warn",
+                    "options": {
+                        "paths": {
+                            "wagmi": {
+                                "importNames": [
+                                    "useEnsAvatar",
+                                    "useEnsName"
+                                ],
+                                "message": "Import ENS hooks from @/modules/ens instead. They provide consistent chainId, caching, monitoring, and app-level wrappers. Add biome-ignore with reason if direct wagmi access is needed."
+                            }
+                        }
+                    }
+                }
             },
             "suspicious": {
                 "noAsyncPromiseExecutor": "error",
@@ -244,88 +258,6 @@
         ]
     },
     "overrides": [
-        {
-            "includes": [
-                "**/*.ts",
-                "**/*.tsx",
-                "**/*.mts",
-                "**/*.cts"
-            ],
-            "linter": {
-                "rules": {
-                    "complexity": {
-                        "noArguments": "error"
-                    },
-                    "correctness": {
-                        "noConstAssign": "off",
-                        "noGlobalObjectCalls": "off",
-                        "noInvalidBuiltinInstantiation": "off",
-                        "noInvalidConstructorSuper": "off",
-                        "noSetterReturn": "off",
-                        "noUndeclaredVariables": "off",
-                        "noUnreachable": "off",
-                        "noUnreachableSuper": "off"
-                    },
-                    "style": {
-                        "useConst": "error"
-                    },
-                    "suspicious": {
-                        "noClassAssign": "off",
-                        "noDuplicateClassMembers": "off",
-                        "noDuplicateObjectKeys": "off",
-                        "noDuplicateParameters": "off",
-                        "noFunctionAssign": "off",
-                        "noImportAssign": "off",
-                        "noRedeclare": "off",
-                        "noUnsafeNegation": "off",
-                        "noVar": "error",
-                        "noWith": "off",
-                        "useGetterReturn": "off"
-                    }
-                }
-            }
-        },
-        {
-            "includes": [
-                "**/*.ts",
-                "**/*.tsx",
-                "**/*.mts",
-                "**/*.cts"
-            ],
-            "linter": {
-                "rules": {
-                    "complexity": {
-                        "noArguments": "error"
-                    },
-                    "correctness": {
-                        "noConstAssign": "off",
-                        "noGlobalObjectCalls": "off",
-                        "noInvalidBuiltinInstantiation": "off",
-                        "noInvalidConstructorSuper": "off",
-                        "noSetterReturn": "off",
-                        "noUndeclaredVariables": "off",
-                        "noUnreachable": "off",
-                        "noUnreachableSuper": "off"
-                    },
-                    "style": {
-                        "useConst": "error"
-                    },
-                    "suspicious": {
-                        "noClassAssign": "off",
-                        "noDuplicateClassMembers": "off",
-                        "noDuplicateObjectKeys": "off",
-                        "noDuplicateParameters": "off",
-                        "noFunctionAssign": "off",
-                        "noImportAssign": "off",
-                        "noRedeclare": "off",
-                        "noUnsafeNegation": "off",
-                        "noVar": "error",
-                        "noWith": "off",
-                        "useGetterReturn": "off"
-                    }
-                }
-            }
-        },
         {
             "includes": [
                 "**/*.ts",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -1566,6 +1566,12 @@
           },
           "efpCard": {
             "title": "Ethereum Follow Protocol"
+          },
+          "links": {
+            "title": "Links",
+            "website": "Website",
+            "twitter": "X",
+            "github": "GitHub"
           }
         },
         "error": {

--- a/src/daos/boundless/components/boundlessPageHeader/boundlessPageHeader.tsx
+++ b/src/daos/boundless/components/boundlessPageHeader/boundlessPageHeader.tsx
@@ -2,7 +2,8 @@
 
 import classNames from 'classnames';
 import { useMemo } from 'react';
-import { useConnection, useEnsName } from 'wagmi';
+import { useConnection } from 'wagmi';
+import { useEnsName } from '@/modules/ens';
 import { Carousel } from '@/shared/components/carousel';
 import { Container } from '@/shared/components/container';
 import { useTranslations } from '@/shared/components/translationsProvider';
@@ -17,10 +18,7 @@ export const BoundlessPageHeader: React.FC<IBoundlessPageHeaderProps> = (
 ) => {
     const { dao, className, ...otherProps } = props;
     const { address } = useConnection();
-    const { data: ensName } = useEnsName({
-        address,
-        chainId: 1,
-    });
+    const { data: ensName } = useEnsName(address);
 
     const { t } = useTranslations();
     const actions = useMemo(() => getActions(dao), [dao]);

--- a/src/daos/cryptex/components/cryptexPageHeader/cryptexPageHeader.tsx
+++ b/src/daos/cryptex/components/cryptexPageHeader/cryptexPageHeader.tsx
@@ -2,7 +2,8 @@
 
 import classNames from 'classnames';
 import { useEffect, useMemo, useState } from 'react';
-import { useConnection, useEnsName } from 'wagmi';
+import { useConnection } from 'wagmi';
+import { useEnsName } from '@/modules/ens';
 import { Carousel } from '@/shared/components/carousel';
 import { Container } from '@/shared/components/container';
 import { useTranslations } from '@/shared/components/translationsProvider';
@@ -18,10 +19,7 @@ export const CryptexPageHeader: React.FC<ICryptexPageHeaderProps> = (props) => {
     const [isLightMode, setIsLightMode] = useState(true);
     const [isShimLightMode, setIsShimLightMode] = useState(false);
     const { address } = useConnection();
-    const { data: ensName } = useEnsName({
-        address,
-        chainId: 1,
-    });
+    const { data: ensName } = useEnsName(address);
 
     const { t } = useTranslations();
     const actions = useMemo(() => getActions(dao), [dao]);

--- a/src/daos/xmaquina/components/xmaquinaPageHeader/xmaquinaPageHeader.tsx
+++ b/src/daos/xmaquina/components/xmaquinaPageHeader/xmaquinaPageHeader.tsx
@@ -3,8 +3,9 @@
 import classNames from 'classnames';
 import Image from 'next/image';
 import { useMemo } from 'react';
-import { useConnection, useEnsName } from 'wagmi';
+import { useConnection } from 'wagmi';
 import { twkEverett } from '@/daos/xmaquina/assets/fonts/twkEverett';
+import { useEnsName } from '@/modules/ens';
 import { Carousel } from '@/shared/components/carousel';
 import { Container } from '@/shared/components/container';
 import { useTranslations } from '@/shared/components/translationsProvider';
@@ -21,10 +22,7 @@ export const XmaquinaPageHeader: React.FC<IXmaquinaPageHeaderProps> = (
 ) => {
     const { dao, className, ...otherProps } = props;
     const { address } = useConnection();
-    const { data: ensName } = useEnsName({
-        address,
-        chainId: 1,
-    });
+    const { data: ensName } = useEnsName(address);
 
     const { t } = useTranslations();
 

--- a/src/modules/application/constants/wagmi.ts
+++ b/src/modules/application/constants/wagmi.ts
@@ -22,6 +22,17 @@ const wagmiAdapter = new WagmiAdapter({
         createClient({
             chain,
             transport: http(`/api/rpc/${chain.id.toString()}`),
+            // Enables automatic batching of all readContract calls (including ENS
+            // resolution from useEnsName / getEnsText) into a single eth_call via
+            // the Multicall3 contract. 50 list items = 1 HTTP request instead of 50.
+            //
+            // Known limitations:
+            // - Multicall3 must be deployed on the target chain (available on all major
+            //   EVM chains including mainnet, Arbitrum, Base, Polygon, etc.)
+            // - simulateContract calls are NOT batched (by viem design)
+            // - RPC-level errors inside a batch (e.g. rate-limit 429) may not trigger
+            //   retries since the HTTP response is still 200
+            batch: { multicall: true },
         }),
     projectId: walletConnectDefinitions.projectId,
     storage: createStorage({ storage: cookieStorage }),

--- a/src/modules/application/dialogs/userDialog/userDialog.test.tsx
+++ b/src/modules/application/dialogs/userDialog/userDialog.test.tsx
@@ -8,6 +8,7 @@ import {
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import * as wagmi from 'wagmi';
+import * as ensModule from '@/modules/ens';
 import * as useDialogContext from '@/shared/components/dialogProvider';
 import { generateDialogContext } from '@/shared/testUtils';
 import { type IUserDialogProps, UserDialog } from './userDialog';
@@ -24,7 +25,8 @@ describe('<UserDialog /> component', () => {
     );
     const useConnectionSpy = jest.spyOn(wagmi, 'useConnection');
     const useDisconnectSpy = jest.spyOn(wagmi, 'useDisconnect');
-    const useEnsNameSpy = jest.spyOn(wagmi, 'useEnsName');
+    const useEnsNameSpy = jest.spyOn(ensModule, 'useEnsName');
+    const useEnsAvatarSpy = jest.spyOn(ensModule, 'useEnsAvatar');
     const clipboardCopySpy = jest.spyOn(clipboardUtils, 'copy');
 
     beforeEach(() => {
@@ -35,9 +37,14 @@ describe('<UserDialog /> component', () => {
         useDisconnectSpy.mockReturnValue(
             {} as unknown as wagmi.UseDisconnectReturnType,
         );
-        useEnsNameSpy.mockReturnValue(
-            {} as unknown as wagmi.UseEnsNameReturnType,
-        );
+        useEnsNameSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
+        useEnsAvatarSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsAvatar>);
     });
 
     afterEach(() => {
@@ -45,6 +52,7 @@ describe('<UserDialog /> component', () => {
         useConnectionSpy.mockReset();
         useDisconnectSpy.mockReset();
         useEnsNameSpy.mockReset();
+        useEnsAvatarSpy.mockReset();
         clipboardCopySpy.mockReset();
     });
 
@@ -77,7 +85,8 @@ describe('<UserDialog /> component', () => {
         } as unknown as wagmi.UseConnectionReturnType);
         useEnsNameSpy.mockReturnValue({
             data: ensName,
-        } as unknown as wagmi.UseEnsNameReturnType);
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
         render(createTestComponent());
         expect(screen.getByTestId('member-avatar-mock')).toBeInTheDocument();
         expect(screen.getByText(ensName)).toBeInTheDocument();
@@ -91,9 +100,6 @@ describe('<UserDialog /> component', () => {
         useConnectionSpy.mockReturnValue({
             address,
         } as unknown as wagmi.UseConnectionReturnType);
-        useEnsNameSpy.mockReturnValue({
-            data: null,
-        } as unknown as wagmi.UseEnsNameReturnType);
         render(createTestComponent());
         expect(
             screen.getByText(addressUtils.truncateAddress(address)),

--- a/src/modules/application/dialogs/userDialog/userDialog.tsx
+++ b/src/modules/application/dialogs/userDialog/userDialog.tsx
@@ -9,8 +9,8 @@ import {
     useBlockExplorer,
 } from '@aragon/gov-ui-kit';
 import { useEffect } from 'react';
-import { mainnet } from 'viem/chains';
-import { useConnection, useDisconnect, useEnsName } from 'wagmi';
+import { useConnection, useDisconnect } from 'wagmi';
+import { useEnsAvatar, useEnsName } from '@/modules/ens';
 import {
     type IDialogComponentProps,
     useDialogContext,
@@ -29,11 +29,8 @@ export const UserDialog: React.FC<IUserDialogProps> = (props) => {
     const { address, chainId } = useConnection();
     const { disconnect } = useDisconnect();
 
-    const { data: ensName } = useEnsName({
-        address,
-        query: { enabled: address != null },
-        chainId: mainnet.id,
-    });
+    const { data: ensName } = useEnsName(address);
+    const { data: ensAvatar } = useEnsAvatar(ensName);
 
     const formattedAddress = addressUtils.truncateAddress(address);
 
@@ -63,6 +60,8 @@ export const UserDialog: React.FC<IUserDialogProps> = (props) => {
             <div className="flex flex-col gap-3 px-8">
                 <MemberAvatar
                     address={address}
+                    avatarSrc={ensAvatar ?? undefined}
+                    ensName={ensName ?? undefined}
                     responsiveSize={{ sm: 'xl' }}
                     size="lg"
                 />

--- a/src/modules/createDao/components/createProcessForm/createProcessFormGovernance/fields/governanceBodyField/governanceBodiesFieldItemDefault.tsx
+++ b/src/modules/createDao/components/createProcessForm/createProcessFormGovernance/fields/governanceBodyField/governanceBodiesFieldItemDefault.tsx
@@ -3,9 +3,8 @@ import {
     ChainEntityType,
     DefinitionList,
 } from '@aragon/gov-ui-kit';
-import type { Hash } from 'viem';
-import { useEnsName } from 'wagmi';
 import type { ISetupBodyForm } from '@/modules/createDao/dialogs/setupBodyDialog';
+import { useEnsName } from '@/modules/ens';
 import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
@@ -32,10 +31,9 @@ export const GovernanceBodiesFieldItemDefault: React.FC<
     const { data: dao } = useDao({ urlParams: { id: daoId } });
     const { buildEntityUrl } = useDaoChain({ network: dao?.network });
 
-    const { data: ensName } = useEnsName({
-        address:
-            body.type !== BodyType.NEW ? (body.address as Hash) : undefined,
-    });
+    const { data: ensName } = useEnsName(
+        body.type !== BodyType.NEW ? body.address : undefined,
+    );
 
     if (body.type !== BodyType.EXTERNAL && body.type !== BodyType.EXISTING) {
         return null;

--- a/src/modules/ens/constants/ensConfig.ts
+++ b/src/modules/ens/constants/ensConfig.ts
@@ -1,0 +1,31 @@
+import { mainnet } from 'viem/chains';
+
+/** ENS resolution is always performed on mainnet regardless of which chain the DAO is on. */
+export const ENS_CHAIN_ID = mainnet.id;
+
+/**
+ * Cache configuration for ENS data. ENS records (name, avatar, text records) rarely
+ * change, but they are still user-controlled profile data. Use a moderate TTL so
+ * the UI stays reasonably fresh without spamming RPC calls on list views.
+ */
+export const ENS_CACHE = {
+    /** Data is considered fresh for 5 minutes before a background refetch is triggered. */
+    staleTime: 5 * 60 * 1000,
+    /** Unused cache entries are garbage-collected after 1 hour. */
+    gcTime: 60 * 60 * 1000,
+} as const;
+
+/**
+ * ENS text-record keys fetched for member profiles.
+ * To add a new record (e.g. Farcaster) add one entry here and read it from
+ * `useEnsRecords` where needed.
+ */
+export const ENS_RECORD_KEYS = {
+    description: 'description',
+    url: 'url',
+    twitter: 'com.twitter',
+    github: 'com.github',
+} as const;
+
+/** Ordered list of record keys used by `useEnsRecords` to fetch in a single query. */
+export const ENS_PROFILE_KEYS = Object.values(ENS_RECORD_KEYS);

--- a/src/modules/ens/hooks/useEnsAvatar.ts
+++ b/src/modules/ens/hooks/useEnsAvatar.ts
@@ -1,0 +1,73 @@
+import { useEffect, useMemo } from 'react';
+import { normalize } from 'viem/ens';
+// biome-ignore lint/style/noRestrictedImports: authorised wrapper over wagmi's useEnsAvatar (centralises chainId and cache)
+import { useEnsAvatar as useWagmiEnsAvatar } from 'wagmi';
+import { ENS_CACHE, ENS_CHAIN_ID } from '../constants/ensConfig';
+import { logEnsError } from '../utils/logEnsError';
+
+/**
+ * Resolves the avatar for an ENS name.
+ *
+ * Normalises the ENS name once and centralises cache configuration so every
+ * consumer gets the same behaviour.
+ *
+ * @param name - ENS name (for example `"vitalik.eth"`), or `null`/`undefined` to skip.
+ */
+export function useEnsAvatar(name: string | null | undefined) {
+    const { error: normalizeError, normalizedName } = useMemo(() => {
+        if (name == null || name.length === 0) {
+            return {
+                error: null,
+                normalizedName: undefined,
+            };
+        }
+
+        try {
+            return {
+                error: null,
+                normalizedName: normalize(name),
+            };
+        } catch (error) {
+            return {
+                error,
+                normalizedName: undefined,
+            };
+        }
+    }, [name]);
+
+    const result = useWagmiEnsAvatar({
+        name: normalizedName,
+        chainId: ENS_CHAIN_ID,
+        query: {
+            enabled: normalizedName != null,
+            staleTime: ENS_CACHE.staleTime,
+            gcTime: ENS_CACHE.gcTime,
+        },
+    });
+
+    useEffect(() => {
+        if (normalizeError == null || name == null) {
+            return;
+        }
+        logEnsError(normalizeError, {
+            hook: 'useEnsAvatar',
+            stage: 'normalize',
+            name,
+            chainId: ENS_CHAIN_ID,
+        });
+    }, [normalizeError, name]);
+
+    useEffect(() => {
+        if (result.error == null || normalizedName == null) {
+            return;
+        }
+        logEnsError(result.error, {
+            hook: 'useEnsAvatar',
+            stage: 'resolve',
+            name: normalizedName,
+            chainId: ENS_CHAIN_ID,
+        });
+    }, [result.error, normalizedName]);
+
+    return result;
+}

--- a/src/modules/ens/hooks/useEnsAvatar.ts
+++ b/src/modules/ens/hooks/useEnsAvatar.ts
@@ -14,7 +14,7 @@ import { logEnsError } from '../utils/logEnsError';
  * @param name - ENS name (for example `"vitalik.eth"`), or `null`/`undefined` to skip.
  */
 export function useEnsAvatar(name: string | null | undefined) {
-    const { error: normalizeError, normalizedName } = useMemo(() => {
+    const { error: normalizedError, normalizedName } = useMemo(() => {
         if (name == null || name.length === 0) {
             return {
                 error: null,
@@ -46,16 +46,16 @@ export function useEnsAvatar(name: string | null | undefined) {
     });
 
     useEffect(() => {
-        if (normalizeError == null || name == null) {
+        if (normalizedError == null || name == null) {
             return;
         }
-        logEnsError(normalizeError, {
+        logEnsError(normalizedError, {
             hook: 'useEnsAvatar',
             stage: 'normalize',
             name,
             chainId: ENS_CHAIN_ID,
         });
-    }, [normalizeError, name]);
+    }, [normalizedError, name]);
 
     useEffect(() => {
         if (result.error == null || normalizedName == null) {

--- a/src/modules/ens/hooks/useEnsName.ts
+++ b/src/modules/ens/hooks/useEnsName.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { isAddress } from 'viem';
+// biome-ignore lint/style/noRestrictedImports: authorised wrapper over wagmi's useEnsName (centralises chainId and cache)
+import { useEnsName as useWagmiEnsName } from 'wagmi';
+import { ENS_CACHE, ENS_CHAIN_ID } from '../constants/ensConfig';
+import { logEnsError } from '../utils/logEnsError';
+
+/**
+ * Resolves the primary ENS name for a given Ethereum address.
+ *
+ * Thin wrapper over wagmi's `useEnsName` that centralises `chainId` (always mainnet)
+ * and cache configuration so every consumer gets consistent behaviour without
+ * duplicating config. Uses TanStack Query under the hood with long-lived TTLs.
+ *
+ * All calls are auto-batched into a single multicall RPC request via viem's `batch.multicall`.
+ *
+ * @param address - Hex Ethereum address (`0x…`) or `undefined` to skip.
+ */
+export function useEnsName(address: string | undefined) {
+    const validAddress =
+        address != null && isAddress(address) ? address : undefined;
+
+    const result = useWagmiEnsName({
+        address: validAddress,
+        chainId: ENS_CHAIN_ID,
+        query: {
+            enabled: validAddress != null,
+            staleTime: ENS_CACHE.staleTime,
+            gcTime: ENS_CACHE.gcTime,
+        },
+    });
+
+    useEffect(() => {
+        if (result.error == null || validAddress == null) {
+            return;
+        }
+        logEnsError(result.error, {
+            hook: 'useEnsName',
+            address: validAddress,
+            chainId: ENS_CHAIN_ID,
+        });
+    }, [result.error, validAddress]);
+
+    return result;
+}

--- a/src/modules/ens/hooks/useEnsRecords.ts
+++ b/src/modules/ens/hooks/useEnsRecords.ts
@@ -1,0 +1,76 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { normalize } from 'viem/ens';
+import { getEnsText } from 'wagmi/actions';
+import { wagmiConfig } from '@/modules/application/constants/wagmi';
+import {
+    ENS_CACHE,
+    ENS_CHAIN_ID,
+    ENS_PROFILE_KEYS,
+} from '../constants/ensConfig';
+import type { IEnsRecords } from '../types';
+import { logEnsError } from '../utils/logEnsError';
+
+/**
+ * Fetches multiple ENS text records for a given ENS name in a single TanStack query.
+ *
+ * Each `getEnsText` call is a `readContract` under the hood. With `batch.multicall: true`
+ * on the viem client, all calls within the `Promise.all` are auto-batched into a single multicall RPC request.
+ *
+ * Uses `Promise.allSettled` so that a single record failure doesn't block the rest.
+ * If ALL records fail the query returns an empty result.
+ * The failure is logged once to Sentry via `result.error`.
+ *
+ * @param name - ENS name to look up (e.g. `"vitalik.eth"`), or `null`/`undefined` to skip.
+ */
+export function useEnsRecords(name: string | null | undefined) {
+    const isValid = name != null && name.length > 0;
+
+    const result = useQuery<IEnsRecords>({
+        queryKey: ['ensRecords', name, ENS_PROFILE_KEYS],
+        queryFn: async () => {
+            if (!isValid) {
+                return {};
+            }
+
+            const normalizedName = normalize(name);
+
+            const settled = await Promise.allSettled(
+                ENS_PROFILE_KEYS.map((key) =>
+                    getEnsText(wagmiConfig, {
+                        name: normalizedName,
+                        key,
+                        chainId: ENS_CHAIN_ID,
+                    }),
+                ),
+            );
+
+            return Object.fromEntries(
+                ENS_PROFILE_KEYS.map((key, i) => {
+                    const entry = settled[i];
+                    const value =
+                        entry.status === 'fulfilled'
+                            ? (entry.value ?? null)
+                            : null;
+                    return [key, value];
+                }),
+            );
+        },
+        enabled: isValid,
+        staleTime: ENS_CACHE.staleTime,
+        gcTime: ENS_CACHE.gcTime,
+    });
+
+    useEffect(() => {
+        if (result.error == null || name == null) {
+            return;
+        }
+        logEnsError(result.error, {
+            hook: 'useEnsRecords',
+            name,
+            chainId: ENS_CHAIN_ID,
+        });
+    }, [result.error, name]);
+
+    return result;
+}

--- a/src/modules/ens/index.ts
+++ b/src/modules/ens/index.ts
@@ -1,0 +1,26 @@
+/**
+ * ENS module — single source of truth for all ENS resolution in the app.
+ *
+ * Provides hooks to resolve ENS names, avatars, and text records (bio, links).
+ * Centralises `chainId`, cache TTLs, and record-key configuration so consumers
+ * don't duplicate config.
+ *
+ * @example
+ * ```ts
+ * // In a list item or header
+ * const { data: ensName } = useEnsName(address);
+ * const { data: ensAvatar } = useEnsAvatar(ensName);
+ *
+ * // On a detail page
+ * const { data: ensRecords } = useEnsRecords(ensName);
+ * ```
+ */
+export {
+    ENS_CACHE,
+    ENS_CHAIN_ID,
+    ENS_RECORD_KEYS,
+} from './constants/ensConfig';
+export { useEnsAvatar } from './hooks/useEnsAvatar';
+export { useEnsName } from './hooks/useEnsName';
+export { useEnsRecords } from './hooks/useEnsRecords';
+export type { IEnsRecords, TEnsRecordKey } from './types';

--- a/src/modules/ens/types.ts
+++ b/src/modules/ens/types.ts
@@ -1,0 +1,9 @@
+import type { ENS_RECORD_KEYS } from './constants/ensConfig';
+
+/** Union of all ENS text-record key strings we fetch (e.g. `'description'`, `'com.twitter'`). */
+export type TEnsRecordKey =
+    (typeof ENS_RECORD_KEYS)[keyof typeof ENS_RECORD_KEYS];
+
+/** Map of ENS text-record key → resolved value (or `null` if not set). */
+export interface IEnsRecords
+    extends Partial<Record<TEnsRecordKey, string | null>> {}

--- a/src/modules/ens/utils/logEnsError.ts
+++ b/src/modules/ens/utils/logEnsError.ts
@@ -1,0 +1,23 @@
+import { monitoringUtils } from '@/shared/utils/monitoringUtils';
+
+export interface IEnsErrorContext {
+    chainId?: number;
+    hook?: string;
+    key?: string;
+    name?: string;
+    address?: string;
+    stage?: string;
+}
+
+/**
+ * Reports ENS-related failures to Sentry with a shared namespace so they can be
+ * filtered and monitored separately from generic RPC noise.
+ */
+export function logEnsError(error: unknown, context: IEnsErrorContext = {}) {
+    monitoringUtils.logError(error, {
+        context: {
+            module: 'ens',
+            ...context,
+        },
+    });
+}

--- a/src/modules/governance/api/governanceService/domain/member.ts
+++ b/src/modules/governance/api/governanceService/domain/member.ts
@@ -7,6 +7,8 @@ export interface IMember {
     address: string;
     /**
      * ENS name linked to the member address.
+     * @deprecated Prefer `useEnsName(address)` from `@/modules/ens` for real-time resolution.
+     * This field is still returned by the backend but is no longer used for display.
      */
     ens: string | null;
     /**

--- a/src/modules/governance/components/daoMemberList/daoMemberListDefault.test.tsx
+++ b/src/modules/governance/components/daoMemberList/daoMemberListDefault.test.tsx
@@ -1,6 +1,7 @@
 import { GukModulesProvider } from '@aragon/gov-ui-kit';
 import { render, screen } from '@testing-library/react';
 import * as wagmi from 'wagmi';
+import * as ensModule from '@/modules/ens';
 import type { IMember } from '@/modules/governance/api/governanceService';
 import * as governanceService from '@/modules/governance/api/governanceService';
 import * as useMemberListData from '@/modules/governance/hooks/useMemberListData';
@@ -25,6 +26,15 @@ describe('<DaoMemberListDefault /> component', () => {
     const useConnectionSpy = jest.spyOn(wagmi, 'useConnection');
     const useMemberSpy = jest.spyOn(governanceService, 'useMember');
     const useMemberExistsSpy = jest.spyOn(governanceService, 'useMemberExists');
+    const useEnsNameSpy = jest.spyOn(ensModule, 'useEnsName');
+    const useEnsAvatarSpy = jest.spyOn(ensModule, 'useEnsAvatar');
+
+    const mockEnsNameByAddress = (entries: Record<string, string | null>) => {
+        useEnsNameSpy.mockImplementation(((address) => ({
+            data: address ? (entries[address] ?? null) : null,
+            isLoading: false,
+        })) as typeof ensModule.useEnsName);
+    };
 
     beforeEach(() => {
         useMemberListDataSpy.mockReturnValue({
@@ -50,6 +60,14 @@ describe('<DaoMemberListDefault /> component', () => {
         useMemberExistsSpy.mockReturnValue(
             generateReactQueryResultSuccess({ data: { status: false } }),
         );
+        useEnsNameSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
+        useEnsAvatarSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsAvatar>);
     });
 
     afterEach(() => {
@@ -58,6 +76,8 @@ describe('<DaoMemberListDefault /> component', () => {
         useConnectionSpy.mockReset();
         useMemberSpy.mockReset();
         useMemberExistsSpy.mockReset();
+        useEnsNameSpy.mockReset();
+        useEnsAvatarSpy.mockReset();
     });
 
     const createTestComponent = (
@@ -79,10 +99,15 @@ describe('<DaoMemberListDefault /> component', () => {
     };
 
     it('fetches and renders the multisig member list', () => {
+        const resolvedEns = 'member-1';
         const members = [
             generateMember({ address: '0x123' }),
-            generateMember({ address: '0x456', ens: 'member-1' }),
+            generateMember({ address: '0x456', ens: resolvedEns }),
         ];
+        mockEnsNameByAddress({
+            '0x123': null,
+            '0x456': resolvedEns,
+        });
         useMemberListDataSpy.mockReturnValue({
             memberList: members,
             onLoadMore: jest.fn(),
@@ -94,7 +119,7 @@ describe('<DaoMemberListDefault /> component', () => {
         });
         render(createTestComponent());
         expect(screen.getByText(members[0].address)).toBeInTheDocument();
-        expect(screen.getByText(members[1].ens!)).toBeInTheDocument();
+        expect(screen.getByText(resolvedEns)).toBeInTheDocument();
         expect(screen.getByRole('progressbar')).toBeInTheDocument();
     });
 
@@ -134,6 +159,10 @@ describe('<DaoMemberListDefault /> component', () => {
         useConnectionSpy.mockReturnValue({
             address: userAddress,
         } as unknown as wagmi.UseConnectionReturnType);
+        mockEnsNameByAddress({
+            [userAddress]: 'you.eth',
+            [otherAddress]: 'other.eth',
+        });
 
         useMemberExistsSpy.mockReturnValue(
             generateReactQueryResultSuccess({ data: { status: true } }),
@@ -173,6 +202,9 @@ describe('<DaoMemberListDefault /> component', () => {
         useConnectionSpy.mockReturnValue({
             address: userAddress,
         } as unknown as wagmi.UseConnectionReturnType);
+        mockEnsNameByAddress({
+            [otherMember.address]: 'other.eth',
+        });
 
         useMemberListDataSpy.mockReturnValue({
             memberList: [otherMember],
@@ -213,6 +245,10 @@ describe('<DaoMemberListDefault /> component', () => {
         useConnectionSpy.mockReturnValue({
             address: userAddress,
         } as unknown as wagmi.UseConnectionReturnType);
+        mockEnsNameByAddress({
+            [userAddress]: 'you.eth',
+            [otherMember.address]: 'other.eth',
+        });
 
         useMemberExistsSpy.mockReturnValue(
             generateReactQueryResultSuccess({ data: { status: true } }),

--- a/src/modules/governance/components/daoMemberList/daoMemberListDefault.tsx
+++ b/src/modules/governance/components/daoMemberList/daoMemberListDefault.tsx
@@ -7,6 +7,7 @@ import {
 } from '@aragon/gov-ui-kit';
 import { type ReactNode, useMemo } from 'react';
 import { useConnection } from 'wagmi';
+import { useEnsAvatar, useEnsName } from '@/modules/ens';
 import type {
     IGetMemberListParams,
     IMember,
@@ -148,7 +149,7 @@ export const DaoMemberListDefault: React.FC<IDaoMemberListDefaultProps> = (
     const processedLayoutClassNames =
         layoutClassNames ?? 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3';
 
-    const getMemberLink = (member: IMember) =>
+    const getMemberLink = (member: IMember): string | undefined =>
         onMemberClick != null
             ? undefined
             : daoUtils.getDaoUrl(dao, `members/${member.address}`);
@@ -168,12 +169,10 @@ export const DaoMemberListDefault: React.FC<IDaoMemberListDefaultProps> = (
                 SkeletonElement={MemberDataListItem.Skeleton}
             >
                 {mergedMemberList?.map((member) => (
-                    <MemberDataListItem.Structure
-                        address={member.address}
-                        className="min-w-0"
-                        ensName={member.ens ?? undefined}
+                    <EnsAwareMemberItem
                         href={getMemberLink(member)}
                         key={member.address}
+                        member={member}
                         onClick={() => onMemberClick?.(member)}
                     />
                 ))}
@@ -181,5 +180,34 @@ export const DaoMemberListDefault: React.FC<IDaoMemberListDefaultProps> = (
             {!hidePagination && <DataListPagination />}
             {children}
         </DataListRoot>
+    );
+};
+
+/**
+ * Wrapper component that resolves ENS name and avatar for each member in the list.
+ *
+ * Extracted from the inline `.map()` because React hooks cannot
+ * be called inside a callback — they must be called at the top level of a component.
+ * With `batch.multicall` enabled on the viem client, the ENS reads across
+ * the rendered list items are auto-batched into RPC multicalls.
+ */
+const EnsAwareMemberItem: React.FC<{
+    member: IMember;
+    href?: string;
+    onClick?: () => void;
+}> = (props) => {
+    const { member, href, onClick } = props;
+    const { data: ensName } = useEnsName(member.address);
+    const { data: ensAvatar } = useEnsAvatar(ensName);
+
+    return (
+        <MemberDataListItem.Structure
+            address={member.address}
+            avatarSrc={ensAvatar ?? undefined}
+            className="min-w-0"
+            ensName={ensName ?? undefined}
+            href={href}
+            onClick={onClick}
+        />
     );
 };

--- a/src/modules/governance/components/daoProposalList/daoProposalListDefaultItem.tsx
+++ b/src/modules/governance/components/daoProposalList/daoProposalListDefaultItem.tsx
@@ -1,4 +1,5 @@
 import { ProposalDataListItem, type ProposalStatus } from '@aragon/gov-ui-kit';
+import { useEnsName } from '@/modules/ens';
 import type { IProposal } from '@/modules/governance/api/governanceService';
 import type { IDao } from '@/shared/api/daoService';
 import { useSlotSingleFunction } from '@/shared/hooks/useSlotSingleFunction';
@@ -54,7 +55,8 @@ export const DaoProposalListDefaultItem: React.FC<
     const proposalHref = proposalUtils.getProposalUrl(proposal, dao);
 
     const publisherHref = daoUtils.getDaoUrl(dao, `members/${creator.address}`);
-    const publisherName = creator.ens ?? undefined;
+    const { data: publisherEnsName } = useEnsName(creator.address);
+    const publisherName = publisherEnsName ?? undefined;
 
     return (
         <ProposalDataListItem.Structure

--- a/src/modules/governance/components/memberLinksCard/index.ts
+++ b/src/modules/governance/components/memberLinksCard/index.ts
@@ -1,0 +1,1 @@
+export { MemberLinksCard } from './memberLinksCard';

--- a/src/modules/governance/components/memberLinksCard/memberLinksCard.test.tsx
+++ b/src/modules/governance/components/memberLinksCard/memberLinksCard.test.tsx
@@ -1,8 +1,4 @@
-import {
-    buildGithubUrl,
-    buildTwitterUrl,
-    sanitizeUrl,
-} from './memberLinksCard';
+import { buildGithubUrl, buildTwitterUrl } from './memberLinksCard';
 
 describe('buildTwitterUrl', () => {
     it('builds a valid X profile URL from a plain handle', () => {
@@ -49,45 +45,5 @@ describe('buildGithubUrl', () => {
 
     it('rejects handles with special characters', () => {
         expect(buildGithubUrl('user<script>')).toBeNull();
-    });
-});
-
-describe('sanitizeUrl', () => {
-    it('accepts bare domains by normalizing them to https', () => {
-        expect(sanitizeUrl('example.com')).toBe('https://example.com/');
-    });
-
-    it('accepts https URLs', () => {
-        expect(sanitizeUrl('https://example.com')).toBe('https://example.com/');
-    });
-
-    it('accepts http URLs', () => {
-        expect(sanitizeUrl('http://example.com')).toBe('http://example.com/');
-    });
-
-    it('preserves path and query string', () => {
-        expect(sanitizeUrl('https://example.com/page?q=1')).toBe(
-            'https://example.com/page?q=1',
-        );
-    });
-
-    it('rejects javascript: protocol', () => {
-        expect(sanitizeUrl('javascript:alert(1)')).toBeNull();
-    });
-
-    it('rejects data: protocol', () => {
-        expect(sanitizeUrl('data:text/html,<h1>XSS</h1>')).toBeNull();
-    });
-
-    it('rejects protocol-relative javascript payloads after normalization', () => {
-        expect(sanitizeUrl('//javascript:alert(1)')).toBeNull();
-    });
-
-    it('rejects malformed URLs', () => {
-        expect(sanitizeUrl('not-a-url')).toBeNull();
-    });
-
-    it('rejects empty string', () => {
-        expect(sanitizeUrl('')).toBeNull();
     });
 });

--- a/src/modules/governance/components/memberLinksCard/memberLinksCard.test.tsx
+++ b/src/modules/governance/components/memberLinksCard/memberLinksCard.test.tsx
@@ -1,0 +1,93 @@
+import {
+    buildGithubUrl,
+    buildTwitterUrl,
+    sanitizeUrl,
+} from './memberLinksCard';
+
+describe('buildTwitterUrl', () => {
+    it('builds a valid X profile URL from a plain handle', () => {
+        expect(buildTwitterUrl('vitalik')).toBe('https://x.com/vitalik');
+    });
+
+    it('strips leading @ from handle', () => {
+        expect(buildTwitterUrl('@vitalik')).toBe('https://x.com/vitalik');
+    });
+
+    it('allows underscores in handles', () => {
+        expect(buildTwitterUrl('vitalik_eth')).toBe(
+            'https://x.com/vitalik_eth',
+        );
+    });
+
+    it('rejects handles with path traversal characters', () => {
+        expect(buildTwitterUrl('../malicious')).toBeNull();
+    });
+
+    it('rejects handles with spaces', () => {
+        expect(buildTwitterUrl('foo bar')).toBeNull();
+    });
+
+    it('rejects empty handle after stripping @', () => {
+        expect(buildTwitterUrl('@')).toBeNull();
+    });
+});
+
+describe('buildGithubUrl', () => {
+    it('builds a valid GitHub profile URL', () => {
+        expect(buildGithubUrl('octocat')).toBe('https://github.com/octocat');
+    });
+
+    it('allows hyphens and dots in handles', () => {
+        expect(buildGithubUrl('my-user.name')).toBe(
+            'https://github.com/my-user.name',
+        );
+    });
+
+    it('rejects handles with slashes', () => {
+        expect(buildGithubUrl('user/repo')).toBeNull();
+    });
+
+    it('rejects handles with special characters', () => {
+        expect(buildGithubUrl('user<script>')).toBeNull();
+    });
+});
+
+describe('sanitizeUrl', () => {
+    it('accepts bare domains by normalizing them to https', () => {
+        expect(sanitizeUrl('example.com')).toBe('https://example.com/');
+    });
+
+    it('accepts https URLs', () => {
+        expect(sanitizeUrl('https://example.com')).toBe('https://example.com/');
+    });
+
+    it('accepts http URLs', () => {
+        expect(sanitizeUrl('http://example.com')).toBe('http://example.com/');
+    });
+
+    it('preserves path and query string', () => {
+        expect(sanitizeUrl('https://example.com/page?q=1')).toBe(
+            'https://example.com/page?q=1',
+        );
+    });
+
+    it('rejects javascript: protocol', () => {
+        expect(sanitizeUrl('javascript:alert(1)')).toBeNull();
+    });
+
+    it('rejects data: protocol', () => {
+        expect(sanitizeUrl('data:text/html,<h1>XSS</h1>')).toBeNull();
+    });
+
+    it('rejects protocol-relative javascript payloads after normalization', () => {
+        expect(sanitizeUrl('//javascript:alert(1)')).toBeNull();
+    });
+
+    it('rejects malformed URLs', () => {
+        expect(sanitizeUrl('not-a-url')).toBeNull();
+    });
+
+    it('rejects empty string', () => {
+        expect(sanitizeUrl('')).toBeNull();
+    });
+});

--- a/src/modules/governance/components/memberLinksCard/memberLinksCard.tsx
+++ b/src/modules/governance/components/memberLinksCard/memberLinksCard.tsx
@@ -1,5 +1,6 @@
-import { Link, urlUtils } from '@aragon/gov-ui-kit';
+import { Link } from '@aragon/gov-ui-kit';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { sanitizeExternalHttpUrl } from '@/shared/security';
 
 export interface IMemberLinksCardProps {
     /** ENS `url` text record. */
@@ -42,27 +43,6 @@ export function buildGithubUrl(handle: string): string | null {
 }
 
 /**
- * Normalizes a website URL using the shared UI kit utility and only allows
- * absolute HTTP(S) targets.
- */
-export function sanitizeUrl(url: string): string | null {
-    const normalized = urlUtils.normalizeExternalHref(url);
-    if (normalized == null) {
-        return null;
-    }
-
-    try {
-        const parsed = new URL(normalized);
-        if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
-            return parsed.href;
-        }
-        return null;
-    } catch {
-        return null;
-    }
-}
-
-/**
  * Renders a list of external links (Website, X, GitHub) resolved from ENS text records.
  * Returns `null` when no links are available so the parent can skip rendering the card.
  */
@@ -73,7 +53,7 @@ export const MemberLinksCard: React.FC<IMemberLinksCardProps> = (props) => {
     const links: ILinkEntry[] = [];
 
     if (url) {
-        const safe = sanitizeUrl(url);
+        const safe = sanitizeExternalHttpUrl(url);
         if (safe) {
             links.push({
                 labelKey:

--- a/src/modules/governance/components/memberLinksCard/memberLinksCard.tsx
+++ b/src/modules/governance/components/memberLinksCard/memberLinksCard.tsx
@@ -1,0 +1,129 @@
+import { Link, urlUtils } from '@aragon/gov-ui-kit';
+import { useTranslations } from '@/shared/components/translationsProvider';
+
+export interface IMemberLinksCardProps {
+    /** ENS `url` text record. */
+    url?: string | null;
+    /** ENS `com.twitter` text record. */
+    twitter?: string | null;
+    /** ENS `com.github` text record. */
+    github?: string | null;
+}
+
+interface ILinkEntry {
+    labelKey: string;
+    href: string;
+    display: string;
+}
+
+const SAFE_HANDLE_RE = /^[\w.-]+$/;
+
+/**
+ * Builds a safe X (Twitter) profile URL from a handle.
+ * Strips a leading `@` if present and encodes the handle to prevent URL injection.
+ */
+export function buildTwitterUrl(handle: string): string | null {
+    const cleaned = handle.startsWith('@') ? handle.slice(1) : handle;
+    if (!SAFE_HANDLE_RE.test(cleaned)) {
+        return null;
+    }
+    return `https://x.com/${encodeURIComponent(cleaned)}`;
+}
+
+/**
+ * Builds a safe GitHub profile URL from a username.
+ * Encodes the handle to prevent URL injection.
+ */
+export function buildGithubUrl(handle: string): string | null {
+    if (!SAFE_HANDLE_RE.test(handle)) {
+        return null;
+    }
+    return `https://github.com/${encodeURIComponent(handle)}`;
+}
+
+/**
+ * Normalizes a website URL using the shared UI kit utility and only allows
+ * absolute HTTP(S) targets.
+ */
+export function sanitizeUrl(url: string): string | null {
+    const normalized = urlUtils.normalizeExternalHref(url);
+    if (normalized == null) {
+        return null;
+    }
+
+    try {
+        const parsed = new URL(normalized);
+        if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+            return parsed.href;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Renders a list of external links (Website, X, GitHub) resolved from ENS text records.
+ * Returns `null` when no links are available so the parent can skip rendering the card.
+ */
+export const MemberLinksCard: React.FC<IMemberLinksCardProps> = (props) => {
+    const { url, twitter, github } = props;
+    const { t } = useTranslations();
+
+    const links: ILinkEntry[] = [];
+
+    if (url) {
+        const safe = sanitizeUrl(url);
+        if (safe) {
+            links.push({
+                labelKey:
+                    'app.governance.daoMemberDetailsPage.aside.links.website',
+                href: safe,
+                display: safe,
+            });
+        }
+    }
+
+    if (twitter) {
+        const safe = buildTwitterUrl(twitter);
+        if (safe) {
+            links.push({
+                labelKey:
+                    'app.governance.daoMemberDetailsPage.aside.links.twitter',
+                href: safe,
+                display: safe,
+            });
+        }
+    }
+
+    if (github) {
+        const safe = buildGithubUrl(github);
+        if (safe) {
+            links.push({
+                labelKey:
+                    'app.governance.daoMemberDetailsPage.aside.links.github',
+                href: safe,
+                display: safe,
+            });
+        }
+    }
+
+    if (links.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            {links.map((link) => (
+                <div className="flex flex-col gap-1" key={link.labelKey}>
+                    <Link href={link.href} isExternal={true}>
+                        {t(link.labelKey)}
+                    </Link>
+                    <p className="truncate text-neutral-400 text-sm">
+                        {link.display}
+                    </p>
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/src/modules/governance/components/proposalVotingTerminal/proposalVotingTerminal.test.tsx
+++ b/src/modules/governance/components/proposalVotingTerminal/proposalVotingTerminal.test.tsx
@@ -2,6 +2,7 @@ import { ProposalStatus } from '@aragon/gov-ui-kit';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import * as wagmi from 'wagmi';
+import * as ensModule from '@/modules/ens';
 import { SettingsSlotId } from '@/modules/settings/constants/moduleSlots';
 import { PluginInterfaceType } from '@/shared/api/daoService';
 import * as useDaoPluginInfo from '@/shared/hooks/useDaoPluginInfo';
@@ -34,7 +35,7 @@ describe('<ProposalVotingTerminal /> component', () => {
         'useSlotSingleFunction',
     );
     const useConnectionSpy = jest.spyOn(wagmi, 'useConnection');
-    const useEnsNameSpy = jest.spyOn(wagmi, 'useEnsName');
+    const useEnsNameSpy = jest.spyOn(ensModule, 'useEnsName');
     const useDaoPluginInfoSpy = jest.spyOn(
         useDaoPluginInfo,
         'useDaoPluginInfo',
@@ -43,13 +44,17 @@ describe('<ProposalVotingTerminal /> component', () => {
     beforeEach(() => {
         useConnectionSpy.mockReturnValue({} as wagmi.UseConnectionReturnType);
         useDaoPluginInfoSpy.mockReturnValue([]);
-        useEnsNameSpy.mockReturnValue({} as wagmi.UseEnsNameReturnType);
+        useEnsNameSpy.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
     });
 
     afterEach(() => {
         useConnectionSpy.mockReset();
         useSlotSingleFunctionSpy.mockReset();
         useDaoPluginInfoSpy.mockReset();
+        useEnsNameSpy.mockReset();
     });
 
     const createTestComponent = (

--- a/src/modules/governance/components/proposalVotingTerminal/proposalVotingTerminal.tsx
+++ b/src/modules/governance/components/proposalVotingTerminal/proposalVotingTerminal.tsx
@@ -4,8 +4,8 @@ import {
     ProposalStatus,
     ProposalVoting,
 } from '@aragon/gov-ui-kit';
-import type { Hex } from 'viem';
-import { useConnection, useEnsName } from 'wagmi';
+import { useConnection } from 'wagmi';
+import { useEnsName } from '@/modules/ens';
 import { SettingsSlotId } from '@/modules/settings/constants/moduleSlots';
 import type { IUseGovernanceSettingsParams } from '@/modules/settings/types';
 import { PluginSingleComponent } from '@/shared/components/pluginSingleComponent';
@@ -39,9 +39,7 @@ export const ProposalVotingTerminal: React.FC<IProposalVotingTerminalProps> = (
     const { proposal, status, daoId } = props;
 
     const { address } = useConnection();
-    const { data: pluginEnsName } = useEnsName({
-        address: proposal.pluginAddress as Hex,
-    });
+    const { data: pluginEnsName } = useEnsName(proposal.pluginAddress);
 
     const { network } = daoUtils.parseDaoId(daoId);
     const voteListParams = {

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
@@ -10,6 +10,8 @@ import type * as ReactQuery from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import * as wagmi from 'wagmi';
+import * as ensModule from '@/modules/ens';
+import { ENS_RECORD_KEYS } from '@/modules/ens';
 import { DaoList } from '@/modules/explore/components/daoList';
 import * as efpService from '@/modules/governance/api/efpService';
 import * as daoService from '@/shared/api/daoService';
@@ -54,6 +56,9 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
     const clipboardCopySpy = jest.spyOn(clipboardUtils, 'copy');
     const useEfpStatsSpy = jest.spyOn(efpService, 'useEfpStats');
     const useBlockSpy = jest.spyOn(wagmi, 'useBlock');
+    const useEnsNameSpy = jest.spyOn(ensModule, 'useEnsName');
+    const useEnsAvatarSpy = jest.spyOn(ensModule, 'useEnsAvatar');
+    const useEnsRecordsSpy = jest.spyOn(ensModule, 'useEnsRecords');
 
     const defaultPlugin = generateDaoPlugin({ isBody: true });
 
@@ -72,6 +77,18 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
             }),
         );
         useBlockSpy.mockReturnValue({} as wagmi.UseBlockReturnType);
+        useEnsNameSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
+        useEnsAvatarSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsAvatar>);
+        useEnsRecordsSpy.mockReturnValue({
+            data: {},
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsRecords>);
     });
 
     afterEach(() => {
@@ -80,6 +97,9 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
         clipboardCopySpy.mockReset();
         useEfpStatsSpy.mockReset();
         useBlockSpy.mockReset();
+        useEnsNameSpy.mockReset();
+        useEnsAvatarSpy.mockReset();
+        useEnsRecordsSpy.mockReset();
         (DaoList as jest.Mock).mockClear();
     });
 
@@ -113,13 +133,17 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
         });
         const address = '0x1234567890123456789012345678901234567890';
         const ens = 'member.eth';
-        const member = generateMember({ ens, address });
+        const member = generateMember({ address });
         useMemberSpy.mockReturnValue(
             generateReactQueryResultSuccess({ data: member }),
         );
         useDaoSpy.mockReturnValue(
             generateReactQueryResultSuccess({ data: dao }),
         );
+        useEnsNameSpy.mockReturnValue({
+            data: ens,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
 
         render(
             createTestComponent({
@@ -154,10 +178,14 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
     it('supports member address and ens copy', async () => {
         const ens = 'member.eth';
         const address = '0x1234567890123456789012345678901234567890';
-        const member = generateMember({ ens, address });
+        const member = generateMember({ address });
         useMemberSpy.mockReturnValue(
             generateReactQueryResultSuccess({ data: member }),
         );
+        useEnsNameSpy.mockReturnValue({
+            data: ens,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
         render(createTestComponent({ address }));
         const clipboards = screen.getAllByTestId(IconType.COPY);
         expect(clipboards.length).toBe(2);
@@ -170,10 +198,14 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
     it('renders the member information', () => {
         const ens = 'member.eth';
         const address = '0x1234567890123456789012345678901234567890';
-        const member = generateMember({ ens, address });
+        const member = generateMember({ address });
         useMemberSpy.mockReturnValue(
             generateReactQueryResultSuccess({ data: member }),
         );
+        useEnsNameSpy.mockReturnValue({
+            data: ens,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
         render(createTestComponent({ address }));
 
         expect(
@@ -217,6 +249,67 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
         ).toBeInTheDocument();
     });
 
+    it('renders bio and ENS links when records are present', () => {
+        useEnsNameSpy.mockReturnValue({
+            data: 'member.eth',
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
+        useEnsRecordsSpy.mockReturnValue({
+            data: {
+                [ENS_RECORD_KEYS.description]: 'Delegate bio',
+                [ENS_RECORD_KEYS.url]: 'example.com',
+                [ENS_RECORD_KEYS.twitter]: 'member_handle',
+                [ENS_RECORD_KEYS.github]: 'member-dev',
+            },
+            isLoading: false,
+        } as unknown as ReturnType<typeof ensModule.useEnsRecords>);
+
+        render(createTestComponent());
+
+        expect(screen.getByText('Delegate bio')).toBeInTheDocument();
+        expect(
+            screen.getByText(/daoMemberDetailsPage.aside.links.title/),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('link', {
+                name: /daoMemberDetailsPage.aside.links.website/,
+            }),
+        ).toHaveAttribute('href', 'https://example.com/');
+        expect(
+            screen.getByRole('link', {
+                name: /daoMemberDetailsPage.aside.links.twitter/,
+            }),
+        ).toHaveAttribute('href', 'https://x.com/member_handle');
+        expect(
+            screen.getByRole('link', {
+                name: /daoMemberDetailsPage.aside.links.github/,
+            }),
+        ).toHaveAttribute('href', 'https://github.com/member-dev');
+    });
+
+    it('does not render the links card when no ENS links are available', () => {
+        useEnsNameSpy.mockReturnValue({
+            data: 'member.eth',
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
+        useEnsRecordsSpy.mockReturnValue({
+            data: {
+                [ENS_RECORD_KEYS.description]: 'Delegate bio',
+                [ENS_RECORD_KEYS.url]: null,
+                [ENS_RECORD_KEYS.twitter]: null,
+                [ENS_RECORD_KEYS.github]: null,
+            },
+            isLoading: false,
+        } as unknown as ReturnType<typeof ensModule.useEnsRecords>);
+
+        render(createTestComponent());
+
+        expect(screen.getByText('Delegate bio')).toBeInTheDocument();
+        expect(
+            screen.queryByText(/daoMemberDetailsPage.aside.links.title/),
+        ).not.toBeInTheDocument();
+    });
+
     it('passes the correct params to the DaoList component', () => {
         const plugin = generateDaoPlugin({
             address: 'plugin-address',
@@ -227,7 +320,7 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
             plugins: [plugin],
         });
         const address = '0x1234567890123456789012345678901234567890';
-        const member = generateMember({ ens: 'member.eth', address });
+        const member = generateMember({ address });
         const pageSize = 3;
         const excludeDaoId = dao.id;
 
@@ -237,6 +330,10 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
         useDaoSpy.mockReturnValue(
             generateReactQueryResultSuccess({ data: dao }),
         );
+        useEnsNameSpy.mockReturnValue({
+            data: 'member.eth',
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
 
         render(
             createTestComponent({

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
@@ -9,9 +9,16 @@ import {
     MemberAvatar,
 } from '@aragon/gov-ui-kit';
 import { useBlock } from 'wagmi';
+import {
+    ENS_RECORD_KEYS,
+    useEnsAvatar,
+    useEnsName,
+    useEnsRecords,
+} from '@/modules/ens';
 import { DaoList } from '@/modules/explore/components/daoList';
 import { useEfpStats } from '@/modules/governance/api/efpService';
 import { EfpCard } from '@/modules/governance/components/efpCard';
+import { MemberLinksCard } from '@/modules/governance/components/memberLinksCard';
 import { useDao } from '@/shared/api/daoService';
 import { Page } from '@/shared/components/page';
 import type { IPageHeaderStat } from '@/shared/components/page/pageHeader/pageHeaderStat';
@@ -156,13 +163,21 @@ export const DaoMemberDetailsPageClient: React.FC<
         },
     ];
 
+    const { data: ensName } = useEnsName(address);
+    const { data: ensAvatar } = useEnsAvatar(ensName);
+    const { data: ensRecords } = useEnsRecords(ensName);
+    const memberLinks = {
+        github: ensRecords?.[ENS_RECORD_KEYS.github],
+        twitter: ensRecords?.[ENS_RECORD_KEYS.twitter],
+        url: ensRecords?.[ENS_RECORD_KEYS.url],
+    };
+
     if (member == null || dao == null || bodyPlugin == null) {
         return null;
     }
 
-    const { ens } = member;
     const truncatedAddress = addressUtils.truncateAddress(address);
-    const memberName = ens ?? truncatedAddress;
+    const memberName = ensName ?? truncatedAddress;
 
     const addressUrl = buildEntityUrl({
         type: ChainEntityType.ADDRESS,
@@ -214,11 +229,13 @@ export const DaoMemberDetailsPageClient: React.FC<
                 avatar={
                     <MemberAvatar
                         address={address}
-                        ensName={ens ?? undefined}
+                        avatarSrc={ensAvatar ?? undefined}
+                        ensName={ensName ?? undefined}
                         size="2xl"
                     />
                 }
                 breadcrumbs={pageBreadcrumbs}
+                description={ensRecords?.description ?? undefined}
                 stats={stats}
                 title={memberName}
             />
@@ -270,15 +287,15 @@ export const DaoMemberDetailsPageClient: React.FC<
                             >
                                 {truncatedAddress}
                             </DefinitionList.Item>
-                            {ens && addressUrl && (
+                            {ensName && addressUrl && (
                                 <DefinitionList.Item
-                                    copyValue={ens}
+                                    copyValue={ensName}
                                     link={{ href: addressUrl }}
                                     term={t(
                                         'app.governance.daoMemberDetailsPage.aside.details.ens',
                                     )}
                                 >
-                                    {ens}
+                                    {ensName}
                                 </DefinitionList.Item>
                             )}
                             <DefinitionList.Item
@@ -290,6 +307,21 @@ export const DaoMemberDetailsPageClient: React.FC<
                             </DefinitionList.Item>
                         </DefinitionList.Container>
                     </Page.AsideCard>
+                    {(memberLinks.url ||
+                        memberLinks.twitter ||
+                        memberLinks.github) && (
+                        <Page.AsideCard
+                            title={t(
+                                'app.governance.daoMemberDetailsPage.aside.links.title',
+                            )}
+                        >
+                            <MemberLinksCard
+                                github={memberLinks.github}
+                                twitter={memberLinks.twitter}
+                                url={memberLinks.url}
+                            />
+                        </Page.AsideCard>
+                    )}
                     {efpStats && (
                         <Page.AsideCard
                             icon={EfpLogo as string}

--- a/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.tsx
@@ -18,6 +18,7 @@ import {
     useGukModulesContext,
 } from '@aragon/gov-ui-kit';
 import { useQueryClient } from '@tanstack/react-query';
+import { useEnsName } from '@/modules/ens';
 import { ProposalExecutionStatus } from '@/modules/governance/components/proposalExecutionStatus';
 import { proposalActionsImportExportUtils } from '@/modules/governance/utils/proposalActionsImportExportUtils';
 import { AragonBackendServiceError } from '@/shared/api/aragonBackendService';
@@ -128,6 +129,8 @@ export const DaoProposalDetailsPageClient: React.FC<
         isError: hasSimulationFailed,
     } = useSimulateProposal();
 
+    const { data: creatorEnsName } = useEnsName(proposal?.creator.address);
+
     if (proposal == null || dao == null) {
         return null;
     }
@@ -196,7 +199,7 @@ export const DaoProposalDetailsPageClient: React.FC<
     );
 
     const creatorName =
-        creator.ens ?? addressUtils.truncateAddress(creator.address);
+        creatorEnsName ?? addressUtils.truncateAddress(creator.address);
 
     const creatorLink = buildEntityUrl({
         type: ChainEntityType.ADDRESS,
@@ -409,7 +412,7 @@ export const DaoProposalDetailsPageClient: React.FC<
                                 </p>
                             </DefinitionList.Item>
                             <DefinitionList.Item
-                                copyValue={creator.ens ?? creator.address}
+                                copyValue={creatorEnsName ?? creator.address}
                                 link={{ href: creatorLink }}
                                 term={t(
                                     'app.governance.daoProposalDetailsPage.aside.details.creator',

--- a/src/plugins/multisigPlugin/components/multisigVoteList/multisigVoteList.tsx
+++ b/src/plugins/multisigPlugin/components/multisigVoteList/multisigVoteList.tsx
@@ -5,8 +5,10 @@ import {
     DataListPagination,
     DataListRoot,
     VoteDataListItem,
+    type VoteIndicator,
     VoteProposalDataListItem,
 } from '@aragon/gov-ui-kit';
+import { useEnsAvatar, useEnsName } from '@/modules/ens';
 import type { IGetVoteListParams } from '@/modules/governance/api/governanceService';
 import {
     type IVoteListProps,
@@ -69,23 +71,41 @@ export const MultisigVoteList: React.FC<IMultisigVoteListProps> = (props) => {
                             voteIndicator={votingIndicator}
                         />
                     ) : (
-                        <VoteDataListItem.Structure
-                            href={daoUtils.getDaoUrl(
-                                dao,
-                                `members/${vote.member.address}`,
-                            )}
+                        <MultisigVoteItem
+                            dao={dao}
                             key={vote.transactionHash}
+                            vote={vote}
                             voteIndicator={votingIndicator}
-                            voter={{
-                                address: vote.member.address,
-                                avatarSrc: vote.member.avatar ?? undefined,
-                                name: vote.member.ens ?? undefined,
-                            }}
                         />
                     );
                 })}
             </DataListContainer>
             <DataListPagination />
         </DataListRoot>
+    );
+};
+
+/**
+ * Wrapper for a single vote item that resolves the voter's ENS name.
+ */
+const MultisigVoteItem: React.FC<{
+    vote: IMultisigVote;
+    dao: ReturnType<typeof useDao>['data'];
+    voteIndicator: VoteIndicator;
+}> = (props) => {
+    const { vote, dao, voteIndicator } = props;
+    const { data: ensName } = useEnsName(vote.member.address);
+    const { data: ensAvatar } = useEnsAvatar(ensName);
+
+    return (
+        <VoteDataListItem.Structure
+            href={daoUtils.getDaoUrl(dao, `members/${vote.member.address}`)}
+            voteIndicator={voteIndicator}
+            voter={{
+                address: vote.member.address,
+                avatarSrc: ensAvatar ?? undefined,
+                name: ensName ?? undefined,
+            }}
+        />
     );
 };

--- a/src/plugins/sppPlugin/components/sppProposalListItem/sppProposalListItem.tsx
+++ b/src/plugins/sppPlugin/components/sppProposalListItem/sppProposalListItem.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ProposalDataListItem } from '@aragon/gov-ui-kit';
+import { useEnsName } from '@/modules/ens';
 import type { IDaoProposalListDefaultItemProps } from '@/modules/governance/components/daoProposalList';
 import { proposalUtils } from '@/modules/governance/utils/proposalUtils';
 import { sppProposalUtils } from '@/plugins/sppPlugin/utils/sppProposalUtils';
@@ -39,6 +40,7 @@ export const SppProposalListItem: React.FC<ISppProposalListItemProps> = (
 
     const proposalLink = proposalUtils.getProposalUrl(proposal, dao);
     const publisherLink = daoUtils.getDaoUrl(dao, `members/${creator.address}`);
+    const { data: publisherEnsName } = useEnsName(creator.address);
 
     return (
         <ProposalDataListItem.Structure
@@ -49,7 +51,7 @@ export const SppProposalListItem: React.FC<ISppProposalListItemProps> = (
             key={id}
             publisher={{
                 address: creator.address,
-                name: creator.ens ?? undefined,
+                name: publisherEnsName ?? undefined,
                 link: publisherLink,
             }}
             status={proposalStatus}

--- a/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppVotingTerminalMultiBodySummaryDefault.tsx
+++ b/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppVotingTerminalMultiBodySummaryDefault.tsx
@@ -1,8 +1,6 @@
 import { addressUtils, ProposalStatus } from '@aragon/gov-ui-kit';
 import classNames from 'classnames';
-import type { Hex } from 'viem';
-import { mainnet } from 'viem/chains';
-import { useEnsName } from 'wagmi';
+import { useEnsName } from '@/modules/ens';
 import type { ISppProposal, ISppStage } from '@/plugins/sppPlugin/types';
 import { sppProposalUtils } from '@/plugins/sppPlugin/utils/sppProposalUtils';
 import { sppStageUtils } from '@/plugins/sppPlugin/utils/sppStageUtils';
@@ -33,10 +31,7 @@ export const SppVotingTerminalMultiBodySummaryDefault: React.FC<
     const { proposal, body, stage, canVote } = props;
 
     const { t } = useTranslations();
-    const { data: ensName } = useEnsName({
-        address: body as Hex,
-        chainId: mainnet.id,
-    });
+    const { data: ensName } = useEnsName(body);
 
     const stageStatus = sppStageUtils.getStageStatus(proposal, stage);
     const displayName = ensName ?? addressUtils.truncateAddress(body);

--- a/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppVotingTerminalStageBodyContent.tsx
+++ b/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppVotingTerminalStageBodyContent.tsx
@@ -3,8 +3,7 @@ import {
     ProposalVoting,
     ProposalVotingTab,
 } from '@aragon/gov-ui-kit';
-import type { Hex } from 'viem';
-import { useEnsName } from 'wagmi';
+import { useEnsName } from '@/modules/ens';
 import { brandedExternals } from '@/plugins/sppPlugin/constants/sppPluginBrandedExternals';
 import type { ISppProposal, ISppStage, ISppStagePlugin } from '../../../types';
 import { sppStageUtils } from '../../../utils/sppStageUtils';
@@ -39,7 +38,7 @@ export const SppVotingTerminalStageBodyContent: React.FC<
 > = (props) => {
     const { plugin, stage, proposal, daoId, displayStatus } = props;
 
-    const { data: pluginEns } = useEnsName({ address: plugin.address as Hex });
+    const { data: pluginEns } = useEnsName(plugin.address);
 
     const status = sppStageUtils.getStageStatus(proposal, stage);
 

--- a/src/plugins/sppPlugin/hooks/useSppGovernanceSettingsDefault/useSppGovernanceSettingsDefault.ts
+++ b/src/plugins/sppPlugin/hooks/useSppGovernanceSettingsDefault/useSppGovernanceSettingsDefault.ts
@@ -1,7 +1,5 @@
 import { ChainEntityType } from '@aragon/gov-ui-kit';
-import type { Hex } from 'viem';
-import { mainnet } from 'viem/chains';
-import { useEnsName } from 'wagmi';
+import { useEnsName } from '@/modules/ens';
 import type { IUseGovernanceSettingsParams } from '@/modules/settings/types';
 import { useDao } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
@@ -21,10 +19,7 @@ export const useSppGovernanceSettingsDefault = (
 
     const { buildEntityUrl } = useDaoChain({ network: dao?.network });
 
-    const { data: bodyName } = useEnsName({
-        address: pluginAddress as Hex,
-        chainId: mainnet.id,
-    });
+    const { data: bodyName } = useEnsName(pluginAddress);
     const url = buildEntityUrl({
         type: ChainEntityType.ADDRESS,
         id: pluginAddress,

--- a/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.test.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.test.tsx
@@ -1,5 +1,6 @@
 import { GukModulesProvider } from '@aragon/gov-ui-kit';
 import { render, screen } from '@testing-library/react';
+import * as ensModule from '@/modules/ens';
 import {
     generateTokenMember,
     generateTokenPluginSettings,
@@ -19,15 +20,27 @@ import {
 
 describe('<TokenMemberListItem /> component', () => {
     const useDaoSpy = jest.spyOn(daoService, 'useDao');
+    const useEnsNameSpy = jest.spyOn(ensModule, 'useEnsName');
+    const useEnsAvatarSpy = jest.spyOn(ensModule, 'useEnsAvatar');
 
     beforeEach(() => {
         useDaoSpy.mockReturnValue(
             generateReactQueryResultSuccess({ data: generateDao() }),
         );
+        useEnsNameSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
+        useEnsAvatarSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsAvatar>);
     });
 
     afterEach(() => {
         useDaoSpy.mockReset();
+        useEnsNameSpy.mockReset();
+        useEnsAvatarSpy.mockReset();
     });
 
     const createTestComponent = (
@@ -50,12 +63,17 @@ describe('<TokenMemberListItem /> component', () => {
     };
 
     it('renders the token member', () => {
+        const ensName = 'tttt.eth';
         const member = generateTokenMember({
             ens: 'tttt.eth',
             address: '0x123',
         });
+        useEnsNameSpy.mockReturnValue({
+            data: ensName,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
         render(createTestComponent({ member }));
-        expect(screen.getByText(member.ens!)).toBeInTheDocument();
+        expect(screen.getByText(ensName)).toBeInTheDocument();
     });
 
     it('retrieves the plugin settings to parse the member voting power using the decimals of the governance token', () => {

--- a/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.tsx
@@ -1,5 +1,6 @@
 import { MemberDataListItem } from '@aragon/gov-ui-kit';
 import { formatUnits } from 'viem';
+import { useEnsAvatar, useEnsName } from '@/modules/ens';
 import type { ITokenMember } from '@/plugins/tokenPlugin/types';
 import { type IDaoPlugin, useDao } from '@/shared/api/daoService';
 import { bigIntUtils } from '@/shared/utils/bigIntUtils';
@@ -36,12 +37,15 @@ export const TokenMemberListItem: React.FC<ITokenMemberListItemProps> = (
         tokenDecimals,
     );
     const { data: dao } = useDao({ urlParams: { id: daoId } });
+    const { data: ensName } = useEnsName(member.address);
+    const { data: ensAvatar } = useEnsAvatar(ensName);
 
     return (
         <MemberDataListItem.Structure
             address={member.address}
+            avatarSrc={ensAvatar ?? undefined}
             className="min-w-0"
-            ensName={member.ens ?? undefined}
+            ensName={ensName ?? undefined}
             href={daoUtils.getDaoUrl(dao, `members/${member.address}`)}
             isDelegate={isDelegate}
             key={member.address}

--- a/src/plugins/tokenPlugin/components/tokenVoteList/tokenVoteList.tsx
+++ b/src/plugins/tokenPlugin/components/tokenVoteList/tokenVoteList.tsx
@@ -9,6 +9,7 @@ import {
     VoteProposalDataListItem,
 } from '@aragon/gov-ui-kit';
 import { formatUnits } from 'viem';
+import { useEnsAvatar, useEnsName } from '@/modules/ens';
 import type { IGetVoteListParams } from '@/modules/governance/api/governanceService';
 import type { IVoteListProps } from '@/modules/governance/components/voteList';
 import { VoteProposalListItem } from '@/modules/governance/components/voteList';
@@ -82,30 +83,53 @@ export const TokenVoteList: React.FC<ITokenVoteListProps> = (props) => {
                             voteIndicator={voteIndicator}
                         />
                     ) : (
-                        <VoteDataListItem.Structure
-                            href={daoUtils.getDaoUrl(
-                                dao,
-                                `members/${vote.member.address}`,
-                            )}
+                        <TokenVoteItem
+                            dao={dao}
                             isVeto={isVeto}
                             key={vote.transactionHash}
-                            tokenSymbol={vote.token.symbol}
+                            vote={vote}
                             voteIndicator={voteIndicator}
                             voteIndicatorDescription={voteIndicatorDescription}
-                            voter={{
-                                address: vote.member.address,
-                                avatarSrc: vote.member.avatar ?? undefined,
-                                name: vote.member.ens ?? undefined,
-                            }}
-                            votingPower={formatUnits(
-                                BigInt(vote.votingPower),
-                                vote.token.decimals,
-                            )}
                         />
                     );
                 })}
             </DataListContainer>
             <DataListPagination />
         </DataListRoot>
+    );
+};
+
+/**
+ * Wrapper for a single vote item that resolves the voter's ENS name.
+ */
+const TokenVoteItem: React.FC<{
+    vote: ITokenVote;
+    dao: ReturnType<typeof useDao>['data'];
+    voteIndicator: VoteIndicator;
+    voteIndicatorDescription?: string;
+    isVeto?: boolean;
+}> = (props) => {
+    const { vote, dao, voteIndicator, voteIndicatorDescription, isVeto } =
+        props;
+    const { data: ensName } = useEnsName(vote.member.address);
+    const { data: ensAvatar } = useEnsAvatar(ensName);
+
+    return (
+        <VoteDataListItem.Structure
+            href={daoUtils.getDaoUrl(dao, `members/${vote.member.address}`)}
+            isVeto={isVeto}
+            tokenSymbol={vote.token.symbol}
+            voteIndicator={voteIndicator}
+            voteIndicatorDescription={voteIndicatorDescription}
+            voter={{
+                address: vote.member.address,
+                avatarSrc: ensAvatar ?? undefined,
+                name: ensName ?? undefined,
+            }}
+            votingPower={formatUnits(
+                BigInt(vote.votingPower),
+                vote.token.decimals,
+            )}
+        />
     );
 };

--- a/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.test.tsx
+++ b/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.test.tsx
@@ -3,8 +3,8 @@ import { render } from '@testing-library/react';
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import { useRouter } from 'next/navigation';
 import type { ReactElement } from 'react';
-import { mainnet } from 'viem/chains';
 import * as wagmi from 'wagmi';
+import * as ensModule from '@/modules/ens';
 import { Network } from '@/shared/api/daoService';
 import {
     type ITransactionDialogProps,
@@ -28,16 +28,22 @@ jest.mock('next/navigation', () => ({
 
 describe('<TokenDelegationDialog /> component', () => {
     const useConnectionSpy = jest.spyOn(wagmi, 'useConnection');
-    const useEnsNameSpy = jest.spyOn(wagmi, 'useEnsName');
+    const useEnsNameSpy = jest.spyOn(ensModule, 'useEnsName');
+    const useEnsAvatarSpy = jest.spyOn(ensModule, 'useEnsAvatar');
     const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
 
     beforeEach(() => {
         useConnectionSpy.mockReturnValue({
             address: '0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5',
         } as unknown as wagmi.UseConnectionReturnType);
-        useEnsNameSpy.mockReturnValue(
-            {} as unknown as wagmi.UseEnsNameReturnType,
-        );
+        useEnsNameSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
+        useEnsAvatarSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsAvatar>);
         useRouterMock.mockReturnValue({
             back: jest.fn(),
             forward: jest.fn(),
@@ -51,6 +57,7 @@ describe('<TokenDelegationDialog /> component', () => {
     afterEach(() => {
         useConnectionSpy.mockReset();
         useEnsNameSpy.mockReset();
+        useEnsAvatarSpy.mockReset();
         useRouterMock.mockReset();
         (TransactionDialog as jest.Mock).mockReset();
     });
@@ -94,16 +101,12 @@ describe('<TokenDelegationDialog /> component', () => {
         const delegateEnsName = 'delegate.eth';
         useEnsNameSpy.mockReturnValue({
             data: delegateEnsName,
-        } as unknown as wagmi.UseEnsNameReturnType);
+            isLoading: false,
+        } as ReturnType<typeof ensModule.useEnsName>);
 
         render(createTestComponent({ location }));
 
-        expect(useEnsNameSpy).toHaveBeenCalledWith(
-            expect.objectContaining({
-                address: location.params.delegate,
-                chainId: mainnet.id,
-            }),
-        );
+        expect(useEnsNameSpy).toHaveBeenCalledWith(location.params.delegate);
         expect(getDelegateProps()).toEqual(
             expect.objectContaining({
                 address: location.params.delegate,
@@ -114,10 +117,6 @@ describe('<TokenDelegationDialog /> component', () => {
     });
 
     it('passes undefined ENS name when no ENS is resolved', () => {
-        useEnsNameSpy.mockReturnValue({
-            data: null,
-        } as unknown as wagmi.UseEnsNameReturnType);
-
         render(createTestComponent({ location }));
 
         expect(getDelegateProps()).toEqual(

--- a/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.tsx
+++ b/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.tsx
@@ -2,9 +2,9 @@
 
 import { invariant, MemberDataListItem } from '@aragon/gov-ui-kit';
 import { useRouter } from 'next/navigation';
-import { type Hex, zeroAddress } from 'viem';
-import { mainnet } from 'viem/chains';
-import { useConnection, useEnsName } from 'wagmi';
+import { zeroAddress } from 'viem';
+import { useConnection } from 'wagmi';
+import { useEnsAvatar, useEnsName } from '@/modules/ens';
 import type { Network } from '@/shared/api/daoService';
 import type { IDialogComponentProps } from '@/shared/components/dialogProvider';
 import {
@@ -60,10 +60,8 @@ export const TokenDelegationDialog: React.FC<ITokenDelegationDialogProps> = (
         network,
         onSuccessClick,
     } = location.params;
-    const { data: delegateEnsName } = useEnsName({
-        address: delegate as Hex,
-        chainId: mainnet.id,
-    });
+    const { data: delegateEnsName } = useEnsName(delegate);
+    const { data: delegateEnsAvatar } = useEnsAvatar(delegateEnsName);
 
     const { t } = useTranslations();
     const router = useRouter();
@@ -103,6 +101,7 @@ export const TokenDelegationDialog: React.FC<ITokenDelegationDialogProps> = (
         >
             <MemberDataListItem.Structure
                 address={delegate}
+                avatarSrc={delegateEnsAvatar ?? undefined}
                 ensName={delegateEnsName ?? undefined}
                 isDelegate={true}
             />

--- a/src/shared/security/index.ts
+++ b/src/shared/security/index.ts
@@ -5,3 +5,4 @@ export {
     sanitizePlainText,
     sanitizePlainTextMultiline,
 } from './htmlSanitizer';
+export { sanitizeExternalHttpUrl } from './sanitizeExternalUrl';

--- a/src/shared/security/sanitizeExternalUrl.test.ts
+++ b/src/shared/security/sanitizeExternalUrl.test.ts
@@ -1,0 +1,55 @@
+import { sanitizeExternalHttpUrl } from './sanitizeExternalUrl';
+
+describe('sanitizeExternalHttpUrl', () => {
+    it('accepts bare domains by normalizing them to https', () => {
+        expect(sanitizeExternalHttpUrl('example.com')).toBe(
+            'https://example.com/',
+        );
+    });
+
+    it('accepts https URLs', () => {
+        expect(sanitizeExternalHttpUrl('https://example.com')).toBe(
+            'https://example.com/',
+        );
+    });
+
+    it('accepts http URLs', () => {
+        expect(sanitizeExternalHttpUrl('http://example.com')).toBe(
+            'http://example.com/',
+        );
+    });
+
+    it('preserves path and query string', () => {
+        expect(sanitizeExternalHttpUrl('https://example.com/page?q=1')).toBe(
+            'https://example.com/page?q=1',
+        );
+    });
+
+    it('accepts URLs with query string without protocol', () => {
+        expect(sanitizeExternalHttpUrl('example.com/page?q=1')).toBe(
+            'https://example.com/page?q=1',
+        );
+    });
+
+    it('rejects javascript: protocol', () => {
+        expect(sanitizeExternalHttpUrl('javascript:alert(1)')).toBeNull();
+    });
+
+    it('rejects data: protocol', () => {
+        expect(
+            sanitizeExternalHttpUrl('data:text/html,<h1>XSS</h1>'),
+        ).toBeNull();
+    });
+
+    it('rejects protocol-relative javascript payloads after normalization', () => {
+        expect(sanitizeExternalHttpUrl('//javascript:alert(1)')).toBeNull();
+    });
+
+    it('rejects malformed URLs', () => {
+        expect(sanitizeExternalHttpUrl('not-a-url')).toBeNull();
+    });
+
+    it('rejects empty string', () => {
+        expect(sanitizeExternalHttpUrl('')).toBeNull();
+    });
+});

--- a/src/shared/security/sanitizeExternalUrl.ts
+++ b/src/shared/security/sanitizeExternalUrl.ts
@@ -1,0 +1,22 @@
+import { urlUtils } from '@aragon/gov-ui-kit';
+
+/**
+ * Normalizes a website URL using the shared UI kit utility and only allows
+ * absolute HTTP(S) targets.
+ */
+export function sanitizeExternalHttpUrl(url: string): string | null {
+    const normalized = urlUtils.normalizeExternalHref(url);
+    if (normalized == null) {
+        return null;
+    }
+
+    try {
+        const parsed = new URL(normalized);
+        if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+            return parsed.href;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}


### PR DESCRIPTION
# Description

- Add  module as single source of truth for ENS name, avatar, and text record resolution (bio, website, X, GitHub)
- Migrate all ~15 consumer components from wagmi direct imports to module hooks (useEnsName, useEnsAvatar, useEnsRecords)
- Enable viem batch.multicall on wagmi client so list views resolve ENS in a single RPC call instead of N
- Add biome lint rule to prevent direct wagmi ENS imports
- Add MemberLinksCard component for ENS links on member profile
- Add ENS bio (description) to member profile page header
- Deprecate IMember.ens backend field in favour of real-time resolution
- Deduplicate biome.json TypeScript overrides

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [x] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
