### PR TITLE
feat(APP-629, APP-659) Polish Aragon Profiles and ENS

### DIFF
--- a/.changeset/fifty-animals-chew.md
+++ b/.changeset/fifty-animals-chew.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Render the member profile page for any valid address, falling back to ENS and address-only when the backend has no record (fixes featured delegates linking to non-indexed addresses)

--- a/.changeset/modern-garlics-beam.md
+++ b/.changeset/modern-garlics-beam.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Polish Aragon Profiles UX: remove external link icon from "My DAOs", prevent profile creation dialogs from closing on outside click, improve username error message when starting or ending with a hyphen, indicate transaction network when it differs from the current DAO, and reduce the bio field height

--- a/.changeset/quiet-tigers-hold.md
+++ b/.changeset/quiet-tigers-hold.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix DAO members list when the connected user isn't in the paginated backend response yet: pinning no longer evicts a real member from the token/lock-to-vote list, and the "X of Y" counter now reflects the rendered cards in admin/multisig lists.

--- a/.changeset/smooth-towns-show.md
+++ b/.changeset/smooth-towns-show.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Hide ".aragon.eth" from the member data list item and member profile headers

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -424,7 +424,8 @@
         "fields": {
           "subdomain": {
             "error": {
-              "invalidFormat": "Only lowercase letters, numbers, and hyphens are allowed.",
+              "invalidBoundary": "Username must start and end with letters or numbers.",
+              "invalidChars": "Only lowercase letters, numbers, and hyphens are allowed.",
               "nameTaken": "This name is already taken. Please choose a different one."
             },
             "helpText": "Your unique username linked to your address for receiving funds and identifying you in the Aragon App.",
@@ -3607,6 +3608,7 @@
           "proceedAnyway": "Continue in background",
           "retry": "Retry"
         },
+        "networkBadge": "On {{network}}",
         "step": {
           "APPROVE": {
             "addon": "Wallet",

--- a/src/modules/application/dialogs/aragonProfileClaimSubdomainDialog/aragonProfileClaimSubdomainDialog.tsx
+++ b/src/modules/application/dialogs/aragonProfileClaimSubdomainDialog/aragonProfileClaimSubdomainDialog.tsx
@@ -26,6 +26,9 @@ const subdomainMinLength = 3;
  */
 const ensLabelPattern = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
 
+/** Allowed characters for an ENS label, ignoring position constraints. */
+const ensLabelAllowedCharsPattern = /^[a-z0-9-]+$/;
+
 interface IFormData {
     /** ENS subdomain label to claim, e.g. "alice". */
     subdomain: string;
@@ -91,11 +94,18 @@ export const AragonProfileClaimSubdomainDialog: React.FC<
             required: true,
             maxLength: subdomainMaxLength,
             minLength: subdomainMinLength,
-            pattern: {
-                value: ensLabelPattern,
-                message: t(
-                    'app.application.aragonProfileClaimSubdomainDialog.fields.subdomain.error.invalidFormat',
-                ),
+            validate: (value) => {
+                if (!ensLabelAllowedCharsPattern.test(value)) {
+                    return t(
+                        'app.application.aragonProfileClaimSubdomainDialog.fields.subdomain.error.invalidChars',
+                    );
+                }
+                if (!ensLabelPattern.test(value)) {
+                    return t(
+                        'app.application.aragonProfileClaimSubdomainDialog.fields.subdomain.error.invalidBoundary',
+                    );
+                }
+                return true;
             },
         },
         sanitizeOnBlur: true,

--- a/src/modules/application/dialogs/aragonProfileDialog/aragonProfileDialog.tsx
+++ b/src/modules/application/dialogs/aragonProfileDialog/aragonProfileDialog.tsx
@@ -258,6 +258,7 @@ export const AragonProfileDialog: React.FC<IAragonProfileDialogProps> = (
 
                 <TextArea
                     id="aragon-profile-bio"
+                    inputClassName="!min-h-24"
                     isOptional
                     maxLength={160}
                     {...bioField}

--- a/src/modules/application/dialogs/aragonProfileIntroDialog/aragonProfileIntroDialog.tsx
+++ b/src/modules/application/dialogs/aragonProfileIntroDialog/aragonProfileIntroDialog.tsx
@@ -31,9 +31,13 @@ export const AragonProfileIntroDialog: React.FC<
 
     const handleCta = () => {
         if (mode === 'edit') {
-            open(ApplicationDialogId.ARAGON_PROFILE);
+            open(ApplicationDialogId.ARAGON_PROFILE, {
+                disableOutsideClick: true,
+            });
         } else {
-            open(ApplicationDialogId.ARAGON_PROFILE_CLAIM_SUBDOMAIN);
+            open(ApplicationDialogId.ARAGON_PROFILE_CLAIM_SUBDOMAIN, {
+                disableOutsideClick: true,
+            });
         }
     };
 

--- a/src/modules/application/dialogs/userDialog/userDialog.tsx
+++ b/src/modules/application/dialogs/userDialog/userDialog.tsx
@@ -53,12 +53,14 @@ export const UserDialog: React.FC<IUserDialogProps> = (props) => {
     const handleCreateAragonProfile = () =>
         open(ApplicationDialogId.ARAGON_PROFILE_INTRO, {
             stack: true,
+            disableOutsideClick: true,
             params: { mode: 'create' },
         });
 
     const handleEditAragonProfile = () =>
         open(ApplicationDialogId.ARAGON_PROFILE_INTRO, {
             stack: true,
+            disableOutsideClick: true,
             params: { mode: 'edit' },
         });
 
@@ -142,7 +144,6 @@ export const UserDialog: React.FC<IUserDialogProps> = (props) => {
                 <div className="flex flex-col gap-3">
                     <Button
                         className="w-full"
-                        iconRight={IconType.LINK_EXTERNAL}
                         onClick={handleMyDaosClick}
                         size="md"
                         variant="tertiary"

--- a/src/modules/ens/hooks/useEnsName.test.ts
+++ b/src/modules/ens/hooks/useEnsName.test.ts
@@ -24,10 +24,10 @@ describe('useEnsName hook', () => {
         expect(result.current.data).toBe('alice.aragonx.eth');
     });
 
-    it('strips the aragon subdomain suffix when shortenAragonName is set', () => {
+    it('strips the aragon subdomain suffix when stripAragonRegistrySuffix is set', () => {
         mockEnsResult('alice.aragonx.eth');
         const { result } = renderHook(() =>
-            useEnsName(validAddress, { shortenAragonName: true }),
+            useEnsName(validAddress, { stripAragonRegistrySuffix: true }),
         );
         expect(result.current.data).toBe('alice');
     });
@@ -35,7 +35,7 @@ describe('useEnsName hook', () => {
     it('returns the ENS name as-is when it is not an aragon subdomain', () => {
         mockEnsResult('alice.eth');
         const { result } = renderHook(() =>
-            useEnsName(validAddress, { shortenAragonName: true }),
+            useEnsName(validAddress, { stripAragonRegistrySuffix: true }),
         );
         expect(result.current.data).toBe('alice.eth');
     });
@@ -43,7 +43,7 @@ describe('useEnsName hook', () => {
     it('passes through null when no ENS is resolved', () => {
         mockEnsResult(null);
         const { result } = renderHook(() =>
-            useEnsName(validAddress, { shortenAragonName: true }),
+            useEnsName(validAddress, { stripAragonRegistrySuffix: true }),
         );
         expect(result.current.data).toBeNull();
     });

--- a/src/modules/ens/hooks/useEnsName.test.ts
+++ b/src/modules/ens/hooks/useEnsName.test.ts
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react';
+import * as wagmi from 'wagmi';
+import { useEnsName } from './useEnsName';
+
+describe('useEnsName hook', () => {
+    const useWagmiEnsNameSpy = jest.spyOn(wagmi, 'useEnsName');
+
+    const mockEnsResult = (data: string | null | undefined) =>
+        useWagmiEnsNameSpy.mockReturnValue({
+            data,
+            error: null,
+            isLoading: false,
+        } as unknown as ReturnType<typeof wagmi.useEnsName>);
+
+    const validAddress = '0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5';
+
+    afterEach(() => {
+        useWagmiEnsNameSpy.mockReset();
+    });
+
+    it('returns the full ENS name by default', () => {
+        mockEnsResult('alice.aragonx.eth');
+        const { result } = renderHook(() => useEnsName(validAddress));
+        expect(result.current.data).toBe('alice.aragonx.eth');
+    });
+
+    it('strips the aragon subdomain suffix when shortenAragonName is set', () => {
+        mockEnsResult('alice.aragonx.eth');
+        const { result } = renderHook(() =>
+            useEnsName(validAddress, { shortenAragonName: true }),
+        );
+        expect(result.current.data).toBe('alice');
+    });
+
+    it('returns the ENS name as-is when it is not an aragon subdomain', () => {
+        mockEnsResult('alice.eth');
+        const { result } = renderHook(() =>
+            useEnsName(validAddress, { shortenAragonName: true }),
+        );
+        expect(result.current.data).toBe('alice.eth');
+    });
+
+    it('passes through null when no ENS is resolved', () => {
+        mockEnsResult(null);
+        const { result } = renderHook(() =>
+            useEnsName(validAddress, { shortenAragonName: true }),
+        );
+        expect(result.current.data).toBeNull();
+    });
+
+    it('skips the wagmi query when the address is invalid', () => {
+        mockEnsResult(null);
+        renderHook(() => useEnsName('not-an-address'));
+        expect(useWagmiEnsNameSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                address: undefined,
+                query: expect.objectContaining({ enabled: false }),
+            }),
+        );
+    });
+});

--- a/src/modules/ens/hooks/useEnsName.ts
+++ b/src/modules/ens/hooks/useEnsName.ts
@@ -10,10 +10,11 @@ export interface IUseEnsNameOptions {
     /**
      * When true and the resolved ENS is an Aragon member-registry subdomain
      * (e.g. `alice.aragonx.eth`), the hook returns just the subdomain (`alice`).
-     * Used on member surfaces (list items, delegation card, profile header)
+     * Used on member-facing surfaces: member list items (token + default),
+     * delegation card, and profile header (title and breadcrumb).
      * Anywhere else, leave this off so the full ENS is shown.
      */
-    shortenAragonName?: boolean;
+    stripAragonRegistrySuffix?: boolean;
 }
 
 /**
@@ -32,7 +33,7 @@ export function useEnsName(
     address: string | undefined,
     options?: IUseEnsNameOptions,
 ) {
-    const { shortenAragonName = false } = options ?? {};
+    const { stripAragonRegistrySuffix = false } = options ?? {};
 
     const validAddress =
         address != null && isAddress(address) ? address : undefined;
@@ -59,7 +60,7 @@ export function useEnsName(
     }, [result.error, validAddress]);
 
     const data =
-        shortenAragonName &&
+        stripAragonRegistrySuffix &&
         result.data?.endsWith(memberRegistrySubdomainSuffix)
             ? result.data.slice(0, -memberRegistrySubdomainSuffix.length)
             : result.data;

--- a/src/modules/ens/hooks/useEnsName.ts
+++ b/src/modules/ens/hooks/useEnsName.ts
@@ -2,8 +2,19 @@ import { useEffect } from 'react';
 import { isAddress } from 'viem';
 // biome-ignore lint/style/noRestrictedImports: authorised wrapper over wagmi's useEnsName (centralises chainId and cache)
 import { useEnsName as useWagmiEnsName } from 'wagmi';
+import { memberRegistrySubdomainSuffix } from '../constants/contracts';
 import { ensCache, ensChainId } from '../constants/ensConfig';
 import { logEnsError } from '../utils/logEnsError';
+
+export interface IUseEnsNameOptions {
+    /**
+     * When true and the resolved ENS is an Aragon member-registry subdomain
+     * (e.g. `alice.aragonx.eth`), the hook returns just the subdomain (`alice`).
+     * Used on member surfaces (list items, delegation card, profile header)
+     * Anywhere else, leave this off so the full ENS is shown.
+     */
+    shortenAragonName?: boolean;
+}
 
 /**
  * Resolves the primary ENS name for a given Ethereum address.
@@ -15,8 +26,14 @@ import { logEnsError } from '../utils/logEnsError';
  * All calls are auto-batched into a single multicall RPC request via viem's `batch.multicall`.
  *
  * @param address - Hex Ethereum address (`0x…`) or `undefined` to skip.
+ * @param options - Optional behaviour flags (see `IUseEnsNameOptions`).
  */
-export function useEnsName(address: string | undefined) {
+export function useEnsName(
+    address: string | undefined,
+    options?: IUseEnsNameOptions,
+) {
+    const { shortenAragonName = false } = options ?? {};
+
     const validAddress =
         address != null && isAddress(address) ? address : undefined;
 
@@ -41,5 +58,11 @@ export function useEnsName(address: string | undefined) {
         });
     }, [result.error, validAddress]);
 
-    return result;
+    const data =
+        shortenAragonName &&
+        result.data?.endsWith(memberRegistrySubdomainSuffix)
+            ? result.data.slice(0, -memberRegistrySubdomainSuffix.length)
+            : result.data;
+
+    return { ...result, data };
 }

--- a/src/modules/governance/components/daoMemberList/daoMemberListDefault.test.tsx
+++ b/src/modules/governance/components/daoMemberList/daoMemberListDefault.test.tsx
@@ -231,6 +231,58 @@ describe('<DaoMemberListDefault /> component', () => {
         expect(memberNames).toHaveLength(1);
     });
 
+    it('keeps real members visible when the pinned user is missing from the paginated response', () => {
+        // Regression for a backend indexer gap: live `/v2/members/:address`
+        // returns the connected user, but `/v2/members` doesn't include them
+        // yet. The user must be pinned without evicting any real member, and
+        // the rendered list grows by one above the API's `itemsCount`.
+        const userAddress = '0x1234567890abcdef1234567890abcdef12345678';
+        const userMember = generateMember({
+            address: userAddress,
+            ens: 'you.eth',
+        });
+        const otherMember = generateMember({
+            address: '0x9999999999999999999999999999999999999999',
+            ens: 'other.eth',
+        });
+
+        useConnectionSpy.mockReturnValue({
+            address: userAddress,
+        } as unknown as wagmi.UseConnectionReturnType);
+        mockEnsNameByAddress({
+            [userAddress]: 'you.eth',
+            [otherMember.address]: 'other.eth',
+        });
+
+        useMemberExistsSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: { status: true } }),
+        );
+
+        useMemberListDataSpy.mockReturnValue({
+            memberList: [otherMember],
+            onLoadMore: jest.fn(),
+            state: 'idle',
+            pageSize: 10,
+            itemsCount: 1,
+            emptyState: { heading: '', description: '' },
+            errorState: { heading: '', description: '' },
+        });
+
+        useMemberSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: userMember }),
+        );
+
+        render(createTestComponent());
+
+        const headings = screen.getAllByRole('heading');
+        const memberNames = headings
+            .map((h) => h.textContent)
+            .filter((t) => t === 'you.eth' || t === 'other.eth');
+        expect(memberNames).toHaveLength(2);
+        expect(memberNames[0]).toBe('you.eth');
+        expect(memberNames[1]).toBe('other.eth');
+    });
+
     it('deduplicates pinned user from the paginated list', () => {
         const userAddress = '0x1234567890abcdef1234567890abcdef12345678';
         const userMember = generateMember({

--- a/src/modules/governance/components/daoMemberList/daoMemberListDefault.tsx
+++ b/src/modules/governance/components/daoMemberList/daoMemberListDefault.tsx
@@ -146,6 +146,15 @@ export const DaoMemberListDefault: React.FC<IDaoMemberListDefaultProps> = (
         return [paginatedEntry ?? connectedUserMember, ...rest];
     }, [memberList, connectedUserMember]);
 
+    // Pinned connected user not in the paginated response (live single-fetch sees
+    // them, `/v2/members` doesn't) pushes the rendered count above `itemsCount`
+    // from the API. Surface the larger of the two so the "X of Y" counter matches
+    // what's actually on screen.
+    const adjustedItemsCount = Math.max(
+        itemsCount ?? 0,
+        mergedMemberList?.length ?? 0,
+    );
+
     const processedLayoutClassNames =
         layoutClassNames ?? 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3';
 
@@ -157,7 +166,7 @@ export const DaoMemberListDefault: React.FC<IDaoMemberListDefaultProps> = (
     return (
         <DataListRoot
             entityLabel={t('app.governance.daoMemberList.entity')}
-            itemsCount={itemsCount}
+            itemsCount={adjustedItemsCount}
             onLoadMore={onLoadMore}
             pageSize={pageSize}
             state={state}

--- a/src/modules/governance/components/daoMemberList/daoMemberListDefault.tsx
+++ b/src/modules/governance/components/daoMemberList/daoMemberListDefault.tsx
@@ -199,13 +199,16 @@ const EnsAwareMemberItem: React.FC<{
     const { member, href, onClick } = props;
     const { data: ensName } = useEnsName(member.address);
     const { data: ensAvatar } = useEnsAvatar(ensName);
+    const { data: displayName } = useEnsName(member.address, {
+        stripAragonRegistrySuffix: true,
+    });
 
     return (
         <MemberDataListItem.Structure
             address={member.address}
             avatarSrc={ensAvatar ?? undefined}
             className="min-w-0"
-            ensName={ensName ?? undefined}
+            ensName={displayName ?? undefined}
             href={href}
             onClick={onClick}
         />

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPage.test.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPage.test.tsx
@@ -51,12 +51,14 @@ describe('<DaoMemberDetailsPage /> component', () => {
         getDaoSpy.mockReset();
     });
 
+    const validAddress = '0x1234567890123456789012345678901234567890';
+
     const createTestComponent = async (
         props?: Partial<IDaoMemberDetailsPageProps>,
     ) => {
         const completeProps: IDaoMemberDetailsPageProps = {
             params: Promise.resolve({
-                address: 'test-address',
+                address: validAddress,
                 addressOrEns: 'test.dao.eth',
                 network: Network.ETHEREUM_MAINNET,
             }),
@@ -79,7 +81,7 @@ describe('<DaoMemberDetailsPage /> component', () => {
         const params = {
             addressOrEns: 'test.dao.eth',
             network: Network.ETHEREUM_SEPOLIA,
-            address: 'test-address',
+            address: validAddress,
             pluginAddress: dao.plugins[0].address,
         };
         const expectedDaoId = 'test-dao-id';
@@ -104,16 +106,15 @@ describe('<DaoMemberDetailsPage /> component', () => {
         expect(screen.getByTestId('page-client-mock')).toBeInTheDocument();
     });
 
-    it('renders error with a link to proposal list page on fetch proposal error', async () => {
+    it('renders error with a link to the members page when the address is not a valid hex address', async () => {
         const daoEns = 'test.dao.eth';
         const daoNetwork = Network.ETHEREUM_MAINNET;
         const params = {
             addressOrEns: daoEns,
             network: daoNetwork,
-            address: '',
+            address: 'not-an-address',
         };
 
-        fetchQuerySpy.mockResolvedValueOnce({}).mockRejectedValueOnce('error');
         render(await createTestComponent({ params: Promise.resolve(params) }));
         const errorLink = screen.getByRole('link', {
             name: /daoMemberDetailsPage.error.action/,
@@ -122,5 +123,13 @@ describe('<DaoMemberDetailsPage /> component', () => {
         expect(errorLink.getAttribute('href')).toEqual(
             `/dao/${daoNetwork}/${daoEns}/members`,
         );
+    });
+
+    it('still renders the page client component when the member prefetch fails', async () => {
+        fetchQuerySpy
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(new Error('not found'));
+        render(await createTestComponent());
+        expect(screen.getByTestId('page-client-mock')).toBeInTheDocument();
     });
 });

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPage.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPage.tsx
@@ -1,4 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
+import { isAddress } from 'viem';
 import { daoOverridesOptions } from '@/shared/api/cmsService';
 import { daoService } from '@/shared/api/daoService';
 import { Page } from '@/shared/components/page';
@@ -6,7 +7,6 @@ import { RedirectToUrl } from '@/shared/components/redirectToUrl';
 import { PluginType } from '@/shared/types';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { daoVisibilityUtils } from '@/shared/utils/daoVisibilityUtils';
-import { errorUtils } from '@/shared/utils/errorUtils';
 import { memberOptions } from '../../api/governanceService';
 import type { IDaoMemberPageParams } from '../../types';
 import { DaoMemberDetailsPageClient } from './daoMemberDetailsPageClient';
@@ -23,6 +23,20 @@ export const DaoMemberDetailsPage: React.FC<
 > = async (props) => {
     const { params } = props;
     const { address, addressOrEns, network } = await params;
+
+    if (!isAddress(address)) {
+        const errorNamespace = 'app.governance.daoMemberDetailsPage.error';
+        const actionLink = `/dao/${network}/${addressOrEns}/members`;
+
+        return (
+            <Page.Error
+                actionLink={actionLink}
+                error={{ name: 'InvalidAddress', message: address }}
+                errorNamespace={errorNamespace}
+            />
+        );
+    }
+
     const daoId = await daoUtils.resolveDaoId({ addressOrEns, network });
     const dao = await daoService.getDao({ urlParams: { id: daoId } });
 
@@ -63,21 +77,9 @@ export const DaoMemberDetailsPage: React.FC<
         queryParams: memberQueryParams,
     };
 
-    try {
-        await queryClient.fetchQuery(memberOptions(memberParams));
-    } catch (error: unknown) {
-        const parsedError = errorUtils.serialize(error);
-        const errorNamespace = 'app.governance.daoMemberDetailsPage.error';
-        const actionLink = `/dao/${network}/${addressOrEns}/members`;
-
-        return (
-            <Page.Error
-                actionLink={actionLink}
-                error={parsedError}
-                errorNamespace={errorNamespace}
-            />
-        );
-    }
+    await queryClient
+        .fetchQuery(memberOptions(memberParams))
+        .catch(() => undefined);
 
     return (
         <Page.Container queryClient={queryClient}>

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
@@ -251,6 +251,33 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
         ).toBeInTheDocument();
     });
 
+    it('shows the shortened aragon name in the header but keeps the full ENS in the aside', () => {
+        const address = '0x1234567890123456789012345678901234567890';
+        useMemberSpy.mockReturnValue(
+            generateReactQueryResultSuccess({
+                data: generateMember({ address }),
+            }),
+        );
+        useEnsNameSpy.mockImplementation(
+            (_address, options) =>
+                ({
+                    data: options?.shortenAragonName
+                        ? 'alice'
+                        : 'alice.aragonx.eth',
+                    isLoading: false,
+                }) as ReturnType<typeof ensModule.useEnsName>,
+        );
+
+        render(createTestComponent({ address }));
+
+        expect(
+            screen.getByRole('heading', { level: 1, name: 'alice' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('link', { name: 'alice.aragonx.eth' }),
+        ).toBeInTheDocument();
+    });
+
     it('renders bio and ENS links when records are present', () => {
         useEnsNameSpy.mockReturnValue({
             data: 'member.eth',

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
@@ -167,12 +167,18 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
         expect(avatar).toBeInTheDocument();
     });
 
-    it('returns empty container on member fetch error', () => {
+    it('renders the page with a fallback member when useMember has no data', () => {
+        const address = '0x1234567890123456789012345678901234567890';
         useMemberSpy.mockReturnValue(
             generateReactQueryResultError({ error: new Error() }),
         );
-        const { container } = render(createTestComponent());
-        expect(container).toBeEmptyDOMElement();
+        render(createTestComponent({ address }));
+        expect(
+            screen.getByRole('heading', {
+                level: 1,
+                name: addressUtils.truncateAddress(address),
+            }),
+        ).toBeInTheDocument();
     });
 
     it('supports member address and ens copy', async () => {

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
@@ -261,7 +261,7 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
         useEnsNameSpy.mockImplementation(
             (_address, options) =>
                 ({
-                    data: options?.shortenAragonName
+                    data: options?.stripAragonRegistrySuffix
                         ? 'alice'
                         : 'alice.aragonx.eth',
                     isLoading: false,

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
@@ -145,7 +145,7 @@ export const DaoMemberDetailsPageClient: React.FC<
     const { data: ensAvatar } = useEnsAvatar(ensName);
     const { data: ensRecords } = useEnsRecords(ensName);
     const { data: displayName } = useEnsName(address, {
-        shortenAragonName: true,
+        stripAragonRegistrySuffix: true,
     });
     const memberLinks = {
         github: ensRecords?.[ensRecordKeys.github],

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
@@ -144,6 +144,9 @@ export const DaoMemberDetailsPageClient: React.FC<
     const { data: ensName } = useEnsName(address);
     const { data: ensAvatar } = useEnsAvatar(ensName);
     const { data: ensRecords } = useEnsRecords(ensName);
+    const { data: displayName } = useEnsName(address, {
+        shortenAragonName: true,
+    });
     const memberLinks = {
         github: ensRecords?.[ensRecordKeys.github],
         twitter: ensRecords?.[ensRecordKeys.twitter],
@@ -155,7 +158,7 @@ export const DaoMemberDetailsPageClient: React.FC<
     }
 
     const truncatedAddress = addressUtils.truncateAddress(address);
-    const memberName = ensName ?? truncatedAddress;
+    const memberName = displayName ?? truncatedAddress;
 
     const addressUrl = buildEntityUrl({
         type: ChainEntityType.ADDRESS,

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
@@ -28,7 +28,7 @@ import { bigIntUtils } from '@/shared/utils/bigIntUtils';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { networkUtils } from '@/shared/utils/networkUtils';
 import EfpLogo from '../../../../assets/images/efp-logo.svg';
-import { useMember } from '../../api/governanceService';
+import { type IMember, useMember } from '../../api/governanceService';
 import { DaoProposalList } from '../../components/daoProposalList';
 import { DelegationSection } from '../../components/delegationSection';
 import { VoteList } from '../../components/voteList';
@@ -153,9 +153,22 @@ export const DaoMemberDetailsPageClient: React.FC<
         url: ensRecords?.[ensRecordKeys.url],
     };
 
-    if (member == null || dao == null || bodyPlugin == null) {
+    if (dao == null || bodyPlugin == null) {
         return null;
     }
+
+    const fallbackMember: IMember = {
+        address,
+        ens: null,
+        type: '',
+        firstActive: null,
+        lastActive: null,
+        metrics: {
+            firstActivity: null,
+            lastActivity: null,
+        },
+    };
+    const memberData = member ?? fallbackMember;
 
     const truncatedAddress = addressUtils.truncateAddress(address);
     const memberName = displayName ?? truncatedAddress;
@@ -223,7 +236,7 @@ export const DaoMemberDetailsPageClient: React.FC<
                 <Page.Main>
                     <DelegationSection
                         daoId={daoId}
-                        member={member}
+                        member={memberData}
                         title={t(
                             'app.governance.daoMemberDetailsPage.main.delegation.title',
                         )}

--- a/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.test.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.test.tsx
@@ -76,6 +76,22 @@ describe('<TokenMemberListItem /> component', () => {
         expect(screen.getByText(ensName)).toBeInTheDocument();
     });
 
+    it('shows the shortened aragon name when the member has an aragon subdomain', () => {
+        const member = generateTokenMember({ address: '0x123' });
+        useEnsNameSpy.mockImplementation(
+            (_address, options) =>
+                ({
+                    data: options?.shortenAragonName
+                        ? 'alice'
+                        : 'alice.aragonx.eth',
+                    isLoading: false,
+                }) as ReturnType<typeof ensModule.useEnsName>,
+        );
+        render(createTestComponent({ member }));
+        expect(screen.getByText('alice')).toBeInTheDocument();
+        expect(screen.queryByText('alice.aragonx.eth')).not.toBeInTheDocument();
+    });
+
     it('retrieves the plugin settings to parse the member voting power using the decimals of the governance token', () => {
         const token = generateTokenPluginSettingsToken({ decimals: 6 });
         const pluginSettings = generateTokenPluginSettings({ token });

--- a/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.test.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.test.tsx
@@ -81,7 +81,7 @@ describe('<TokenMemberListItem /> component', () => {
         useEnsNameSpy.mockImplementation(
             (_address, options) =>
                 ({
-                    data: options?.shortenAragonName
+                    data: options?.stripAragonRegistrySuffix
                         ? 'alice'
                         : 'alice.aragonx.eth',
                     isLoading: false,

--- a/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.tsx
@@ -40,7 +40,7 @@ export const TokenMemberListItem: React.FC<ITokenMemberListItemProps> = (
     const { data: ensName } = useEnsName(member.address);
     const { data: ensAvatar } = useEnsAvatar(ensName);
     const { data: displayName } = useEnsName(member.address, {
-        shortenAragonName: true,
+        stripAragonRegistrySuffix: true,
     });
 
     return (

--- a/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.tsx
@@ -39,6 +39,9 @@ export const TokenMemberListItem: React.FC<ITokenMemberListItemProps> = (
     const { data: dao } = useDao({ urlParams: { id: daoId } });
     const { data: ensName } = useEnsName(member.address);
     const { data: ensAvatar } = useEnsAvatar(ensName);
+    const { data: displayName } = useEnsName(member.address, {
+        shortenAragonName: true,
+    });
 
     return (
         <MemberDataListItem.Structure
@@ -46,7 +49,7 @@ export const TokenMemberListItem: React.FC<ITokenMemberListItemProps> = (
             avatarSrc={ensAvatar ?? undefined}
             className="min-w-0"
             delegationCount={member.metrics.delegationCount}
-            ensName={ensName ?? undefined}
+            ensName={displayName ?? undefined}
             href={daoUtils.getDaoUrl(dao, `members/${member.address}`)}
             isDelegate={isDelegate}
             key={member.address}

--- a/src/plugins/tokenPlugin/components/tokenMemberList/tokenMemberListBase.test.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/tokenMemberListBase.test.tsx
@@ -193,11 +193,10 @@ describe('<TokenMemberListBase />', () => {
         render(createTestComponent());
 
         const memberElements = screen.getAllByTestId('member-mock');
-        expect(memberElements).toHaveLength(2);
+        expect(memberElements).toHaveLength(paginatedMembers.length + 1);
         expect(memberElements[0].textContent).toBe(userAddress);
-        expect(memberElements[1].textContent).toBe(
-            '0x9999999999999999999999999999999999999999',
-        );
+        expect(memberElements[1].textContent).toBe(paginatedMembers[0].address);
+        expect(memberElements[2].textContent).toBe(paginatedMembers[1].address);
     });
 
     it('pins the delegate to the top when user has a valid delegate', () => {
@@ -259,13 +258,15 @@ describe('<TokenMemberListBase />', () => {
         render(createTestComponent({ enableDelegation: true }));
 
         const memberElements = screen.getAllByTestId('member-mock');
-        expect(memberElements).toHaveLength(2);
+        expect(memberElements).toHaveLength(paginatedMembers.length + 2);
         expect(memberElements[0].textContent).toBe(userAddress);
         expect(memberElements[1].textContent).toBe(delegateAddr);
         expect(memberElements[1].getAttribute('data-is-delegate')).toBe('true');
+        expect(memberElements[2].textContent).toBe(paginatedMembers[0].address);
+        expect(memberElements[3].textContent).toBe(paginatedMembers[1].address);
     });
 
-    it('keeps the rendered member count aligned with the backend page size', () => {
+    it('renders pinned user and delegate alongside the paginated members without dropping any', () => {
         const userAddress = '0x1234567890abcdef1234567890abcdef12345678';
         const delegateAddr = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
         const paginatedMembers = [
@@ -324,9 +325,69 @@ describe('<TokenMemberListBase />', () => {
         render(createTestComponent({ enableDelegation: true }));
 
         const memberElements = screen.getAllByTestId('member-mock');
-        expect(memberElements).toHaveLength(paginatedMembers.length);
+        expect(memberElements).toHaveLength(paginatedMembers.length + 2);
         expect(memberElements[0].textContent).toBe(userAddress);
         expect(memberElements[1].textContent).toBe(delegateAddr);
+        expect(memberElements[2].textContent).toBe(paginatedMembers[0].address);
+        expect(memberElements[3].textContent).toBe(paginatedMembers[1].address);
+    });
+
+    it('keeps real members visible and bumps the counter when the pinned user is missing from the paginated response', () => {
+        // Regression for a backend indexer gap: live `/v2/members/:address`
+        // sees the connected user with VP > 0 (they delegated on-chain), but
+        // `/v2/members` doesn't include them yet. The pinning must not evict
+        // a real member, and the "X of Y" counter must reflect what's rendered.
+        const userAddress = '0x1234567890abcdef1234567890abcdef12345678';
+        const paginatedMembers = [
+            generateTokenMember({
+                address: '0x9999999999999999999999999999999999999999',
+                votingPower: '5000',
+            }),
+            generateTokenMember({
+                address: '0x8888888888888888888888888888888888888888',
+                votingPower: '4000',
+            }),
+        ];
+        const userMember = generateTokenMember({
+            address: userAddress,
+            votingPower: '100',
+        });
+
+        useConnectionSpy.mockReturnValue({
+            address: userAddress,
+        } as unknown as wagmi.UseConnectionReturnType);
+
+        useMemberListDataSpy.mockReturnValue({
+            memberList: paginatedMembers,
+            onLoadMore: jest.fn(),
+            state: 'idle',
+            pageSize: 10,
+            itemsCount: paginatedMembers.length,
+            emptyState: { heading: '', description: '' },
+            errorState: { heading: '', description: '' },
+        });
+
+        useMemberSpy.mockImplementation((params) => {
+            if (params.urlParams.address === userAddress) {
+                return generateReactQueryResultSuccess({ data: userMember });
+            }
+            return generateReactQueryResultSuccess({
+                data: undefined as unknown as ITokenMember,
+            });
+        });
+
+        render(createTestComponent());
+
+        const memberElements = screen.getAllByTestId('member-mock');
+        expect(memberElements).toHaveLength(paginatedMembers.length + 1);
+        expect(memberElements[0].textContent).toBe(userAddress);
+        expect(memberElements.map((el) => el.textContent)).toEqual(
+            expect.arrayContaining([
+                userAddress,
+                paginatedMembers[0].address,
+                paginatedMembers[1].address,
+            ]),
+        );
     });
 
     describe('linked-account daoId resolution', () => {

--- a/src/plugins/tokenPlugin/components/tokenMemberList/tokenMemberListBase.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/tokenMemberListBase.tsx
@@ -133,13 +133,22 @@ export const TokenMemberListBase: React.FC<ITokenMemberListBaseProps> = (
             merged.push(member);
         }
 
-        return merged.slice(0, memberList.length);
+        return merged;
     }, [memberList, connectedUserMember, delegateMember, hasValidDelegate]);
+
+    // Pinned members that aren't yet indexed in the backend's paginated response
+    // (live single-fetch sees them, but `/v2/members` doesn't) push the rendered
+    // count above `itemsCount` from the API. Surface the larger of the two so the
+    // "X of Y" counter matches what's actually on screen and never shrinks below it.
+    const adjustedItemsCount = Math.max(
+        itemsCount ?? 0,
+        mergedMemberList?.length ?? 0,
+    );
 
     return (
         <DataListRoot
             entityLabel={t('app.plugins.token.tokenMemberList.entity')}
-            itemsCount={itemsCount}
+            itemsCount={adjustedItemsCount}
             onLoadMore={onLoadMore}
             pageSize={pageSize}
             state={state}

--- a/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.test.tsx
+++ b/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.test.tsx
@@ -132,7 +132,7 @@ describe('<TokenDelegationDialog /> component', () => {
         useEnsNameSpy.mockImplementation(
             (_address, options) =>
                 ({
-                    data: options?.shortenAragonName
+                    data: options?.stripAragonRegistrySuffix
                         ? 'alice'
                         : 'alice.aragonx.eth',
                     isLoading: false,

--- a/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.test.tsx
+++ b/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.test.tsx
@@ -127,4 +127,26 @@ describe('<TokenDelegationDialog /> component', () => {
             }),
         );
     });
+
+    it('shows the shortened aragon name when the delegate has an aragon subdomain', () => {
+        useEnsNameSpy.mockImplementation(
+            (_address, options) =>
+                ({
+                    data: options?.shortenAragonName
+                        ? 'alice'
+                        : 'alice.aragonx.eth',
+                    isLoading: false,
+                }) as ReturnType<typeof ensModule.useEnsName>,
+        );
+
+        render(createTestComponent({ location }));
+
+        expect(getDelegateProps()).toEqual(
+            expect.objectContaining({
+                address: location.params.delegate,
+                ensName: 'alice',
+                isDelegate: true,
+            }),
+        );
+    });
 });

--- a/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.tsx
+++ b/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.tsx
@@ -63,7 +63,7 @@ export const TokenDelegationDialog: React.FC<ITokenDelegationDialogProps> = (
     const { data: delegateEnsName } = useEnsName(delegate);
     const { data: delegateEnsAvatar } = useEnsAvatar(delegateEnsName);
     const { data: delegateDisplayName } = useEnsName(delegate, {
-        shortenAragonName: true,
+        stripAragonRegistrySuffix: true,
     });
 
     const { t } = useTranslations();

--- a/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.tsx
+++ b/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.tsx
@@ -62,6 +62,9 @@ export const TokenDelegationDialog: React.FC<ITokenDelegationDialogProps> = (
     } = location.params;
     const { data: delegateEnsName } = useEnsName(delegate);
     const { data: delegateEnsAvatar } = useEnsAvatar(delegateEnsName);
+    const { data: delegateDisplayName } = useEnsName(delegate, {
+        shortenAragonName: true,
+    });
 
     const { t } = useTranslations();
     const router = useRouter();
@@ -102,7 +105,7 @@ export const TokenDelegationDialog: React.FC<ITokenDelegationDialogProps> = (
             <MemberDataListItem.Structure
                 address={delegate}
                 avatarSrc={delegateEnsAvatar ?? undefined}
-                ensName={delegateEnsName ?? undefined}
+                ensName={delegateDisplayName ?? undefined}
                 isDelegate={true}
             />
         </TransactionDialog>

--- a/src/shared/components/transactionDialog/transactionDialog.test.tsx
+++ b/src/shared/components/transactionDialog/transactionDialog.test.tsx
@@ -24,6 +24,10 @@ jest.mock('./transactionDialogFooter', () => ({
     TransactionDialogFooter: () => <div data-testid="footer-mock" />,
 }));
 
+jest.mock('next/navigation', () => ({
+    useParams: jest.fn(() => ({})),
+}));
+
 jest.mock('@tanstack/react-query', () => ({
     __esModule: true,
     ...jest.requireActual<typeof ReactQuery>('@tanstack/react-query'),

--- a/src/shared/components/transactionDialog/transactionDialog.tsx
+++ b/src/shared/components/transactionDialog/transactionDialog.tsx
@@ -1,5 +1,6 @@
-import { ChainEntityType, Dialog, IconType } from '@aragon/gov-ui-kit';
+import { ChainEntityType, Dialog, IconType, Tag } from '@aragon/gov-ui-kit';
 import { useMutation } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
     useConnection,
@@ -10,6 +11,7 @@ import {
 import { Network } from '@/shared/api/daoService';
 import { useTransactionStatus } from '@/shared/api/transactionService';
 import { useDialogContext } from '@/shared/components/dialogProvider';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import {
     type ITransactionStatusStepMetaAddon,
@@ -70,6 +72,11 @@ export const TransactionDialog = <TCustomStepId extends string>(
     const { chainId: requiredChainId, buildEntityUrl } = useDaoChain({
         network,
     });
+
+    const { network: daoNetworkParam } = useParams<{ network?: string }>();
+    const isCrossNetworkTransaction =
+        daoNetworkParam != null && daoNetworkParam !== network;
+    const transactionNetworkName = networkDefinitions[network]?.name;
 
     const handleTransactionError = useCallback(
         (stepId?: string) =>
@@ -309,6 +316,17 @@ export const TransactionDialog = <TCustomStepId extends string>(
             <Dialog.Header description={description} title={title} />
             <Dialog.Content>
                 <div className="flex flex-col gap-6 pb-3 md:pb-4">
+                    {isCrossNetworkTransaction &&
+                        transactionNetworkName != null && (
+                            <Tag
+                                className="self-start"
+                                label={t(
+                                    'app.shared.transactionDialog.networkBadge',
+                                    { network: transactionNetworkName },
+                                )}
+                                variant="warning"
+                            />
+                        )}
                     {children}
                     <TransactionStatus.Container
                         steps={steps}


### PR DESCRIPTION
# Description

**Add useEnsName hook functionality for Aragon subdomain handling**
- Updated the useEnsName hook to accept an options parameter for shortening Aragon member-registry subdomains.
- Modified components to utilize the new display name logic, ensuring the shortened name is shown where appropriate.

**Polish Aragon Profiles UX:**
- Drop external link icon from "My DAOs" in the user dialog
- Disable outside-click close on profile create/edit dialogs to preserve typed data
- Split subdomain validation: distinct messages for invalid characters and for leading/trailing hyphen
- Show "On {Network}" tag on transaction dialog when target network differs from current DAO scope
- Reduce bio textarea min-height so 160 chars fills the field on realistic widths

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [x] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
