### PR TITLE
fix(APP-711): Update address validation to use addressUtils

### DIFF
--- a/.changeset/tame-clouds-build.md
+++ b/.changeset/tame-clouds-build.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix "Something went wrong" on the DAO member page for valid but non-checksummed addresses by normalizing to EIP-55 and redirecting to the canonical URL.

--- a/biome.json
+++ b/biome.json
@@ -192,6 +192,12 @@
                                     "useEnsName"
                                 ],
                                 "message": "Import ENS hooks from @/modules/ens, wallet account state (address/chainId) from @/modules/application/hooks/useWalletAccount, and connection-gating from @/modules/application/hooks/useWalletConnected. Add biome-ignore with reason if direct wagmi access is needed."
+                            },
+                            "viem": {
+                                "importNames": [
+                                    "isAddress"
+                                ],
+                                "message": "Use addressUtils.isAddress from @aragon/gov-ui-kit instead. Viem's isAddress defaults to strict EIP-55 checksum validation, which rejects otherwise valid mixed-case addresses (e.g. links shared from other tools). If you must use viem directly (e.g. inside a server component, where the gov-ui-kit client shim breaks), biome-ignore this line and pass { strict: false } explicitly."
                             }
                         }
                     }

--- a/src/modules/ens/hooks/useEnsName.ts
+++ b/src/modules/ens/hooks/useEnsName.ts
@@ -1,5 +1,5 @@
+import { addressUtils } from '@aragon/gov-ui-kit';
 import { useEffect } from 'react';
-import { isAddress } from 'viem';
 // biome-ignore lint/style/noRestrictedImports: authorised wrapper over wagmi's useEnsName (centralises chainId and cache)
 import { useEnsName as useWagmiEnsName } from 'wagmi';
 import { memberRegistrySubdomainSuffix } from '../constants/contracts';
@@ -36,7 +36,9 @@ export function useEnsName(
     const { stripAragonRegistrySuffix = false } = options ?? {};
 
     const validAddress =
-        address != null && isAddress(address) ? address : undefined;
+        address != null && addressUtils.isAddress(address)
+            ? addressUtils.getChecksum(address)
+            : undefined;
 
     const result = useWagmiEnsName({
         address: validAddress,

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPage.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPage.tsx
@@ -1,5 +1,6 @@
 import { QueryClient } from '@tanstack/react-query';
-import { isAddress } from 'viem';
+// biome-ignore lint/style/noRestrictedImports: server component cannot use the gov-ui-kit client shim; called with { strict: false } below.
+import { getAddress, isAddress } from 'viem';
 import { daoOverridesOptions } from '@/shared/api/cmsService';
 import { daoService } from '@/shared/api/daoService';
 import { Page } from '@/shared/components/page';
@@ -22,19 +23,26 @@ export const DaoMemberDetailsPage: React.FC<
     IDaoMemberDetailsPageProps
 > = async (props) => {
     const { params } = props;
-    const { address, addressOrEns, network } = await params;
+    const { address: rawAddress, addressOrEns, network } = await params;
 
-    if (!isAddress(address)) {
+    if (!isAddress(rawAddress, { strict: false })) {
         const errorNamespace = 'app.governance.daoMemberDetailsPage.error';
         const actionLink = `/dao/${network}/${addressOrEns}/members`;
 
         return (
             <Page.Error
                 actionLink={actionLink}
-                error={{ name: 'InvalidAddress', message: address }}
+                error={{ name: 'InvalidAddress', message: rawAddress }}
                 errorNamespace={errorNamespace}
             />
         );
+    }
+
+    const address = getAddress(rawAddress);
+
+    if (address !== rawAddress) {
+        const canonicalUrl = `/dao/${network}/${addressOrEns}/members/${address}`;
+        return <RedirectToUrl url={canonicalUrl} />;
     }
 
     const daoId = await daoUtils.resolveDaoId({ addressOrEns, network });

--- a/src/modules/governance/utils/proposalActionsImportExportUtils/proposalActionsImportExportUtils.ts
+++ b/src/modules/governance/utils/proposalActionsImportExportUtils/proposalActionsImportExportUtils.ts
@@ -1,5 +1,5 @@
 import { addressUtils } from '@aragon/gov-ui-kit';
-import { formatUnits, isAddress, isHex, zeroAddress } from 'viem';
+import { formatUnits, isHex, zeroAddress } from 'viem';
 import {
     type IProposalAction,
     ProposalActionType,
@@ -441,7 +441,10 @@ class ProposalActionsImportExportUtils {
             return 'app.governance.createProposalForm.actionsImportExport.errors.invalidFormat';
         }
 
-        if (typeof actionObj.to !== 'string' || !isAddress(actionObj.to)) {
+        if (
+            typeof actionObj.to !== 'string' ||
+            !addressUtils.isAddress(actionObj.to)
+        ) {
             return 'app.governance.createProposalForm.actionsImportExport.errors.invalidAddress';
         }
 


### PR DESCRIPTION

# Description

- Replaced viem's isAddress with addressUtils.isAddress in multiple components to ensure compatibility with mixed-case addresses.
- Updated useEnsName hook to utilize addressUtils for address validation and checksum conversion.
- Adjusted DaoMemberDetailsPage to handle address validation with strict mode disabled.
- Enhanced proposalActionsImportExportUtils to use addressUtils for address checks, improving error handling for invalid addresses.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
