### PR TITLE
fix(APP-784): stabilize smoke and BV on staging

### DIFF
--- a/.changeset/slick-showers-report.md
+++ b/.changeset/slick-showers-report.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Improve E2E reliability against staging.

--- a/e2e/helpers/constants/index.ts
+++ b/e2e/helpers/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './bvDaos';
 export * from './daos';
+export * from './metamaskActions';
 export * from './timeouts';

--- a/e2e/helpers/constants/metamaskActions.ts
+++ b/e2e/helpers/constants/metamaskActions.ts
@@ -1,0 +1,26 @@
+/** Button labels MetaMask may show on notification popups (exact match). */
+export const MM_PRIMARY_ACTION_NAMES = [
+    'Connect',
+    'Switch network',
+    'Approve',
+    'Confirm',
+    'Sign',
+    'Sign transaction',
+] as const;
+
+/** Subset used before AppKit connect (network switch only). */
+export const MM_NETWORK_SWITCH_ACTION_NAMES = [
+    'Switch network',
+    'Approve',
+    'Confirm',
+] as const;
+
+const MM_PRIMARY_ACTION_PATTERN = MM_PRIMARY_ACTION_NAMES.map((name) =>
+    name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+).join('|');
+
+/** Fallback when no primary-action button matches by accessible name. */
+export const MM_PRIMARY_ACTION_REGEX = new RegExp(
+    `^(${MM_PRIMARY_ACTION_PATTERN})$`,
+    'i',
+);

--- a/e2e/helpers/constants/timeouts.ts
+++ b/e2e/helpers/constants/timeouts.ts
@@ -4,7 +4,7 @@
  */
 
 /** MetaMask notification popup may appear with a delay after a dApp action. */
-export const MM_NOTIFICATION_TIMEOUT = 15_000;
+export const MM_NOTIFICATION_TIMEOUT = 20_000;
 
 /** Extended timeout for MetaMask notifications during transaction confirmation. */
 export const MM_CONFIRM_NOTIFICATION_TIMEOUT = 45_000;
@@ -16,7 +16,7 @@ export const GOVERNANCE_DIALOG_TIMEOUT = 35_000;
 export const VIEW_PROPOSAL_TIMEOUT = 120_000;
 
 /** MetaMask confirm-action button search within a notification popup. */
-export const MM_CONFIRM_ACTION_TIMEOUT = 12_000;
+export const MM_CONFIRM_ACTION_TIMEOUT = 18_000;
 
 /** Waiting for proposal creation elements (title, actions, asset dialog). */
 export const PROPOSAL_FORM_ELEMENT_TIMEOUT = 25_000;
@@ -29,3 +29,42 @@ export const EXECUTION_TIMEOUT = 120_000;
 
 /** Member-gate API response before interacting with proposals page. */
 export const MEMBER_GATE_API_TIMEOUT = 25_000;
+
+/** Proposals list API + skeleton → links (slow on staging). */
+export const PROPOSALS_API_TIMEOUT = 60_000;
+
+/** Optional MetaMask popup poll (e.g. network switch before connect). */
+export const MM_OPTIONAL_NOTIFICATION_TIMEOUT = 5000;
+
+/** Plugin picker dialog when creating a proposal. */
+export const PLUGIN_SELECT_DIALOG_TIMEOUT = 10_000;
+
+/** Typical form step / option visibility (wizard, explore). */
+export const UI_STEP_TIMEOUT = 15_000;
+
+/** Asset picker and similar heavier dialogs. */
+export const UI_DIALOG_TIMEOUT = 20_000;
+
+/** Short assertion after debounced field input. */
+export const UI_FIELD_VALUE_TIMEOUT = 10_000;
+
+/** Aragon profile intro dismiss after wallet connect. */
+export const ARAGON_PROFILE_DISMISS_TIMEOUT = 20_000;
+
+/** Explore DAO search debounced API response. */
+export const EXPLORE_SEARCH_API_TIMEOUT = 30_000;
+
+/** Explore DAO cards visible after search. */
+export const EXPLORE_SEARCH_UI_TIMEOUT = 15_000;
+
+/** Redirect to proposal detail after publish. */
+export const PROPOSAL_CREATED_NAV_TIMEOUT = 60_000;
+
+/** Accordion expand affordance on proposal detail. */
+export const ACCORDION_VISIBILITY_TIMEOUT = 5000;
+
+/** "Sign transaction" in publish proposal dialog. */
+export const SIGN_TRANSACTION_TIMEOUT = 40_000;
+
+/** Governance dialog sign / resend button click. */
+export const GOVERNANCE_SIGN_CLICK_TIMEOUT = 90_000;

