### PR TITLE
fix: Set focus on WC dialog so you can search

### DIFF
--- a/.changeset/focused-dialogs-help.md
+++ b/.changeset/focused-dialogs-help.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Set focus to WalletConnect dialog to allow wallet search to work

--- a/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.tsx
+++ b/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.tsx
@@ -61,7 +61,7 @@ export const ConnectWalletDialog: React.FC<IConnectWalletDialogProps> = (
     // and track the wallet-connection status
     useEffect(() => {
         const disableOutsideClick = isAppKitModalOpen;
-        updateOptions({ disableOutsideClick });
+        updateOptions({ disableOutsideClick, modal: !isAppKitModalOpen });
         // There is a known issue on the radix dialog where elements are not scrollable when the dialog is open.
         // see here: https://github.com/radix-ui/primitives/issues/1159
         const appKitModal = document.querySelector('w3m-modal');

--- a/src/shared/components/dialogProvider/dialogProvider.api.ts
+++ b/src/shared/components/dialogProvider/dialogProvider.api.ts
@@ -20,6 +20,10 @@ export interface IDialogLocationOptions<
      */
     disableOutsideClick?: boolean;
     /**
+     * Determines whether interactions with elements outside of the dialog will be disabled.
+     */
+    modal?: IDialogRootProps['modal'];
+    /**
      * Callback triggered instead of the default close function.
      */
     onClose?: () => void;

--- a/src/shared/components/dialogRoot/dialogRoot.tsx
+++ b/src/shared/components/dialogRoot/dialogRoot.tsx
@@ -44,7 +44,7 @@ export const DialogRoot: React.FC<IDialogRootProps> = (props) => {
                 } = dialogDefinition;
 
                 const isAlertDialog = 'variant' in otherDialogProps;
-                const { disableOutsideClick, onClose } = location;
+                const { disableOutsideClick, modal, onClose } = location;
 
                 const handleInteractOutside = (event: Event) => {
                     // Only handle interaction for the topmost dialog
@@ -66,7 +66,7 @@ export const DialogRoot: React.FC<IDialogRootProps> = (props) => {
                 const DialogWrapper = isAlertDialog
                     ? DialogAlert.Root
                     : Dialog.Root;
-
+                const modalProps = isAlertDialog ? {} : { modal };
                 const processedHiddenTitle = hiddenTitle
                     ? t(hiddenTitle)
                     : undefined;
@@ -83,6 +83,7 @@ export const DialogRoot: React.FC<IDialogRootProps> = (props) => {
                         hiddenDescription={processedHiddenDescription}
                         hiddenTitle={processedHiddenTitle}
                         key={`${location.id}-${String(index)}`}
+                        {...modalProps}
                         onInteractOutside={handleInteractOutside}
                         onOpenChange={onOpenChange}
                         open={true}


### PR DESCRIPTION
# Description

There's a focus issue where the wallet search doesn't work. Imagine you have an obscure browser wallet that we don't highlight as "featured". When you browse through all wallets you would have to scroll and search manually through countless wallets.

By setting focus it now works.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
