### PR TITLE
fix: Pin wallet connect prompt to the DAO's network

### DIFF
--- a/.changeset/public-bees-divide.md
+++ b/.changeset/public-bees-divide.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix AppKit excess network approval prompts

--- a/src/__mocks__/@reown/appkit/react.ts
+++ b/src/__mocks__/@reown/appkit/react.ts
@@ -2,12 +2,14 @@ const createAppKit = jest.fn();
 const useAppKit = () => ({ open: jest.fn() });
 const useAppKitState = jest.fn();
 const useAppKitAccount = jest.fn(() => ({ isConnected: false }));
+const useAppKitNetwork = jest.fn(() => ({ switchNetwork: jest.fn() }));
 const useDisconnect = jest.fn(() => ({ disconnect: jest.fn() }));
 
 export {
     createAppKit,
     useAppKit,
     useAppKitAccount,
+    useAppKitNetwork,
     useAppKitState,
     useDisconnect,
 };

--- a/src/__mocks__/next/navigation.ts
+++ b/src/__mocks__/next/navigation.ts
@@ -1,5 +1,6 @@
+const useParams = jest.fn(() => ({}));
 const usePathname = jest.fn();
 const useRouter = jest.fn();
 const useSearchParams = jest.fn(() => new URLSearchParams());
 
-export { usePathname, useRouter, useSearchParams };
+export { useParams, usePathname, useRouter, useSearchParams };

--- a/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.test.tsx
+++ b/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.test.tsx
@@ -1,8 +1,11 @@
 import * as AppKit from '@reown/appkit/react';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import * as NextNavigation from 'next/navigation';
 import * as UseWalletConnected from '@/modules/application/hooks/useWalletConnected';
