### PR TITLE
fix(APP-654): Update plugin visibility logic in useDaoPlugins hook

### DIFF
--- a/.changeset/frank-crabs-poke.md
+++ b/.changeset/frank-crabs-poke.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix plugin visibility logic in useDaoPlugins hook

--- a/src/shared/hooks/useDaoPlugins/useDaoPlugins.ts
+++ b/src/shared/hooks/useDaoPlugins/useDaoPlugins.ts
@@ -149,8 +149,12 @@ export const useDaoPlugins = (
     });
 
     const daoOverride = daoOverrides?.[daoId];
+    // Apply visibility override only for plugin listings/navigation. When the
+    // caller is doing a direct lookup by `pluginAddress` (e.g. from an SPP
+    // sub-proposal that references a hidden body), keep the plugin so existing
+    // proposals continue to render.
     const plugins =
-        allPlugins != null
+        allPlugins != null && pluginAddress == null
             ? daoVisibilityUtils.filterHiddenPlugins(allPlugins, daoOverride)
             : allPlugins;
 


### PR DESCRIPTION

# Description

- Adjusted the visibility override logic to apply only for plugin listings/navigation.
- Ensured that direct lookups by `pluginAddress` retain hidden plugins for existing proposals.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
