### PR TITLE
fix: Pin SPP voting terminal Settings tab to proposal snapshot

### DIFF
--- a/.changeset/sparkly-pots-knock.md
+++ b/.changeset/sparkly-pots-knock.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Pin SPP voting terminal Settings tab to the proposal snapshot so it agrees with the Breakdown tab on per-proposal settings (e.g. quorum threshold).

--- a/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppVotingTerminalBodyContent.tsx
+++ b/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppVotingTerminalBodyContent.tsx
@@ -63,7 +63,9 @@ export const SppVotingTerminalBodyContent: React.FC<
     const isExternalBody = plugin.interfaceType == null;
     const isVeto = sppStageUtils.isVeto(stage);
 
-    const pluginSettings = isExternalBody ? {} : plugin.settings;
+    const pluginSettings = isExternalBody
+        ? {}
+        : (subProposal?.settings ?? plugin.settings);
     const settings = useSlotSingleFunction<
         IUseGovernanceSettingsParams,
         IDefinitionSetting[]


### PR DESCRIPTION
## What

Pin the SPP voting terminal Settings tab to the proposal snapshot (`subProposal.settings`) so it agrees with the Breakdown tab on per-proposal settings.

## Why

Without the pin, the Settings tab reads live `plugin.settings` while the Breakdown tab reads `subProposal.settings`. For DAOs whose plugin settings have drifted since proposal creation, the two tabs show different quorum thresholds for the same proposal — confusing for voters and wrong for any historical proposal.

## Where this fans out

- [APP-619](https://linear.app/aragon/issue/APP-619) — Cryptex's wrong-total-supply root cause (`token.totalSupply` inheriting from the underlying ERC20 instead of the iVotesAdapter) is fixed at the source by [BE-221](https://linear.app/aragon/issue/BE-221) / aragon/app-backend#1298. This PR is the cross-tab consistency piece needed to fully close APP-619.
- [APP-628](https://linear.app/aragon/issue/APP-628) — Lock-to-vote needs the participation denominator computed from live total supply (Steakhouse-reported). Tracked separately; needs a backend or contract decision before any further frontend change.

## Verification

Cryptex CIP-1 on dev with BE-221 backend included:
- Settings tab: ≥ 3.00% (≥ 19.32K CTX)
- Breakdown tab: 544.62K of 19.32K CTX (2,818.5%)
- Both tabs agree, sourced from the adapter's `getPastTotalSupply` snapshot at proposal-creation block. No console errors.

## Test plan

- [ ] Cryptex / any SPP proposal with drifted settings: Settings tab and Breakdown tab agree
- [ ] No regression on token-voting or lockToVote-only DAOs (no SPP)

[APP-619]: https://aragonassociation.atlassian.net/browse/APP-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-628]: https://aragonassociation.atlassian.net/browse/APP-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