+import { Network } from '@/shared/api/daoService';
 import * as useDialogContext from '@/shared/components/dialogProvider';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { generateDialogContext } from '@/shared/testUtils';
 import {
     ConnectWalletDialog,
@@ -16,6 +19,8 @@ describe('<ConnectWalletDialog /> component', () => {
     );
     const useAppKitSpy = jest.spyOn(AppKit, 'useAppKit');
     const useAppKitStateSpy = jest.spyOn(AppKit, 'useAppKitState');
+    const useAppKitNetworkSpy = jest.spyOn(AppKit, 'useAppKitNetwork');
+    const useParamsSpy = jest.spyOn(NextNavigation, 'useParams');
     const useWalletConnectedSpy = jest.spyOn(
         UseWalletConnected,
         'useWalletConnected',
@@ -30,6 +35,13 @@ describe('<ConnectWalletDialog /> component', () => {
             initialized: true,
             connectingWallet: undefined,
         });
+        useAppKitNetworkSpy.mockReturnValue({
+            switchNetwork: jest.fn(),
+            caipNetwork: undefined,
+            chainId: undefined,
+            caipNetworkId: undefined,
+        });
+        useParamsSpy.mockReturnValue({});
         useWalletConnectedSpy.mockReturnValue(false);
     });
 
@@ -37,6 +49,8 @@ describe('<ConnectWalletDialog /> component', () => {
         useDialogContextSpy.mockReset();
         useAppKitSpy.mockReset();
         useAppKitStateSpy.mockReset();
+        useAppKitNetworkSpy.mockReset();
+        useParamsSpy.mockReset();
         useWalletConnectedSpy.mockReset();
     });
 
@@ -99,6 +113,49 @@ describe('<ConnectWalletDialog /> component', () => {
 
         await userEvent.click(connectButton);
         expect(openWeb3Modal).toHaveBeenCalledWith({ view: 'Connect' });
+    });
+
+    it('pins the AppKit active network to the DAO network from the URL before opening the modal', async () => {
+        const openWeb3Modal = jest.fn();
+        const switchNetwork = jest.fn();
+        useAppKitSpy.mockReturnValue({ open: openWeb3Modal, close: jest.fn() });
+        useAppKitNetworkSpy.mockReturnValue({
+            switchNetwork,
+            caipNetwork: undefined,
+            chainId: undefined,
+            caipNetworkId: undefined,
+        });
+        useParamsSpy.mockReturnValue({ network: Network.ETHEREUM_MAINNET });
+        render(createTestComponent());
+
+        await userEvent.click(
+            screen.getByRole('button', {
+                name: /connectWalletDialog.action.connect/,
+            }),
+        );
+        expect(switchNetwork).toHaveBeenCalledWith(
+            networkDefinitions[Network.ETHEREUM_MAINNET],
+        );
+        expect(openWeb3Modal).toHaveBeenCalledWith({ view: 'Connect' });
+    });
+
+    it('does not switch network when no DAO network is in the URL', async () => {
+        const switchNetwork = jest.fn();
+        useAppKitNetworkSpy.mockReturnValue({
+            switchNetwork,
+            caipNetwork: undefined,
+            chainId: undefined,
+            caipNetworkId: undefined,
+        });
+        useParamsSpy.mockReturnValue({});
+        render(createTestComponent());
+
+        await userEvent.click(
+            screen.getByRole('button', {
+                name: /connectWalletDialog.action.connect/,
+            }),
+        );
+        expect(switchNetwork).not.toHaveBeenCalled();
     });
 
     it('closes the dialog and calls onSuccess when the wallet connects', () => {

--- a/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.tsx
+++ b/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.tsx
@@ -44,18 +44,18 @@ export const ConnectWalletDialog: React.FC<IConnectWalletDialogProps> = (
     const isConnected = useWalletConnected();
     const { t } = useTranslations();
 
-    // DAO routes are scoped by `/dao/[network]/...` — pin the wallet prompt to
-    // that network so MetaMask doesn't ask for permission on a stale chain
-    // (e.g. whatever was last persisted in AppKit's `active_caip_network_id`).
     const { network: networkParam } = useParams<{ network?: Network }>();
-    const daoNetwork = networkParam
-        ? networkDefinitions[networkParam as Network]
-        : undefined;
 
     // Force "Connect" view; we don't want to see other modal views, which might happen if AppKit state gets out of sync with wagmi store.
     const handleConnectClick = () => {
+        // DAO routes are scoped by `/dao/[network]/...` — pin the wallet prompt to
+        // that network so MetaMask doesn't ask for permission on a stale chain
+        // (e.g. whatever was last persisted in AppKit's `active_caip_network_id`).
+        const daoNetwork = networkParam
+            ? networkDefinitions[networkParam as Network]
+            : undefined;
+
         if (daoNetwork) {
-            // clean up localStorage state for previous network if it exists!
             void switchNetwork(daoNetwork);
         }
         void openWeb3Modal({ view: 'Connect' });

--- a/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.tsx
+++ b/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.tsx
@@ -55,6 +55,7 @@ export const ConnectWalletDialog: React.FC<IConnectWalletDialogProps> = (
     // Force "Connect" view; we don't want to see other modal views, which might happen if AppKit state gets out of sync with wagmi store.
     const handleConnectClick = () => {
         if (daoNetwork) {
+            // clean up localStorage state for previous network if it exists!
             void switchNetwork(daoNetwork);
         }
         void openWeb3Modal({ view: 'Connect' });

--- a/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.tsx
+++ b/src/modules/application/dialogs/connectWalletDialog/connectWalletDialog.tsx
@@ -1,13 +1,20 @@
 import { AvatarIcon, Dialog, IconType, Link } from '@aragon/gov-ui-kit';
-import { useAppKit, useAppKitState } from '@reown/appkit/react';
+import {
+    useAppKit,
+    useAppKitNetwork,
+    useAppKitState,
+} from '@reown/appkit/react';
+import { useParams } from 'next/navigation';
 import { useCallback, useEffect } from 'react';
 import { useWalletConnected } from '@/modules/application/hooks/useWalletConnected';
+import type { Network } from '@/shared/api/daoService';
 import { AragonLogo } from '@/shared/components/aragonLogo';
 import {
     type IDialogComponentProps,
     useDialogContext,
 } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 
 export interface IConnectWalletDialogParams {
     /**
@@ -33,11 +40,25 @@ export const ConnectWalletDialog: React.FC<IConnectWalletDialogProps> = (
     const { close, updateOptions } = useDialogContext();
     const { open: openWeb3Modal } = useAppKit();
     const { open: isAppKitModalOpen } = useAppKitState();
+    const { switchNetwork } = useAppKitNetwork();
     const isConnected = useWalletConnected();
     const { t } = useTranslations();
 
+    // DAO routes are scoped by `/dao/[network]/...` — pin the wallet prompt to
+    // that network so MetaMask doesn't ask for permission on a stale chain
+    // (e.g. whatever was last persisted in AppKit's `active_caip_network_id`).
+    const { network: networkParam } = useParams<{ network?: Network }>();
+    const daoNetwork = networkParam
+        ? networkDefinitions[networkParam as Network]
+        : undefined;
+
     // Force "Connect" view; we don't want to see other modal views, which might happen if AppKit state gets out of sync with wagmi store.
-    const handleConnectClick = () => openWeb3Modal({ view: 'Connect' });
+    const handleConnectClick = () => {
+        if (daoNetwork) {
+            void switchNetwork(daoNetwork);
+        }
+        void openWeb3Modal({ view: 'Connect' });
+    };
 
     // Custom close callback to trigger onError property when dialog is closed and user is not connected
     const handleDialogClose = useCallback(() => {


### PR DESCRIPTION
# Description

When connecting a wallet on a non-Sepolia DAO, MetaMask was prompting to approve permission for Sepolia (or whatever chain AppKit had cached in `@appkit/active_caip_network_id` / whatever chain the wallet was currently sitting on). The chain MetaMask shows in its permission consent is determined by the chain wagmi targets at connect time, which is AppKit's *active* CAIP network — not the DAO the user is viewing.

This change pins AppKit's active network to the current DAO's chain (read from the `/dao/[network]/...` route segment) immediately before opening the AppKit Connect modal. The `switchNetwork` call is fire-and-forget: while disconnected it just updates AppKit's controller state + storage, and the wagmi connector reads that active chain at wallet-pick time.

Outside DAO routes (explore, profile, etc.) the URL has no `network` segment and we fall through to AppKit's existing behaviour.

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing