### PR TITLE
chore(APP-663): Make slotId prop of PluginFilterComponent optional

### DIFF
--- a/.changeset/slow-eels-shop.md
+++ b/.changeset/slow-eels-shop.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Set slotId prop of PluginFilterComponent as an optional prop

--- a/src/modules/governance/components/delegationSection/delegationSection.tsx
+++ b/src/modules/governance/components/delegationSection/delegationSection.tsx
@@ -8,7 +8,6 @@ import {
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
 import { PluginType } from '@/shared/types';
 import type { IMember } from '../../api/governanceService';
-import { GovernanceSlotId } from '../../constants/moduleSlots';
 import { DelegationStatementCard } from '../delegationStatementCard';
 import { DelegationStatsCard } from '../delegationStatsCard';
 
@@ -63,7 +62,6 @@ export const DelegationSection: React.FC<IDelegationSectionProps> = (props) => {
             <PluginFilterComponent
                 plugins={bodiesWithDelegation}
                 renderContent={renderSelectedPlugin}
-                slotId={GovernanceSlotId.GOVERNANCE_MEMBER_PANEL}
             />
         </Page.MainSection>
     );

--- a/src/shared/components/pluginFilterComponent/pluginFilterComponent.api.tsx
+++ b/src/shared/components/pluginFilterComponent/pluginFilterComponent.api.tsx
@@ -42,9 +42,10 @@ export interface IPluginFilterComponentProps<
     TProps extends object = object,
 > {
     /**
-     * Id of the slot component to load.
+     * Id of the slot component to load. Required when using slot-based rendering; omit when
+     * all plugins provide their own renderContent.
      */
-    slotId: SlotId;
+    slotId?: SlotId;
     /**
      * Plugin definitions to load the component from.
      */

--- a/src/shared/components/pluginFilterComponent/pluginFilterComponent.tsx
+++ b/src/shared/components/pluginFilterComponent/pluginFilterComponent.tsx
@@ -26,14 +26,17 @@ export const PluginFilterComponent = <
         ...otherProps
     } = props;
 
-    const supportedPlugins = plugins.filter(
-        (plugin) =>
-            plugin.renderContent != null ||
-            pluginRegistryUtils.getSlotComponent({
-                slotId,
-                pluginId: plugin.id,
-            }) != null,
-    );
+    const supportedPlugins =
+        slotId == null
+            ? plugins
+            : plugins.filter(
+                  (plugin) =>
+                      plugin.renderContent != null ||
+                      pluginRegistryUtils.getSlotComponent({
+                          slotId,
+                          pluginId: plugin.id,
+                      }) != null,
+              );
 
     // The components renders null if there is no fallback specified for the slot-id AND the slot has no supported plugins.
     const hasNoContent = Fallback == null && !supportedPlugins.length;
@@ -81,6 +84,10 @@ export const PluginFilterComponent = <
 
         if (plugin.renderContent != null) {
             return plugin.renderContent();
+        }
+
+        if (slotId == null) {
+            return null;
         }
 
         return (


### PR DESCRIPTION
# Description

Makes the `slotId` prop of `PluginFilterComponent` optional so the component can be used without slot-based rendering — i.e. when all plugins provide their own `renderContent`. When `slotId` is omitted, all passed plugins are treated as supported and slot resolution is skipped entirely.

Also removes the now-unnecessary `slotId` prop from the `DelegationSection` usage.

Closes [APP-663](https://linear.app/aragon/issue/APP-663/extend-pluginfiltercomponent-to-optionally-use-slotid)

## Type of Change

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project