### PR TITLE
fix(APP-664): Reduce Sentry noise from expected 404s and wallet rejections

### DIFF
--- a/.changeset/fruity-tools-knock.md
+++ b/.changeset/fruity-tools-knock.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix sentry errors (APP-NEXT-1JH, APP-NEXT-1Z6, APP-NEXT-27P)

--- a/src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.test.ts
+++ b/src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.test.ts
@@ -1,15 +1,19 @@
+import { AragonBackendServiceError } from '@/shared/api/aragonBackendService';
 import { daoService, Network } from '@/shared/api/daoService';
 import { generateDao } from '@/shared/testUtils';
+import { monitoringUtils } from '@/shared/utils/monitoringUtils';
 import { ipfsUtils } from '../../../../shared/utils/ipfsUtils';
 import { applicationMetadataUtils } from './applicationMetadataUtils';
 
 describe('applicationMetadata utils', () => {
     const getDaoSpy = jest.spyOn(daoService, 'getDao');
     const cidToSrcSpy = jest.spyOn(ipfsUtils, 'cidToSrc');
+    const logErrorSpy = jest.spyOn(monitoringUtils, 'logError');
 
     afterEach(() => {
         getDaoSpy.mockReset();
         cidToSrcSpy.mockReset();
+        logErrorSpy.mockReset();
     });
 
     describe('generateDaoMetadata', () => {
@@ -51,6 +55,41 @@ describe('applicationMetadata utils', () => {
             );
             expect(cidToSrcSpy).toHaveBeenCalledWith(dao.avatar);
             expect(metadata.openGraph?.images).toEqual([ipfsUrl]);
+        });
+
+        it('does not log to monitoring when the DAO is not found', async () => {
+            const notFoundError = new AragonBackendServiceError(
+                AragonBackendServiceError.notFoundCode,
+                'Resource not found',
+                404,
+            );
+            getDaoSpy.mockRejectedValue(notFoundError);
+
+            const metadata = await applicationMetadataUtils.generateDaoMetadata(
+                {
+                    params: Promise.resolve({
+                        addressOrEns: 'unknown-dao',
+                        network: Network.ETHEREUM_SEPOLIA,
+                    }),
+                },
+            );
+
+            expect(metadata.title).toEqual('DAO not found');
+            expect(logErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('logs to monitoring when an unexpected error occurs', async () => {
+            const error = new Error('boom');
+            getDaoSpy.mockRejectedValue(error);
+
+            await applicationMetadataUtils.generateDaoMetadata({
+                params: Promise.resolve({
+                    addressOrEns: 'test-dao-id',
+                    network: Network.ETHEREUM_SEPOLIA,
+                }),
+            });
+
+            expect(logErrorSpy).toHaveBeenCalledWith(error);
         });
 
         it('returns undefined OG images when DAO has no avatar', async () => {

--- a/src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.ts
+++ b/src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { AragonBackendServiceError } from '@/shared/api/aragonBackendService';
 import { daoService } from '@/shared/api/daoService';
 import type { IDaoPageParams } from '@/shared/types';
 import { daoUtils } from '@/shared/utils/daoUtils';
@@ -50,7 +51,11 @@ class ApplicationMetadataUtils {
                 image,
             });
         } catch (error: unknown) {
-            monitoringUtils.logError(error);
+            // Suppress notFound: the page renders an empty/404 state for arbitrary URLs
+            // (bots, stale links) — these aren't bugs and would flood Sentry.
+            if (!AragonBackendServiceError.isNotFoundError(error)) {
+                monitoringUtils.logError(error);
+            }
 
             return metadataUtils.buildMetadata({
                 title: 'DAO not found',

--- a/src/modules/governance/utils/governanceMetadataUtils/governanceMetadataUtils.test.ts
+++ b/src/modules/governance/utils/governanceMetadataUtils/governanceMetadataUtils.test.ts
@@ -1,9 +1,11 @@
 import { governanceService } from '@/modules/governance/api/governanceService';
 import { generateProposal } from '@/modules/governance/testUtils';
+import { AragonBackendServiceError } from '@/shared/api/aragonBackendService';
 import { daoService, Network } from '@/shared/api/daoService';
 import { generateDao } from '@/shared/testUtils';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { ipfsUtils } from '@/shared/utils/ipfsUtils';
+import { monitoringUtils } from '@/shared/utils/monitoringUtils';
 import { governanceMetadataUtils } from './governanceMetadataUtils';
 
 describe('governanceMetadata utils', () => {
@@ -14,12 +16,14 @@ describe('governanceMetadata utils', () => {
         'getProposalBySlug',
     );
     const resolveDaoIdSpy = jest.spyOn(daoUtils, 'resolveDaoId');
+    const logErrorSpy = jest.spyOn(monitoringUtils, 'logError');
 
     afterEach(() => {
         getDaoSpy.mockReset();
         cidToSrcSpy.mockReset();
         getProposalBySlugSpy.mockReset();
         resolveDaoIdSpy.mockReset();
+        logErrorSpy.mockReset();
     });
 
     describe('generateProposalMetadata', () => {
@@ -66,6 +70,44 @@ describe('governanceMetadata utils', () => {
                 type: 'article',
                 images: [ipfsUrl],
             });
+        });
+
+        it('does not log to monitoring when the proposal is not found', async () => {
+            const notFoundError = new AragonBackendServiceError(
+                AragonBackendServiceError.notFoundCode,
+                'Resource not found',
+                404,
+            );
+            resolveDaoIdSpy.mockResolvedValue('test-dao-id');
+            getProposalBySlugSpy.mockRejectedValue(notFoundError);
+
+            const metadata =
+                await governanceMetadataUtils.generateProposalMetadata({
+                    params: Promise.resolve({
+                        addressOrEns: 'test.dao.eth',
+                        network: Network.ETHEREUM_MAINNET,
+                        proposalSlug: 'unknown',
+                    }),
+                });
+
+            expect(metadata.title).toEqual('Proposal not found');
+            expect(logErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('logs to monitoring when an unexpected error occurs', async () => {
+            const error = new Error('boom');
+            resolveDaoIdSpy.mockResolvedValue('test-dao-id');
+            getProposalBySlugSpy.mockRejectedValue(error);
+
+            await governanceMetadataUtils.generateProposalMetadata({
+                params: Promise.resolve({
+                    addressOrEns: 'test.dao.eth',
+                    network: Network.ETHEREUM_MAINNET,
+                    proposalSlug: 'p',
+                }),
+            });
+
+            expect(logErrorSpy).toHaveBeenCalledWith(error);
         });
     });
 });

--- a/src/modules/governance/utils/governanceMetadataUtils/governanceMetadataUtils.ts
+++ b/src/modules/governance/utils/governanceMetadataUtils/governanceMetadataUtils.ts
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { governanceService } from '@/modules/governance/api/governanceService';
 import type { IDaoProposalPageParams } from '@/modules/governance/types';
+import { AragonBackendServiceError } from '@/shared/api/aragonBackendService';
 import { daoService } from '@/shared/api/daoService';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { ipfsUtils } from '@/shared/utils/ipfsUtils';
@@ -43,7 +44,11 @@ class GovernanceMetadataUtils {
                 type: 'article',
             });
         } catch (error: unknown) {
-            monitoringUtils.logError(error);
+            // Suppress notFound: the page renders an empty/404 state for arbitrary URLs
+            // (bots, stale links) — these aren't bugs and would flood Sentry.
+            if (!AragonBackendServiceError.isNotFoundError(error)) {
+                monitoringUtils.logError(error);
+            }
 
             return metadataUtils.buildMetadata({
                 title: 'Proposal not found',

--- a/src/shared/components/transactionDialog/transactionDialogUtils.test.tsx
+++ b/src/shared/components/transactionDialog/transactionDialogUtils.test.tsx
@@ -43,10 +43,14 @@ describe('transactionDialog utils', () => {
             ).toBeFalsy();
         });
 
-        it('returns true when error matches one of the ignore error list', () => {
-            const error = new Error(
-                'User rejected the request. stack: "Error: [...]',
-            );
+        it.each([
+            { message: 'User rejected the request. stack: "Error: [...]' },
+            { message: 'Signing aborted by user. Details: ...' },
+            { message: 'User denied transaction signature.' },
+        ])('returns true when error message contains "$message"', ({
+            message,
+        }) => {
+            const error = new Error(message);
             expect(
                 transactionDialogUtils['shouldIgnoreError'](error),
             ).toBeTruthy();

--- a/src/shared/components/transactionDialog/transactionDialogUtils.tsx
+++ b/src/shared/components/transactionDialog/transactionDialogUtils.tsx
@@ -4,7 +4,9 @@ import type { TransactionStatusState } from '../transactionStatus';
 
 export class TransactionDialogUtils {
     private ignoreErrors = [
-        'User rejected the request', // Error caused by user rejecting the transaction on their wallet
+        'User rejected the request', // Standard wallet rejection (MetaMask, WalletConnect, …)
+        'Signing aborted by user', // Opera wallet rejection
+        'User denied transaction signature', // Older wallet variants
     ];
 
     queryToStepState = (

--- a/src/shared/utils/responseUtils/responseUtils.test.ts
+++ b/src/shared/utils/responseUtils/responseUtils.test.ts
@@ -195,7 +195,7 @@ describe('responseUtils.safeJsonParse', () => {
             expect(monitoringUtils.logError).not.toHaveBeenCalled();
         });
 
-        it('should handle error responses with invalid JSON', async () => {
+        it('should not log when invalid JSON comes from a non-OK response (caller surfaces a typed error)', async () => {
             const invalidErrorJson = 'Server Error';
             const response = new Response(invalidErrorJson, {
                 status: 500,
@@ -204,19 +204,20 @@ describe('responseUtils.safeJsonParse', () => {
             const result = await responseUtils.safeJsonParse(response);
 
             expect(result).toBeNull();
-            expect(monitoringUtils.logError).toHaveBeenCalledTimes(1);
-            const calls = (monitoringUtils.logError as jest.Mock).mock
-                .calls as [Error, { context: Record<string, unknown> }][];
-            expect(calls[0][0].name).toBe('SyntaxError');
-            expect(calls[0][1]).toEqual({
-                context: {
-                    errorType: 'json_parse_error',
-                    status: 500,
-                    url: '',
-                    contentType: 'application/json',
-                    bodyPreview: invalidErrorJson.slice(0, 100),
-                },
+            expect(monitoringUtils.logError).not.toHaveBeenCalled();
+        });
+
+        it('should not log when invalid JSON comes from an HTML 502 response', async () => {
+            const htmlBody =
+                '<html><head><title>502 Bad Gateway</title></head></html>';
+            const response = new Response(htmlBody, {
+                status: 502,
+                headers: { 'content-type': 'text/html' },
             });
+            const result = await responseUtils.safeJsonParse(response);
+
+            expect(result).toBeNull();
+            expect(monitoringUtils.logError).not.toHaveBeenCalled();
         });
     });
 

--- a/src/shared/utils/responseUtils/responseUtils.ts
+++ b/src/shared/utils/responseUtils/responseUtils.ts
@@ -14,7 +14,8 @@ class ResponseUtils {
      * Safely parses a response as JSON, handling empty responses and various status codes.
      * @returns The parsed JSON data, or null if:
      *   - Response has no-content status (204, 205, 304)
-     *   - JSON parsing fails (error logged to monitoring)
+     *   - JSON parsing fails on a non-OK response (silent — the caller surfaces a typed error)
+     *   - JSON parsing fails on an OK response (error logged to monitoring)
      */
     async safeJsonParse(response: Response): Promise<JsonValue | null> {
         // Treat standard no-content statuses as empty bodies
@@ -31,6 +32,13 @@ class ResponseUtils {
         try {
             return (await response.json()) as JsonValue;
         } catch (error) {
+            // For non-OK responses (e.g., 5xx with HTML body) skip logging the parse-error
+            // log: the caller turns the failure into a typed error and decides
+            // whether to surface it. Logging here would double-count.
+            if (!response.ok) {
+                return null;
+            }
+
             const contentType = response.headers.get('content-type') ?? '';
 
             let text = '';


### PR DESCRIPTION
# Description

Reduces Sentry noise from three sources of expected, non-actionable errors:

1. **DAO / proposal metadata 404s** (`applicationMetadataUtils`, `governanceMetadataUtils`) — bots and stale links hitting arbitrary URLs were logging `AragonBackendServiceError` (404) on every request. The page already renders an empty/404 state; we now suppress `notFound` errors and only log unexpected failures.
2. **Wallet rejection variants** (`transactionDialogUtils`) — Opera wallet emits `Signing aborted by user` and older wallets emit `User denied transaction signature`. Added these to the existing `ignoreErrors` list alongside `User rejected the request`.
3. **Backend HTML 5xx responses** (`responseUtils.safeJsonParse`) — when an upstream returns HTML on a non-OK response, JSON parsing predictably fails. Skip the parse-error log for non-OK responses; the caller already turns the failure into a typed error and decides what to surface. OK responses with malformed JSON still log.

Refs Linear APP-664 and Sentry issues APP-NEXT-1JH, APP-NEXT-1Z6, APP-NEXT-27P.

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project