### PR TITLE
chore: Harden pnpm configuration

### DIFF
--- a/.changeset/harden-pnpm-config.md
+++ b/.changeset/harden-pnpm-config.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Harden pnpm configuration with strictDepBuilds and trustPolicy settings

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ minimumReleaseAgeExclude: # https://pnpm.io/settings#minimumreleaseageexclude
     - "@next/*"
     - "next"
     - "undici"
+strictDepBuilds: true
+trustPolicy: no-downgrade


### PR DESCRIPTION
# Description

Hardens the pnpm workspace configuration based on recommendations from the [pnpm supply chain security newsroom article](https://pnpm.io/blog/2025/12/05/newsroom-npm-supply-chain-security).

Two settings added to `pnpm-workspace.yaml`:
- **`strictDepBuilds: true`** — prevents packages from running install scripts unless explicitly allowed
- **`trustPolicy: no-downgrade`** — prevents packages from being installed with a lower trust level than currently configured

## Type of Change

- [x] Patch: Enhancement (non-breaking change to an existing feature)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Confirmed that changes follow the code style guidelines of this project