### PR TITLE
fix(APP-648): Strip hop-by-hop headers from proxied backend requests

### DIFF
--- a/.changeset/fix-proxy-hop-by-hop-headers.md
+++ b/.changeset/fix-proxy-hop-by-hop-headers.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Strip hop-by-hop headers from proxied backend requests

--- a/src/modules/application/utils/proxyBackendUtils/proxyBackendUtils.test.ts
+++ b/src/modules/application/utils/proxyBackendUtils/proxyBackendUtils.test.ts
@@ -63,6 +63,25 @@ describe('proxyBackend utils', () => {
             expect(result.status).toEqual(204);
         });
 
+        it('does not forward hop-by-hop headers to upstream fetch', async () => {
+            const inboundHeaders = new Headers({
+                'transfer-encoding': 'chunked',
+                'keep-alive': 'timeout=5',
+                connection: 'keep-alive',
+                'content-type': 'text/plain',
+            });
+
+            await proxyBackendUtils.request(
+                generateNextRequest({ headers: inboundHeaders }),
+            );
+
+            const request = fetchSpy.mock.calls[0][1] as NextRequest;
+            expect(request.headers.get('transfer-encoding')).toBeNull();
+            expect(request.headers.get('keep-alive')).toBeNull();
+            expect(request.headers.get('connection')).toBeNull();
+            expect(request.headers.get('content-type')).toBe('text/plain');
+        });
+
         it('appends the authorization header when set', async () => {
             const apiKey = 'test-api-key-123';
             process.env.NEXT_SECRET_ARAGON_BACKEND_API_KEY = apiKey;

--- a/src/modules/application/utils/proxyBackendUtils/proxyBackendUtils.ts
+++ b/src/modules/application/utils/proxyBackendUtils/proxyBackendUtils.ts
@@ -62,10 +62,14 @@ export class ProxyBackendUtils {
         'proxy-authenticate',
         'proxy-authorization',
         'te',
+        'trailer',
         'trailers',
         'transfer-encoding',
         'upgrade',
         'host',
+        // Body is re-read as text so Node recomputes length; strip the
+        // original to prevent a stale value confusing undici.
+        'content-length',
     ];
 
     private buildRequestOptions = async (

--- a/src/modules/application/utils/proxyBackendUtils/proxyBackendUtils.ts
+++ b/src/modules/application/utils/proxyBackendUtils/proxyBackendUtils.ts
@@ -55,6 +55,19 @@ export class ProxyBackendUtils {
         return url;
     };
 
+    // Headers that must not be forwarded to the upstream server as per RFC 7230.
+    private readonly hopByHopHeaders = [
+        'connection',
+        'keep-alive',
+        'proxy-authenticate',
+        'proxy-authorization',
+        'te',
+        'trailers',
+        'transfer-encoding',
+        'upgrade',
+        'host',
+    ];
+
     private buildRequestOptions = async (
         request: NextRequest,
     ): Promise<RequestInit> => {
@@ -63,6 +76,10 @@ export class ProxyBackendUtils {
             method.toUpperCase() === 'POST' ? await request.text() : undefined;
 
         const processedHeaders = new Headers(headers);
+
+        for (const header of this.hopByHopHeaders) {
+            processedHeaders.delete(header);
+        }
 
         if (process.env.NEXT_SECRET_ARAGON_BACKEND_API_KEY) {
             processedHeaders.set(


### PR DESCRIPTION
# Description

Strips RFC 7230 hop-by-hop headers (`connection`, `keep-alive`, `proxy-authenticate`, `proxy-authorization`, `te`, `trailers`, `transfer-encoding`, `upgrade`, `host`) from requests before forwarding them to the upstream backend via the Next.js proxy route. Forwarding these headers can cause upstream servers to reject or mishandle requests.

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project