### PR TITLE
feat(APP-662): Update Aragon names and profiles to production values

### DIFF
--- a/src/modules/ens/constants/contracts.ts
+++ b/src/modules/ens/constants/contracts.ts
@@ -6,7 +6,7 @@ export const memberRegistryAddress =
 /**
  * Subdomain suffix for member ENS names.
  */
-export const memberRegistrySubdomainSuffix = '.aragonx.eth';
+export const memberRegistrySubdomainSuffix = '.aragon.eth';
 
 /**
  * ENS Reverse Registrar contract address on mainnet.

--- a/src/modules/ens/constants/ensDelegateKey.test.ts
+++ b/src/modules/ens/constants/ensDelegateKey.test.ts
@@ -7,14 +7,14 @@ import {
 describe('NETWORK_EIP3770_SHORTNAME', () => {
     it.each([
         { network: Network.ETHEREUM_MAINNET, expected: 'eth' },
-        { network: Network.POLYGON_MAINNET, expected: 'matic' },
+        { network: Network.POLYGON_MAINNET, expected: 'pol' },
         { network: Network.BASE_MAINNET, expected: 'base' },
         { network: Network.ARBITRUM_MAINNET, expected: 'arb1' },
         { network: Network.OPTIMISM_MAINNET, expected: 'oeth' },
         { network: Network.AVAX_MAINNET, expected: 'avax' },
         { network: Network.ZKSYNC_MAINNET, expected: 'zksync' },
-        { network: Network.CHILIZ_MAINNET, expected: 'chz' },
-        { network: Network.PEAQ_MAINNET, expected: 'peaq' },
+        { network: Network.CHILIZ_MAINNET, expected: 'chzmainnet' },
+        { network: Network.PEAQ_MAINNET, expected: 'PEAQ' },
         { network: Network.CITREA_MAINNET, expected: 'citrea' },
         { network: Network.KATANA_MAINNET, expected: 'katana' },
     ])('maps mainnet $network to canonical EIP-3770 shortname "$expected"', ({
@@ -67,11 +67,11 @@ describe('buildEnsDelegateKey', () => {
     });
 
     it.each([
-        { network: Network.POLYGON_MAINNET, prefix: 'matic' },
+        { network: Network.POLYGON_MAINNET, prefix: 'pol' },
         { network: Network.BASE_MAINNET, prefix: 'base' },
         { network: Network.ARBITRUM_MAINNET, prefix: 'arb1' },
         { network: Network.OPTIMISM_MAINNET, prefix: 'oeth' },
-        { network: Network.PEAQ_MAINNET, prefix: 'peaq' },
+        { network: Network.PEAQ_MAINNET, prefix: 'PEAQ' },
     ])('builds the key with the network shortname for $network', ({
         network,
         prefix,

--- a/src/modules/ens/constants/ensDelegateKey.ts
+++ b/src/modules/ens/constants/ensDelegateKey.ts
@@ -28,14 +28,14 @@ import { Network } from '@/shared/api/daoService';
  */
 export const NETWORK_EIP3770_SHORTNAME: Record<Network, string> = {
     [Network.ETHEREUM_MAINNET]: 'eth',
-    [Network.POLYGON_MAINNET]: 'matic',
+    [Network.POLYGON_MAINNET]: 'pol',
     [Network.BASE_MAINNET]: 'base',
     [Network.ARBITRUM_MAINNET]: 'arb1',
     [Network.OPTIMISM_MAINNET]: 'oeth',
     [Network.AVAX_MAINNET]: 'avax',
     [Network.ZKSYNC_MAINNET]: 'zksync',
-    [Network.CHILIZ_MAINNET]: 'chz',
-    [Network.PEAQ_MAINNET]: 'peaq',
+    [Network.CHILIZ_MAINNET]: 'chzmainnet',
+    [Network.PEAQ_MAINNET]: 'PEAQ',
     [Network.CITREA_MAINNET]: 'citrea',
     [Network.KATANA_MAINNET]: 'katana',
     [Network.ETHEREUM_SEPOLIA]: 'test',

--- a/src/modules/ens/constants/memberRegistryAbi.ts
+++ b/src/modules/ens/constants/memberRegistryAbi.ts
@@ -2,62 +2,44 @@
 // Do not edit manually.
 
 export const memberRegistryAbi = [
-    {
-        type: 'constructor',
-        inputs: [],
-        stateMutability: 'nonpayable',
-    },
+    { type: 'constructor', inputs: [], stateMutability: 'nonpayable' },
     {
         type: 'function',
-        name: 'REVOKE_MEMBER_PERMISSION_ID',
+        name: 'EVICT_SUBDOMAIN_PERMISSION_ID',
         inputs: [],
-        outputs: [
-            {
-                name: '',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-        ],
+        outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
         stateMutability: 'view',
     },
     {
         type: 'function',
         name: 'UPGRADE_REGISTRY_PERMISSION_ID',
         inputs: [],
-        outputs: [
-            {
-                name: '',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-        ],
+        outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
         stateMutability: 'view',
     },
     {
         type: 'function',
         name: 'dao',
         inputs: [],
-        outputs: [
-            {
-                name: '',
-                type: 'address',
-                internalType: 'contract IDAO',
-            },
-        ],
+        outputs: [{ name: '', type: 'address', internalType: 'contract IDAO' }],
         stateMutability: 'view',
     },
     {
         type: 'function',
         name: 'ens',
         inputs: [],
-        outputs: [
-            {
-                name: '',
-                type: 'address',
-                internalType: 'contract ENS',
-            },
-        ],
+        outputs: [{ name: '', type: 'address', internalType: 'contract ENS' }],
         stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        name: 'evict',
+        inputs: [
+            { name: 'subdomain', type: 'string', internalType: 'string' },
+            { name: 'newController', type: 'address', internalType: 'address' },
+        ],
+        outputs: [],
+        stateMutability: 'nonpayable',
     },
     {
         type: 'function',
@@ -68,21 +50,9 @@ export const memberRegistryAbi = [
                 type: 'address',
                 internalType: 'contract IDAO',
             },
-            {
-                name: '_ens',
-                type: 'address',
-                internalType: 'contract ENS',
-            },
-            {
-                name: '_node',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-            {
-                name: '_resolver',
-                type: 'address',
-                internalType: 'address',
-            },
+            { name: '_ens', type: 'address', internalType: 'contract ENS' },
+            { name: '_domain', type: 'string', internalType: 'string' },
+            { name: '_resolver', type: 'address', internalType: 'address' },
         ],
         outputs: [],
         stateMutability: 'nonpayable',
@@ -90,127 +60,36 @@ export const memberRegistryAbi = [
     {
         type: 'function',
         name: 'isRegistered',
-        inputs: [
-            {
-                name: 'member',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
-        outputs: [
-            {
-                name: '',
-                type: 'bool',
-                internalType: 'bool',
-            },
-        ],
+        inputs: [{ name: 'member', type: 'address', internalType: 'address' }],
+        outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
         stateMutability: 'view',
     },
     {
         type: 'function',
         name: 'labelOwner',
-        inputs: [
-            {
-                name: '',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-        ],
-        outputs: [
-            {
-                name: '',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
+        inputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+        outputs: [{ name: '', type: 'address', internalType: 'address' }],
         stateMutability: 'view',
     },
     {
         type: 'function',
         name: 'memberLabel',
-        inputs: [
-            {
-                name: '',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
-        outputs: [
-            {
-                name: '',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-        ],
+        inputs: [{ name: '', type: 'address', internalType: 'address' }],
+        outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
         stateMutability: 'view',
     },
     {
         type: 'function',
         name: 'memberSubdomain',
+        inputs: [{ name: '', type: 'address', internalType: 'address' }],
+        outputs: [{ name: '', type: 'string', internalType: 'string' }],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        name: 'move',
         inputs: [
-            {
-                name: '',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
-        outputs: [
-            {
-                name: '',
-                type: 'string',
-                internalType: 'string',
-            },
-        ],
-        stateMutability: 'view',
-    },
-    {
-        type: 'function',
-        name: 'node',
-        inputs: [],
-        outputs: [
-            {
-                name: '',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-        ],
-        stateMutability: 'view',
-    },
-    {
-        type: 'function',
-        name: 'protocolVersion',
-        inputs: [],
-        outputs: [
-            {
-                name: '',
-                type: 'uint8[3]',
-                internalType: 'uint8[3]',
-            },
-        ],
-        stateMutability: 'pure',
-    },
-    {
-        type: 'function',
-        name: 'proxiableUUID',
-        inputs: [],
-        outputs: [
-            {
-                name: '',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-        ],
-        stateMutability: 'view',
-    },
-    {
-        type: 'function',
-        name: 'register',
-        inputs: [
-            {
-                name: 'subdomain',
-                type: 'string',
-                internalType: 'string',
-            },
+            { name: 'newSubdomain', type: 'string', internalType: 'string' },
             {
                 name: 'records',
                 type: 'tuple',
@@ -233,11 +112,69 @@ export const memberRegistryAbi = [
                             },
                         ],
                     },
+                    { name: 'addr', type: 'address', internalType: 'address' },
                     {
-                        name: 'addr',
-                        type: 'address',
-                        internalType: 'address',
+                        name: 'contenthash',
+                        type: 'bytes',
+                        internalType: 'bytes',
                     },
+                ],
+            },
+        ],
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        name: 'move',
+        inputs: [
+            { name: 'newSubdomain', type: 'string', internalType: 'string' },
+        ],
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        name: 'parentDomain',
+        inputs: [],
+        outputs: [{ name: '', type: 'string', internalType: 'string' }],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        name: 'parentNode',
+        inputs: [],
+        outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        name: 'register',
+        inputs: [
+            { name: 'subdomain', type: 'string', internalType: 'string' },
+            {
+                name: 'records',
+                type: 'tuple',
+                internalType: 'struct IMemberRegistry.Records',
+                components: [
+                    {
+                        name: 'textRecords',
+                        type: 'tuple[]',
+                        internalType: 'struct IMemberRegistry.TextRecord[]',
+                        components: [
+                            {
+                                name: 'key',
+                                type: 'string',
+                                internalType: 'string',
+                            },
+                            {
+                                name: 'value',
+                                type: 'string',
+                                internalType: 'string',
+                            },
+                        ],
+                    },
+                    { name: 'addr', type: 'address', internalType: 'address' },
                     {
                         name: 'contenthash',
                         type: 'bytes',
@@ -252,13 +189,7 @@ export const memberRegistryAbi = [
     {
         type: 'function',
         name: 'register',
-        inputs: [
-            {
-                name: 'subdomain',
-                type: 'string',
-                internalType: 'string',
-            },
-        ],
+        inputs: [{ name: 'subdomain', type: 'string', internalType: 'string' }],
         outputs: [],
         stateMutability: 'nonpayable',
     },
@@ -271,351 +202,9 @@ export const memberRegistryAbi = [
     },
     {
         type: 'function',
-        name: 'rename',
-        inputs: [
-            {
-                name: 'newSubdomain',
-                type: 'string',
-                internalType: 'string',
-            },
-            {
-                name: 'records',
-                type: 'tuple',
-                internalType: 'struct IMemberRegistry.Records',
-                components: [
-                    {
-                        name: 'textRecords',
-                        type: 'tuple[]',
-                        internalType: 'struct IMemberRegistry.TextRecord[]',
-                        components: [
-                            {
-                                name: 'key',
-                                type: 'string',
-                                internalType: 'string',
-                            },
-                            {
-                                name: 'value',
-                                type: 'string',
-                                internalType: 'string',
-                            },
-                        ],
-                    },
-                    {
-                        name: 'addr',
-                        type: 'address',
-                        internalType: 'address',
-                    },
-                    {
-                        name: 'contenthash',
-                        type: 'bytes',
-                        internalType: 'bytes',
-                    },
-                ],
-            },
-        ],
-        outputs: [],
-        stateMutability: 'nonpayable',
-    },
-    {
-        type: 'function',
-        name: 'rename',
-        inputs: [
-            {
-                name: 'newSubdomain',
-                type: 'string',
-                internalType: 'string',
-            },
-        ],
-        outputs: [],
-        stateMutability: 'nonpayable',
-    },
-    {
-        type: 'function',
         name: 'resolver',
         inputs: [],
-        outputs: [
-            {
-                name: '',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
+        outputs: [{ name: '', type: 'address', internalType: 'address' }],
         stateMutability: 'view',
-    },
-    {
-        type: 'function',
-        name: 'revoke',
-        inputs: [
-            {
-                name: 'member',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
-        outputs: [],
-        stateMutability: 'nonpayable',
-    },
-    {
-        type: 'function',
-        name: 'upgradeTo',
-        inputs: [
-            {
-                name: 'newImplementation',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
-        outputs: [],
-        stateMutability: 'nonpayable',
-    },
-    {
-        type: 'function',
-        name: 'upgradeToAndCall',
-        inputs: [
-            {
-                name: 'newImplementation',
-                type: 'address',
-                internalType: 'address',
-            },
-            {
-                name: 'data',
-                type: 'bytes',
-                internalType: 'bytes',
-            },
-        ],
-        outputs: [],
-        stateMutability: 'payable',
-    },
-    {
-        type: 'event',
-        name: 'AdminChanged',
-        inputs: [
-            {
-                name: 'previousAdmin',
-                type: 'address',
-                indexed: false,
-                internalType: 'address',
-            },
-            {
-                name: 'newAdmin',
-                type: 'address',
-                indexed: false,
-                internalType: 'address',
-            },
-        ],
-        anonymous: false,
-    },
-    {
-        type: 'event',
-        name: 'BeaconUpgraded',
-        inputs: [
-            {
-                name: 'beacon',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
-            },
-        ],
-        anonymous: false,
-    },
-    {
-        type: 'event',
-        name: 'Initialized',
-        inputs: [
-            {
-                name: 'version',
-                type: 'uint8',
-                indexed: false,
-                internalType: 'uint8',
-            },
-        ],
-        anonymous: false,
-    },
-    {
-        type: 'event',
-        name: 'MemberRegistered',
-        inputs: [
-            {
-                name: 'member',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
-            },
-            {
-                name: 'subdomain',
-                type: 'string',
-                indexed: false,
-                internalType: 'string',
-            },
-        ],
-        anonymous: false,
-    },
-    {
-        type: 'event',
-        name: 'MemberReleased',
-        inputs: [
-            {
-                name: 'member',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
-            },
-            {
-                name: 'subdomain',
-                type: 'string',
-                indexed: false,
-                internalType: 'string',
-            },
-        ],
-        anonymous: false,
-    },
-    {
-        type: 'event',
-        name: 'MemberRenamed',
-        inputs: [
-            {
-                name: 'member',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
-            },
-            {
-                name: 'oldSubdomain',
-                type: 'string',
-                indexed: false,
-                internalType: 'string',
-            },
-            {
-                name: 'newSubdomain',
-                type: 'string',
-                indexed: false,
-                internalType: 'string',
-            },
-        ],
-        anonymous: false,
-    },
-    {
-        type: 'event',
-        name: 'MemberRevoked',
-        inputs: [
-            {
-                name: 'member',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
-            },
-            {
-                name: 'revoker',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
-            },
-            {
-                name: 'subdomain',
-                type: 'string',
-                indexed: false,
-                internalType: 'string',
-            },
-        ],
-        anonymous: false,
-    },
-    {
-        type: 'event',
-        name: 'Upgraded',
-        inputs: [
-            {
-                name: 'implementation',
-                type: 'address',
-                indexed: true,
-                internalType: 'address',
-            },
-        ],
-        anonymous: false,
-    },
-    {
-        type: 'error',
-        name: 'AlreadyRegistered',
-        inputs: [
-            {
-                name: 'member',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
-    },
-    {
-        type: 'error',
-        name: 'DaoUnauthorized',
-        inputs: [
-            {
-                name: 'dao',
-                type: 'address',
-                internalType: 'address',
-            },
-            {
-                name: 'where',
-                type: 'address',
-                internalType: 'address',
-            },
-            {
-                name: 'who',
-                type: 'address',
-                internalType: 'address',
-            },
-            {
-                name: 'permissionId',
-                type: 'bytes32',
-                internalType: 'bytes32',
-            },
-        ],
-    },
-    {
-        type: 'error',
-        name: 'InvalidENSRegistry',
-        inputs: [
-            {
-                name: 'ens',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
-    },
-    {
-        type: 'error',
-        name: 'InvalidNode',
-        inputs: [],
-    },
-    {
-        type: 'error',
-        name: 'InvalidSubdomain',
-        inputs: [
-            {
-                name: 'subdomain',
-                type: 'string',
-                internalType: 'string',
-            },
-        ],
-    },
-    {
-        type: 'error',
-        name: 'NotRegistered',
-        inputs: [
-            {
-                name: 'member',
-                type: 'address',
-                internalType: 'address',
-            },
-        ],
-    },
-    {
-        type: 'error',
-        name: 'SubdomainAlreadyTaken',
-        inputs: [
-            {
-                name: 'subdomain',
-                type: 'string',
-                internalType: 'string',
-            },
-        ],
     },
 ] as const;

--- a/src/modules/ens/hooks/useEnsName.test.ts
+++ b/src/modules/ens/hooks/useEnsName.test.ts
@@ -19,13 +19,13 @@ describe('useEnsName hook', () => {
     });
 
     it('returns the full ENS name by default', () => {
-        mockEnsResult('alice.aragonx.eth');
+        mockEnsResult('alice.aragon.eth');
         const { result } = renderHook(() => useEnsName(validAddress));
-        expect(result.current.data).toBe('alice.aragonx.eth');
+        expect(result.current.data).toBe('alice.aragon.eth');
     });
 
     it('strips the aragon subdomain suffix when stripAragonRegistrySuffix is set', () => {
-        mockEnsResult('alice.aragonx.eth');
+        mockEnsResult('alice.aragon.eth');
         const { result } = renderHook(() =>
             useEnsName(validAddress, { stripAragonRegistrySuffix: true }),
         );

--- a/src/modules/ens/hooks/useEnsName.ts
+++ b/src/modules/ens/hooks/useEnsName.ts
@@ -9,7 +9,7 @@ import { logEnsError } from '../utils/logEnsError';
 export interface IUseEnsNameOptions {
     /**
      * When true and the resolved ENS is an Aragon member-registry subdomain
-     * (e.g. `alice.aragonx.eth`), the hook returns just the subdomain (`alice`).
+     * (e.g. `alice.aragon.eth`), the hook returns just the subdomain (`alice`).
      * Used on member-facing surfaces: member list items (token + default),
      * delegation card, and profile header (title and breadcrumb).
      * Anywhere else, leave this off so the full ENS is shown.

--- a/src/modules/governance/dialogs/delegateStatementTransactionDialog/delegateStatementTransactionDialogUtils.test.ts
+++ b/src/modules/governance/dialogs/delegateStatementTransactionDialog/delegateStatementTransactionDialogUtils.test.ts
@@ -78,7 +78,7 @@ describe('delegateStatementTransactionDialogUtils.buildTransaction', () => {
             data: tx.data,
         });
         expect(decoded.args[1]).toBe(
-            'matic.0x1234abcdef1234abcdef1234abcdef1234abcdef.delegate',
+            'pol.0x1234abcdef1234abcdef1234abcdef1234abcdef.delegate',
         );
     });
 

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
@@ -269,7 +269,7 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
                 ({
                     data: options?.stripAragonRegistrySuffix
                         ? 'alice'
-                        : 'alice.aragonx.eth',
+                        : 'alice.aragon.eth',
                     isLoading: false,
                 }) as ReturnType<typeof ensModule.useEnsName>,
         );
@@ -280,7 +280,7 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
             screen.getByRole('heading', { level: 1, name: 'alice' }),
         ).toBeInTheDocument();
         expect(
-            screen.getByRole('link', { name: 'alice.aragonx.eth' }),
+            screen.getByRole('link', { name: 'alice.aragon.eth' }),
         ).toBeInTheDocument();
     });
 

--- a/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.test.tsx
+++ b/src/plugins/tokenPlugin/components/tokenMemberList/components/tokenMemberListItem.test.tsx
@@ -83,13 +83,13 @@ describe('<TokenMemberListItem /> component', () => {
                 ({
                     data: options?.stripAragonRegistrySuffix
                         ? 'alice'
-                        : 'alice.aragonx.eth',
+                        : 'alice.aragon.eth',
                     isLoading: false,
                 }) as ReturnType<typeof ensModule.useEnsName>,
         );
         render(createTestComponent({ member }));
         expect(screen.getByText('alice')).toBeInTheDocument();
-        expect(screen.queryByText('alice.aragonx.eth')).not.toBeInTheDocument();
+        expect(screen.queryByText('alice.aragon.eth')).not.toBeInTheDocument();
     });
 
     it('retrieves the plugin settings to parse the member voting power using the decimals of the governance token', () => {

--- a/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.test.tsx
+++ b/src/plugins/tokenPlugin/dialogs/tokenDelegationDialog/tokenDelegationDialog.test.tsx
@@ -134,7 +134,7 @@ describe('<TokenDelegationDialog /> component', () => {
                 ({
                     data: options?.stripAragonRegistrySuffix
                         ? 'alice'
-                        : 'alice.aragonx.eth',
+                        : 'alice.aragon.eth',
                     isLoading: false,
                 }) as ReturnType<typeof ensModule.useEnsName>,
         );


### PR DESCRIPTION
# Description

Migrates ENS member names and profile values to their production configuration:

- Switch the member-registry subdomain suffix from `.aragonx.eth` to `.aragon.eth`.
- Update EIP-3770 network shortnames to production values (`matic` → `pol`, `chz` → `chzmainnet`, `peaq` → `PEAQ`).
- Update the `memberRegistry` ABI.
- Adjust ENS-related tests accordingly.

## Type of Change

- [x] Patch: Enhancement (non-breaking change to an existing feature)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project