### PR TITLE
feat(APP-280): Enhance Sentry integration with third-party error filtering and deny URL patterns

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,17 +1,33 @@
 import * as Sentry from '@sentry/nextjs';
-import { replayIntegration } from '@sentry/nextjs';
+import {
+    replayIntegration,
+    thirdPartyErrorFilterIntegration,
+} from '@sentry/nextjs';
 import { monitoringUtils } from '@/shared/utils/monitoringUtils';
 
 Sentry.init({
     ...monitoringUtils.getBaseConfig(),
 
-    // Replay may only be enabled for the client-side
     integrations: [
         replayIntegration({
             // Self-host the replay web worker to comply to the strict CSP policies and avoid allowing worker-src: blob
             // (see https://docs.sentry.io/platforms/javascript/session-replay/configuration/#using-a-custom-compression-worker)
             workerUrl: '/web-workers/sentry-replay.min.js',
         }),
+        thirdPartyErrorFilterIntegration({
+            filterKeys: ['aragon-app'],
+            behaviour: 'apply-tag-if-exclusively-contains-third-party-frames', // TODO: change to drop-error-if-exclusively-contains-third-party-frames after testing
+        }),
+    ],
+
+    // Filter out errors from common browser extensions and injected scripts
+    denyUrls: [
+        /extensions\//i,
+        /^chrome:\/\//i,
+        /^chrome-extension:\/\//i,
+        /^moz-extension:\/\//i,
+        /^safari-extension:/i,
+        /^safari-web-extension:/i,
     ],
 
     replaysSessionSampleRate: 0,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -68,6 +68,10 @@ const sentryConfig = {
         : { deleteSourcemapsAfterUpload: true },
     // Disable sending data to Sentry
     telemetry: false,
+    // Mark first-party bundles for thirdPartyErrorFilterIntegration
+    _experimental: {
+        turbopackApplicationKey: 'aragon-app',
+    },
 };
 
 /** @type {import('next').NextConfig} */


### PR DESCRIPTION
# Description

- Added `thirdPartyErrorFilterIntegration` to filter errors from specific third-party frames.
- Updated `denyUrls` to exclude errors from common browser extensions and injected scripts.
- Configured `turbopackApplicationKey` for first-party bundles in the Next.js configuration.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