--- a/e2e/helpers/flows/multisigTreasuryWithdrawalFlow.ts
+++ b/e2e/helpers/flows/multisigTreasuryWithdrawalFlow.ts
@@ -3,14 +3,23 @@ import type { MetaMask } from '@synthetixio/synpress/playwright';
 import { getAddress } from 'viem';
 import type { BvMultisigTreasuryDao } from '../constants/bvDaos';
 import {
+    ACCORDION_VISIBILITY_TIMEOUT,
+    ARAGON_PROFILE_DISMISS_TIMEOUT,
     MEMBER_GATE_API_TIMEOUT,
+    PLUGIN_SELECT_DIALOG_TIMEOUT,
+    PROPOSAL_CREATED_NAV_TIMEOUT,
     PROPOSAL_FORM_ELEMENT_TIMEOUT,
     PUBLISH_DIALOG_TIMEOUT,
+    UI_DIALOG_TIMEOUT,
+    UI_FIELD_VALUE_TIMEOUT,
+    UI_STEP_TIMEOUT,
 } from '../constants/timeouts';
 import { DaoProposalDetailPage } from '../pages/daoProposalDetailPage/daoProposalDetailPage';
 import { DaoProposalsPage } from '../pages/daoProposalsPage/daoProposalsPage';
 import { WalletConnectionPage } from '../shared/walletConnectionPage/walletConnectionPage';
 import {
+    approveOptionalMetaMaskNotifications,
+    getConnectedWalletAddress,
     signTransactionInDappDialog,
     switchNetwork,
 } from '../utils/metamaskUtils';
@@ -41,7 +50,10 @@ async function advanceFromActionsStepSkippingSimulation(
             }),
         })
         .last();
-    await actionsFooterMenu.waitFor({ state: 'visible', timeout: 15_000 });
+    await actionsFooterMenu.waitFor({
+        state: 'visible',
+        timeout: UI_STEP_TIMEOUT,
+    });
     await page
         .locator('button[type="submit"][form="createProposalWizard"]')
         .filter({ hasText: 'Skip simulation' })
@@ -68,7 +80,27 @@ export async function ensureBvDaoSession(
     });
     await walletPage.navigate();
     await walletPage.connectWallet(metamask);
+    await approveOptionalMetaMaskNotifications(metamask);
     await switchNetwork(page, metamask, dao.network);
+
+    const walletAddress = await getConnectedWalletAddress(page);
+    // AragonProfileOnboardingWatcher — once per address after connect
+    await page.evaluate((addr) => {
+        localStorage.setItem(
+            `aragon-profile-onboarding:${addr.toLowerCase()}`,
+            'true',
+        );
+    }, walletAddress);
+    await page
+        .getByRole('dialog')
+        .filter({
+            has: page.getByRole('heading', {
+                name: /your profile|Aragon name/i,
+            }),
+        })
+        .getByRole('button', { name: 'Cancel', exact: true })
+        .click({ timeout: ARAGON_PROFILE_DISMISS_TIMEOUT })
+        .catch(() => undefined);
 }
 
 /**
@@ -76,8 +108,9 @@ export async function ensureBvDaoSession(
  * "New Proposal" button on the proposals page. Without this, clicking
  * the button may race against the member-check and fail.
  */
