### PR TITLE
fix(APP-579): Remove inaccurate 'You' pinned member on multisig lists

### DIFF
--- a/.changeset/cozy-clowns-lie.md
+++ b/.changeset/cozy-clowns-lie.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix innaccurate 'You' member showing on multisig for connected wallets

--- a/src/modules/governance/components/daoMemberList/daoMemberListDefault.test.tsx
+++ b/src/modules/governance/components/daoMemberList/daoMemberListDefault.test.tsx
@@ -24,6 +24,7 @@ describe('<DaoMemberListDefault /> component', () => {
     const useDaoSpy = jest.spyOn(daoService, 'useDao');
     const useConnectionSpy = jest.spyOn(wagmi, 'useConnection');
     const useMemberSpy = jest.spyOn(governanceService, 'useMember');
+    const useMemberExistsSpy = jest.spyOn(governanceService, 'useMemberExists');
 
     beforeEach(() => {
         useMemberListDataSpy.mockReturnValue({
@@ -46,6 +47,9 @@ describe('<DaoMemberListDefault /> component', () => {
                 data: undefined as unknown as IMember,
             }),
         );
+        useMemberExistsSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: { status: false } }),
+        );
     });
 
     afterEach(() => {
@@ -53,6 +57,7 @@ describe('<DaoMemberListDefault /> component', () => {
         useDaoSpy.mockReset();
         useConnectionSpy.mockReset();
         useMemberSpy.mockReset();
+        useMemberExistsSpy.mockReset();
     });
 
     const createTestComponent = (
@@ -130,6 +135,10 @@ describe('<DaoMemberListDefault /> component', () => {
             address: userAddress,
         } as unknown as wagmi.UseConnectionReturnType);
 
+        useMemberExistsSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: { status: true } }),
+        );
+
         useMemberListDataSpy.mockReturnValue({
             memberList: [otherMember, userMember],
             onLoadMore: jest.fn(),
@@ -204,6 +213,10 @@ describe('<DaoMemberListDefault /> component', () => {
         useConnectionSpy.mockReturnValue({
             address: userAddress,
         } as unknown as wagmi.UseConnectionReturnType);
+
+        useMemberExistsSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: { status: true } }),
+        );
 
         useMemberListDataSpy.mockReturnValue({
             memberList: [otherMember, userMember],

--- a/src/modules/governance/components/daoMemberList/daoMemberListDefault.tsx
+++ b/src/modules/governance/components/daoMemberList/daoMemberListDefault.tsx
@@ -11,11 +11,15 @@ import type {
     IGetMemberListParams,
     IMember,
 } from '@/modules/governance/api/governanceService';
-import { useMember } from '@/modules/governance/api/governanceService';
+import {
+    useMember,
+    useMemberExists,
+} from '@/modules/governance/api/governanceService';
 import { useMemberListData } from '@/modules/governance/hooks/useMemberListData';
 import {
     type IDaoPlugin,
     type IPluginSettings,
+    type Network,
     useDao,
 } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
@@ -98,12 +102,25 @@ export const DaoMemberListDefault: React.FC<IDaoMemberListDefaultProps> = (
         memberList,
     } = useMemberListData(apiParams);
 
+    const { data: memberExists } = useMemberExists(
+        {
+            urlParams: {
+                memberAddress: connectedAddress ?? '',
+                pluginAddress: plugin.address,
+            },
+            queryParams: { network: dao?.network as Network },
+        },
+        { enabled: connectedAddress != null && dao?.network != null },
+    );
+
+    const isMember = memberExists?.status === true;
+
     const { data: connectedUserMember } = useMember(
         {
             urlParams: { address: connectedAddress ?? '' },
             queryParams: apiParams.queryParams,
         },
-        { enabled: connectedAddress != null },
+        { enabled: isMember },
     );
 
     const mergedMemberList = useMemo(() => {


### PR DESCRIPTION
# Description

Fixes [APP-579](https://linear.app/aragon/issue/APP-579): Connected users who are **not** members of a multisig or admin plugin were being falsely displayed in the member list.

PR #1043 introduced pinning logic in `DaoMemberListDefault` that called `useMember()` for the connected wallet and unconditionally pinned the result to the top of the list. The `getMember` API returns a response with the user's address regardless of actual plugin membership, so non-members were rendered as members.

The fix adds a `useMemberExists()` guard that checks the `/v2/members/:memberAddress/:pluginAddress/exists` endpoint before fetching member data. The `useMember` call is now gated on `isMember`, so non-members are never fetched or pinned.

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project