### PR TITLE
feat(APP-650): Add Linear release management steps to workflows

### DIFF
--- a/.github/workflows/app-production.yml
+++ b/.github/workflows/app-production.yml
@@ -119,6 +119,46 @@ jobs:
       env: "production"
       ref: ${{ github.event.release.tag_name || inputs.tag }}
 
+  linear-release:
+    needs: deploy
+    if: ${{ !cancelled() && needs.deploy.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: '${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+          LINEAR_PIPELINE_ACCESS_KEY: op://kv_app_infra/LINEAR_PIPELINE_ACCESS_KEY/credential
+
+      - name: Checkout
+        if: steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY != ''
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          fetch-depth: 0
+
+      - name: Linear — set stage to released
+        if: steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY != ''
+        continue-on-error: true
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY }}
+          command: update
+          name: ${{ github.event.release.tag_name || inputs.tag }}
+          stage: released
+
+      - name: Linear — complete release
+        if: steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY != ''
+        continue-on-error: true
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY }}
+          command: complete
+          name: ${{ github.event.release.tag_name || inputs.tag }}
+
   e2e:
     needs: deploy
     if: ${{ !cancelled() && needs.deploy.result == 'success' }}

--- a/.github/workflows/app-production.yml
+++ b/.github/workflows/app-production.yml
@@ -140,16 +140,6 @@ jobs:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
           fetch-depth: 0
 
-      - name: Linear — set stage to released
-        if: steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY != ''
-        continue-on-error: true
-        uses: linear/linear-release-action@v0
-        with:
-          access_key: ${{ steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY }}
-          command: update
-          name: ${{ github.event.release.tag_name || inputs.tag }}
-          stage: released
-
       - name: Linear — complete release
         if: steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY != ''
         continue-on-error: true
@@ -157,7 +147,7 @@ jobs:
         with:
           access_key: ${{ steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY }}
           command: complete
-          name: ${{ github.event.release.tag_name || inputs.tag }}
+          version: ${{ github.event.release.tag_name || inputs.tag }}
 
   e2e:
     needs: deploy

--- a/.github/workflows/app-release-v2.yml
+++ b/.github/workflows/app-release-v2.yml
@@ -29,6 +29,7 @@ jobs:
           SLACK_BOT_TOKEN: op://kv_app_infra/SLACK_BOT_TOKEN/credential
           SLACK_CHANNEL_ID: op://kv_app_infra/SLACK_CHANNEL_ID/credential
           LINEAR_API_TOKEN: op://kv_app_infra/LINEAR_API_TOKEN/credential
+          LINEAR_PIPELINE_ACCESS_KEY: op://kv_app_infra/LINEAR_PIPELINE_ACCESS_KEY/credential
 
       - name: Checkout actions
         uses: actions/checkout@v6.0.2
@@ -93,6 +94,25 @@ jobs:
           title: Release v${{ steps.package-version.outputs.current-version }}
           body: ${{ steps.release-summary.outputs.summary }}
           token: ${{ steps.load-secrets.outputs.ARABOT_PAT }}
+
+      - name: Linear — sync release & link issues
+        if: steps.load-secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY != ''
+        continue-on-error: true
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ steps.load-secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY }}
+          command: sync
+          name: v${{ steps.package-version.outputs.current-version }}
+
+      - name: Linear — set stage to in_progress
+        if: steps.load-secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY != ''
+        continue-on-error: true
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ steps.load-secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY }}
+          command: update
+          name: v${{ steps.package-version.outputs.current-version }}
+          stage: in_progress
 
       - name: Notify Slack
         id: slack

--- a/.github/workflows/app-release-v2.yml
+++ b/.github/workflows/app-release-v2.yml
@@ -103,6 +103,7 @@ jobs:
           access_key: ${{ steps.load-secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY }}
           command: sync
           name: v${{ steps.package-version.outputs.current-version }}
+          version: v${{ steps.package-version.outputs.current-version }}
 
       - name: Linear — set stage to in_progress
         if: steps.load-secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY != ''
@@ -111,7 +112,7 @@ jobs:
         with:
           access_key: ${{ steps.load-secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY }}
           command: update
-          name: v${{ steps.package-version.outputs.current-version }}
+          version: v${{ steps.package-version.outputs.current-version }}
           stage: in_progress
 
       - name: Notify Slack

--- a/.github/workflows/release-pr-cancel.yml
+++ b/.github/workflows/release-pr-cancel.yml
@@ -60,13 +60,14 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
 
       - name: Linear — set stage to canceled
+        id: linear-cancel
         if: steps.version.outputs.name != '' && steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY != ''
         continue-on-error: true
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY }}
           command: update
-          name: ${{ steps.version.outputs.name }}
+          version: ${{ steps.version.outputs.name }}
           stage: canceled
 
       - name: Notify Slack (cancelled)
@@ -76,4 +77,5 @@ jobs:
           slack_bot_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
           slack_channel_id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
           thread_ts: ${{ steps.ts.outputs.ts }}
-          message: 🛑 *Release cancelled* — Linear release moved to Canceled stage
+          message: |
+            🛑 *Release cancelled*${{ steps.linear-cancel.outcome == 'success' && ' — Linear release moved to Canceled stage' || '' }}

--- a/.github/workflows/release-pr-cancel.yml
+++ b/.github/workflows/release-pr-cancel.yml
@@ -25,6 +25,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: '${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
           SLACK_BOT_TOKEN: op://kv_app_infra/SLACK_BOT_TOKEN/credential
           SLACK_CHANNEL_ID: op://kv_app_infra/SLACK_CHANNEL_ID/credential
+          LINEAR_PIPELINE_ACCESS_KEY: op://kv_app_infra/LINEAR_PIPELINE_ACCESS_KEY/credential
 
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -50,6 +51,24 @@ jobs:
         with:
           body: ${{ steps.pr.outputs.body }}
 
+      - name: Extract version from PR title
+        id: version
+        run: |
+          VERSION=$(echo "${PR_TITLE}" | sed -nE 's/^Release (v[0-9]+\.[0-9]+\.[0-9]+).*$/\1/p')
+          echo "name=${VERSION}" >> "$GITHUB_OUTPUT"
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+
+      - name: Linear — set stage to canceled
+        if: steps.version.outputs.name != '' && steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY != ''
+        continue-on-error: true
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ steps.secrets.outputs.LINEAR_PIPELINE_ACCESS_KEY }}
+          command: update
+          name: ${{ steps.version.outputs.name }}
+          stage: canceled
+
       - name: Notify Slack (cancelled)
         if: steps.secrets.outputs.SLACK_BOT_TOKEN && steps.ts.outputs.ts
         uses: ./.github/actions/slack-notify
@@ -57,4 +76,4 @@ jobs:
           slack_bot_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
           slack_channel_id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
           thread_ts: ${{ steps.ts.outputs.ts }}
-          message: 🛑 *Release cancelled*
+          message: 🛑 *Release cancelled* — Linear release moved to Canceled stage


### PR DESCRIPTION

# Description

- Implemented a new job in app-production.yml to handle Linear release stages after deployment.
- Enhanced app-release-v2.yml to sync releases and link issues with Linear.
- Added cancellation handling in release-pr-cancel.yml to update Linear stage when a PR is canceled.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