-export async function waitForProposalsMemberGate(page: Page): Promise<void> {
-    await page.waitForResponse(
+/** Call before navigating to proposals — the exists check fires during page load. */
+export function waitForProposalsMemberGate(page: Page) {
+    return page.waitForResponse(
         (res) =>
             /\/v2\/members\/[^/]+\/[^/]+\/exists(?:\?|$)/.test(res.url()) &&
             res.ok(),
@@ -97,9 +130,10 @@ export async function openMultisigProposalWizard(page: Page): Promise<void> {
         .click();
 
     try {
-        await page
-            .getByRole('dialog')
-            .waitFor({ state: 'visible', timeout: 10_000 });
+        await page.getByRole('dialog').waitFor({
+            state: 'visible',
+            timeout: PLUGIN_SELECT_DIALOG_TIMEOUT,
+        });
     } catch {
         // Single-process DAOs skip the plugin selection dialog
         // and navigate straight to the create URL.
@@ -151,24 +185,24 @@ export async function fillMultisigNativeWithdrawProposal(
     const actionSearch = page.getByPlaceholder(
         /Search by action, contract name, or address/i,
     );
-    await expect(actionSearch).toBeVisible({ timeout: 15_000 });
+    await expect(actionSearch).toBeVisible({ timeout: UI_STEP_TIMEOUT });
     await actionSearch.fill('Transfer');
     const transferOption = page.getByRole('option', {
         name: 'Transfer',
         exact: true,
     });
-    await expect(transferOption).toBeVisible({ timeout: 15_000 });
+    await expect(transferOption).toBeVisible({ timeout: UI_STEP_TIMEOUT });
     await transferOption.click();
 
     const assetTrigger = wizardForm.getByRole('button', {
         name: 'Select',
         exact: true,
     });
-    await expect(assetTrigger).toBeVisible({ timeout: 20_000 });
+    await expect(assetTrigger).toBeVisible({ timeout: UI_DIALOG_TIMEOUT });
     await assetTrigger.click();
 
     const assetDialog = page.getByRole('dialog', { name: 'Select an asset' });
-    await expect(assetDialog).toBeVisible({ timeout: 20_000 });
+    await expect(assetDialog).toBeVisible({ timeout: UI_DIALOG_TIMEOUT });
     await expect(
         assetDialog.getByText(/ETH|Ether|Ethereum/i).first(),
     ).toBeVisible({ timeout: PROPOSAL_FORM_ELEMENT_TIMEOUT });
@@ -176,17 +210,21 @@ export async function fillMultisigNativeWithdrawProposal(
         .getByText(/^(Ether|Ethereum|ETH)$/)
         .first()
         .click();
-    await expect(assetDialog).toBeHidden({ timeout: 15_000 });
+    await expect(assetDialog).toBeHidden({ timeout: UI_STEP_TIMEOUT });
 
-    await expect(
-        wizardForm.getByRole('button', { name: 'Max', exact: true }),
-    ).toBeVisible({ timeout: PUBLISH_DIALOG_TIMEOUT });
+    // AssetInput labels the button "Max {balance}" (e.g. "Max 0.51"), not "Max" alone.
+    const maxAmountButton = wizardForm.getByRole('button', { name: /^Max\b/ });
+    await expect(maxAmountButton).toBeVisible({
+        timeout: PUBLISH_DIALOG_TIMEOUT,
+    });
 
     const amountField = wizardForm.getByRole('spinbutton');
-    await expect(amountField).toBeEnabled({ timeout: 15_000 });
+    await expect(amountField).toBeEnabled({ timeout: UI_STEP_TIMEOUT });
     await amountField.fill(amountEth);
     await amountField.blur();
-    await expect(amountField).toHaveValue(amountEth, { timeout: 10_000 });
+    await expect(amountField).toHaveValue(amountEth, {
+        timeout: UI_FIELD_VALUE_TIMEOUT,
+    });
 
     const recipientField = wizardForm.getByPlaceholder(/ENS or 0x/i);
     await recipientField.click();
@@ -199,7 +237,7 @@ export async function fillMultisigNativeWithdrawProposal(
         wizardForm
             .getByText(new RegExp(checksummedReceiver.slice(0, 6), 'i'))
             .first(),
-    ).toBeVisible({ timeout: 20_000 });
+    ).toBeVisible({ timeout: UI_DIALOG_TIMEOUT });
     await page
         .getByRole('heading', { name: 'Add actions', exact: true })
         .click();
@@ -243,7 +281,9 @@ export async function expectProposalActionsDecoded(page: Page): Promise<void> {
         .locator('button[aria-expanded="false"]')
         .first();
     if (
-        await accordionTrigger.isVisible({ timeout: 5000 }).catch(() => false)
+        await accordionTrigger
+            .isVisible({ timeout: ACCORDION_VISIBILITY_TIMEOUT })
+            .catch(() => false)
     ) {
         await accordionTrigger.click();
     }
@@ -277,8 +317,9 @@ export async function createAndPublishMultisigWithdrawProposal(
         network: dao.network,
         address: dao.address,
     });
+    const memberGate = waitForProposalsMemberGate(page);
     await proposals.navigate();
-    await waitForProposalsMemberGate(page);
+    await memberGate.catch(() => undefined);
     await openMultisigProposalWizard(page);
 
     const proposalTitle = `${titlePrefix} ${Date.now()}`;
@@ -289,7 +330,9 @@ export async function createAndPublishMultisigWithdrawProposal(
     });
 
     await signTransactionInDappDialog(page, metamask);
-    await page.waitForURL(/\/proposals/, { timeout: 60_000 });
+    await page.waitForURL(/\/proposals/, {
+        timeout: PROPOSAL_CREATED_NAV_TIMEOUT,
+    });
 
     return { title: proposalTitle, url: page.url() };
 }

--- a/e2e/helpers/pages/daoProposalsPage/daoProposalsPage.ts
+++ b/e2e/helpers/pages/daoProposalsPage/daoProposalsPage.ts
@@ -1,4 +1,5 @@
 import type { Page as PlaywrightPage } from '@playwright/test';
+import { PROPOSALS_API_TIMEOUT } from '../../constants/timeouts';
 import { DaoPage } from '../../shared';
 
 export class DaoProposalsPage extends DaoPage {
@@ -18,4 +19,33 @@ export class DaoProposalsPage extends DaoPage {
     readonly firstProposal = () => this.proposalList().first();
 
     readonly asideCard = () => this.page.getByRole('complementary');
+
+    private isProposalsListResponse(url: string) {
+        return (
+            url.includes('/v2/proposals') &&
+            url.includes(this.daoId) &&
+            !url.includes('/v2/proposals/slug/')
+        );
+    }
+
+    /** Waits until proposal links render (past loading skeletons). */
+    async waitForProposalListLoaded() {
+        await this.firstProposal().waitFor({
+            state: 'visible',
+            timeout: PROPOSALS_API_TIMEOUT,
+        });
+    }
+
+    override async navigate() {
+        const proposalsResponse = this.page.waitForResponse(
+            (res) => this.isProposalsListResponse(res.url()) && res.ok(),
+            { timeout: PROPOSALS_API_TIMEOUT },
+        );
+
+        await super.navigate();
+        await proposalsResponse.catch(() => undefined);
+        await this.waitForProposalListLoaded();
+
+        return this;
+    }
 }

--- a/e2e/helpers/shared/daoPage/daoPage.ts
+++ b/e2e/helpers/shared/daoPage/daoPage.ts
@@ -9,11 +9,21 @@ export interface IDaoPageParams {
 }
 
 export class DaoPage extends BasePage {
+    protected readonly network: string;
+    protected readonly address: string;
+
     constructor(params: IDaoPageParams) {
         const { page, network, address, path = '' } = params;
         super({
             page,
             path: `/dao/${network}/${address}${path ? `/${path}` : ''}`,
         });
+        this.network = network;
+        this.address = address;
+    }
+
+    /** Backend DAO id segment used in API URLs (`{network}-{address}`). */
+    protected get daoId(): string {
+        return `${this.network}-${this.address}`;
     }
 }

--- a/e2e/helpers/shared/page/page.ts
+++ b/e2e/helpers/shared/page/page.ts
@@ -20,7 +20,7 @@ export class BasePage {
         this.path = params.path;
     }
 
-    navigate = async () => {
+    async navigate() {
         try {
             this.response = await this.page.goto(this.path, {
                 waitUntil: 'domcontentloaded',
@@ -34,7 +34,7 @@ export class BasePage {
             this.vercelError = true;
         }
         return this;
-    };
+    }
 
     isVercelError = () => this.vercelError;
 

--- a/e2e/helpers/shared/walletConnectionPage/walletConnectionPage.ts
+++ b/e2e/helpers/shared/walletConnectionPage/walletConnectionPage.ts
@@ -1,11 +1,16 @@
 import type { MetaMask } from '@synthetixio/synpress/playwright';
-import { connectToDapp } from '../../utils/metamaskUtils';
+import {
+    approveOptionalMetaMaskNotifications,
+    connectToDapp,
+} from '../../utils/metamaskUtils';
 import { BasePage } from '../page';
 
 export class WalletConnectionPage extends BasePage {
     async connectWallet(metamask: MetaMask) {
         await this.openConnectDialog();
         await this.openWeb3ConnectDialog();
+        // ConnectWalletDialog switches network before opening AppKit.
+        await approveOptionalMetaMaskNotifications(metamask);
         await this.approveTermsOfCondition();
         await this.selectWallet('MetaMask');
 

--- a/e2e/helpers/utils/metamaskUtils.ts
+++ b/e2e/helpers/utils/metamaskUtils.ts
@@ -2,10 +2,19 @@ import type { BrowserContext, Page } from '@playwright/test';
 import type { MetaMask } from '@synthetixio/synpress/playwright';
 import { parseEther } from 'viem';
 import {
+    MM_NETWORK_SWITCH_ACTION_NAMES,
+    MM_PRIMARY_ACTION_NAMES,
+    MM_PRIMARY_ACTION_REGEX,
+} from '../constants/metamaskActions';
+import {
     GOVERNANCE_DIALOG_TIMEOUT,
+    GOVERNANCE_SIGN_CLICK_TIMEOUT,
     MM_CONFIRM_ACTION_TIMEOUT,
     MM_CONFIRM_NOTIFICATION_TIMEOUT,
     MM_NOTIFICATION_TIMEOUT,
+    MM_OPTIONAL_NOTIFICATION_TIMEOUT,
+    SIGN_TRANSACTION_TIMEOUT,
+    UI_DIALOG_TIMEOUT,
     VIEW_PROPOSAL_TIMEOUT,
 } from '../constants/timeouts';
 
@@ -52,10 +61,15 @@ export async function getMetaMaskActionPage(
 /** Confirms the pending MetaMask notification by trying common button labels. */
 async function clickMetaMaskConfirmAction(
     actionPage: Page,
-    { timeout = MM_CONFIRM_ACTION_TIMEOUT }: { timeout?: number } = {},
+    {
+        timeout = MM_CONFIRM_ACTION_TIMEOUT,
+        preferredNames = MM_PRIMARY_ACTION_NAMES,
+    }: {
+        timeout?: number;
+        preferredNames?: readonly string[];
+    } = {},
 ) {
-    const exactNames = ['Confirm', 'Sign', 'Approve', 'Sign transaction'];
-    for (const name of exactNames) {
+    for (const name of preferredNames) {
         const btn = actionPage.getByRole('button', { name, exact: true });
         if (await btn.isVisible().catch(() => false)) {
             await btn.click();
@@ -64,10 +78,49 @@ async function clickMetaMaskConfirmAction(
     }
     const fallback = actionPage
         .getByRole('button')
-        .filter({ hasText: /^(Confirm|Sign|Approve)$/i })
+        .filter({ hasText: MM_PRIMARY_ACTION_REGEX })
         .first();
     await fallback.waitFor({ state: 'visible', timeout });
     await fallback.click();
+}
+
+/**
+ * Approves any MetaMask notification already open (e.g. network switch from AppKit
+ * before the Connect popup). No-op when no notification is present.
+ */
+export async function approveOptionalMetaMaskNotifications(
+    metamask: MetaMask,
+    {
+        timeout = MM_OPTIONAL_NOTIFICATION_TIMEOUT,
+        maxRounds = 2,
+        preferredNames = MM_NETWORK_SWITCH_ACTION_NAMES,
+    }: {
+        timeout?: number;
+        maxRounds?: number;
+        preferredNames?: readonly string[];
+    } = {},
+) {
+    const extensionId = metamask.extensionId;
+    if (!extensionId) {
+        return;
+    }
+
+    for (let round = 0; round < maxRounds; round++) {
+        try {
+            const actionPage = await getMetaMaskActionPage(
+                metamask.context,
+                extensionId,
+                timeout,
+            );
+            await clickMetaMaskConfirmAction(actionPage, {
+                timeout,
+                preferredNames,
+            });
+            await metamask.page.waitForTimeout(400);
+        } catch {
+            return;
+        }
+    }
 }
 
 /**
@@ -130,7 +183,7 @@ export async function signTransactionInDappDialog(
     page: Page,
     metamask: MetaMask,
     {
-        signTimeout = 40_000,
+        signTimeout = SIGN_TRANSACTION_TIMEOUT,
         viewProposalTimeout = VIEW_PROPOSAL_TIMEOUT,
     }: { signTimeout?: number; viewProposalTimeout?: number } = {},
 ) {
@@ -186,7 +239,11 @@ export async function switchNetwork(
                 params: [{ chainId: cId }],
             });
         }, chainId),
-        getMetaMaskActionPage(metamask.context, extensionId, 5000)
+        getMetaMaskActionPage(
+            metamask.context,
+            extensionId,
+            MM_OPTIONAL_NOTIFICATION_TIMEOUT,
+        )
             .then((actionPage) => clickMetaMaskConfirmAction(actionPage))
             .catch(() => undefined),
     ]);
@@ -254,7 +311,7 @@ export async function confirmGovernanceTransactionDialog(
 
     for (let round = 0; round < maxRounds; round++) {
         if (await viewProposalCta.isVisible().catch(() => false)) {
-            await viewProposalCta.click({ timeout: 20_000 });
+            await viewProposalCta.click({ timeout: UI_DIALOG_TIMEOUT });
             return;
         }
 
@@ -267,7 +324,7 @@ export async function confirmGovernanceTransactionDialog(
                 state: 'visible',
                 timeout: viewProposalTimeout,
             });
-            await viewProposalCta.click({ timeout: 20_000 });
+            await viewProposalCta.click({ timeout: UI_DIALOG_TIMEOUT });
             return;
         }
 
@@ -280,7 +337,7 @@ export async function confirmGovernanceTransactionDialog(
                 .getByRole('button', { name, exact: true });
             if (await btn.isVisible().catch(() => false)) {
                 await page.bringToFront();
-                await btn.click({ timeout: 90_000 });
+                await btn.click({ timeout: GOVERNANCE_SIGN_CLICK_TIMEOUT });
                 clicked = true;
                 await confirmTransaction(metamask);
                 break;
@@ -297,7 +354,7 @@ export async function confirmGovernanceTransactionDialog(
         state: 'visible',
         timeout: viewProposalTimeout,
     });
-    await viewProposalCta.click({ timeout: 20_000 });
+    await viewProposalCta.click({ timeout: UI_DIALOG_TIMEOUT });
 }
 
 /**

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -21,7 +21,8 @@ export default defineConfig({
                   { outputFolder: './playwright-report', open: 'on-failure' },
               ],
           ],
-    timeout: 60_000,
+    // Proposals navigate waits up to PROPOSALS_API_TIMEOUT for API + list render.
+    timeout: 90_000,
     expect: { timeout: process.env.CI ? 15_000 : 10_000 },
     use: {
         baseURL,

--- a/e2e/tests/smoke/daoPage/daoProposalDetail.spec.ts
+++ b/e2e/tests/smoke/daoPage/daoProposalDetail.spec.ts
@@ -14,7 +14,7 @@ for (const dao of SMOKE_DAOS) {
         }).navigate();
 
         const firstProposalLink = proposals.firstProposal();
-        await expect(firstProposalLink).toBeVisible({ timeout: 30_000 });
+        await expect(firstProposalLink).toBeVisible();
 
         const href = await firstProposalLink.getAttribute('href');
         expect(href).toBeTruthy();

--- a/e2e/tests/smoke/daoPage/daoProposals.spec.ts
+++ b/e2e/tests/smoke/daoPage/daoProposals.spec.ts
@@ -10,9 +10,7 @@ for (const dao of SMOKE_DAOS) {
         }).navigate();
 
         await expect.soft(proposals.pageTitle()).toBeVisible();
-        await expect
-            .soft(proposals.firstProposal())
-            .toBeVisible({ timeout: 30_000 });
+        await expect.soft(proposals.firstProposal()).toBeVisible();
         await expect.soft(proposals.asideCard()).toBeVisible();
     });
 }

--- a/e2e/tests/smoke/explore/exploreDaos.spec.ts
+++ b/e2e/tests/smoke/explore/exploreDaos.spec.ts
@@ -1,4 +1,8 @@
-import { ExplorePage } from '@e2e/helpers';
+import {
+    EXPLORE_SEARCH_API_TIMEOUT,
+    EXPLORE_SEARCH_UI_TIMEOUT,
+    ExplorePage,
+} from '@e2e/helpers';
 import { expect, test } from '@playwright/test';
 
 test.describe('Explore page', () => {
@@ -25,13 +29,25 @@ test.describe('Explore page', () => {
         await expect(explore.daoCards().first()).toBeVisible();
     });
 
-    test('search filters the DAO list', async () => {
+    test('search filters the DAO list', async ({ page }) => {
         const cards = explore.daoCards();
         await expect(cards.first()).toBeVisible();
         const countBefore = await cards.count();
 
+        // DaoList debounces search by 500ms — wait for the filtered API response.
+        const searchResponse = page.waitForResponse(
+            (res) =>
+                res.url().includes('/v2/daos') &&
+                res.url().includes('search=aragon') &&
+                res.ok(),
+            { timeout: EXPLORE_SEARCH_API_TIMEOUT },
+        );
         await explore.searchInput().fill('aragon');
-        await expect(cards.first()).toBeVisible();
+        await searchResponse;
+
+        await expect(cards.first()).toBeVisible({
+            timeout: EXPLORE_SEARCH_UI_TIMEOUT,
+        });
 
         const countAfter = await cards.count();
         expect(countAfter).toBeGreaterThan(0);


### PR DESCRIPTION

# Description

- Wait for proposals API and list render in DaoProposalsPage.navigate
- Handle MetaMask network-switch popups before AppKit connect
- Skip Aragon Profile onboarding modal after wallet connect
- Fix Max button selector (label includes balance, e.g. "Max 0.51")
- Fix explore search race with debounced /v2/daos response
- Fix member-gate waitForResponse race (listen before navigate)
- Centralize timeouts and MetaMask action labels in e2e constants
- Allow DaoProposalsPage to override BasePage.navigate (method, not arrow)
- Add daoId to DaoPage; bump smoke test timeout to 90s

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
