### PR TITLE
fix(APP-327): Unblock navigation after submitting the execute actions transaction

### DIFF
--- a/.changeset/app-327-execute-actions-dialog-fixes.md
+++ b/.changeset/app-327-execute-actions-dialog-fixes.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Unblock navigation after submitting the execute actions transaction and update execute flow copies

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -1736,7 +1736,7 @@
           "summary": "All assets"
         },
         "main": {
-          "newTransaction": "New transaction",
+          "newTransaction": "Execution",
           "title": "Transactions"
         }
       },
@@ -2088,7 +2088,7 @@
       "executeActionsDialog": {
         "button": {
           "submit": "Execute",
-          "success": "View transactions"
+          "success": "Done"
         },
         "description": "To execute these actions on the DAO, confirm the onchain transaction in your wallet.",
         "step": {

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -2098,6 +2098,7 @@
           },
           "submit": {
             "addon": "Wallet",
+            "errorLabel": "Wallet rejected the transaction",
             "label": "Send to wallet"
           }
         },

--- a/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.test.tsx
+++ b/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.test.tsx
@@ -145,4 +145,27 @@ describe('<ExecuteActionsDialog /> component', () => {
             }),
         ).toBeInTheDocument();
     });
+
+    it('surfaces an error and offers a retry when the wallet rejects the transaction straight away', () => {
+        useSendTransactionSpy.mockReturnValue({
+            mutate: jest.fn(),
+            status: 'error',
+        } as unknown as Wagmi.UseSendTransactionReturnType);
+        useMutationSpy.mockReturnValue({
+            mutate: jest.fn(),
+            status: 'success',
+            data: { to: '0x1', value: BigInt(0), data: '0x' },
+        } as unknown as ReactQuery.UseMutationResult);
+
+        render(createTestComponent());
+
+        expect(
+            screen.getByText(/executeActionsDialog.step.submit.errorLabel/),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', {
+                name: /transactionDialog.footer.retry/,
+            }),
+        ).toBeInTheDocument();
+    });
 });

--- a/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
+++ b/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
@@ -1,6 +1,7 @@
 import { Dialog, DialogFooter, IconType, invariant } from '@aragon/gov-ui-kit';
 import { useMutation } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
+import { match } from 'ts-pattern';
 import { useSendTransaction } from 'wagmi';
 import { useWalletAccount } from '@/modules/application/hooks/useWalletAccount';
 import { useDao } from '@/shared/api/daoService';
@@ -171,30 +172,32 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
         },
     ];
 
-    const primaryAction = sendFailed
-        ? {
-              label: t('app.shared.transactionDialog.footer.retry'),
-              iconLeft: IconType.RELOAD,
-              onClick: handleSend,
-          }
-        : isSubmitted
-          ? {
-                label: t('app.governance.executeActionsDialog.button.success'),
-                href: daoUtils.getDaoUrl(dao, 'transactions'),
-                onClick: () => close(),
-            }
-          : prepareStatus === 'error'
-            ? {
-                  label: t('app.shared.transactionDialog.footer.retry'),
-                  iconLeft: IconType.RELOAD,
-                  onClick: () => prepare(),
-              }
-            : {
-                  label: t('app.governance.executeActionsDialog.button.submit'),
-                  onClick: handleSend,
-                  isLoading: isPreparing,
-                  disabled: !isReady,
-              };
+    const primaryAction = match({
+        sendFailed,
+        isSubmitted,
+        prepareFailed: prepareStatus === 'error',
+    })
+        .with({ sendFailed: true }, () => ({
+            label: t('app.shared.transactionDialog.footer.retry'),
+            iconLeft: IconType.RELOAD,
+            onClick: handleSend,
+        }))
+        .with({ isSubmitted: true }, () => ({
+            label: t('app.governance.executeActionsDialog.button.success'),
+            href: daoUtils.getDaoUrl(dao, 'transactions'),
+            onClick: () => close(),
+        }))
+        .with({ prepareFailed: true }, () => ({
+            label: t('app.shared.transactionDialog.footer.retry'),
+            iconLeft: IconType.RELOAD,
+            onClick: () => prepare(),
+        }))
+        .otherwise(() => ({
+            label: t('app.governance.executeActionsDialog.button.submit'),
+            onClick: handleSend,
+            isLoading: isPreparing,
+            disabled: !isReady,
+        }));
 
     return (
         <>

--- a/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
+++ b/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useSendTransaction } from 'wagmi';
 import { useWalletAccount } from '@/modules/application/hooks/useWalletAccount';
 import { useDao } from '@/shared/api/daoService';
+import { useBlockNavigationContext } from '@/shared/components/blockNavigationContext';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { transactionDialogUtils } from '@/shared/components/transactionDialog/transactionDialogUtils';
 import {
@@ -50,9 +51,18 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
 
     const { t } = useTranslations();
     const { close } = useDialogContext();
+    const { setIsBlocked } = useBlockNavigationContext();
     const { data: dao } = useDao({ urlParams: { id: daoId } });
 
     const [isSubmitted, setIsSubmitted] = useState(false);
+
+    // Once the transaction is submitted, unblock navigation so that clicking the success link does
+    // not trigger the confirm-exit guard of the still-dirty wizard form behind the dialog.
+    useEffect(() => {
+        if (isSubmitted) {
+            setIsBlocked(false);
+        }
+    }, [isSubmitted, setIsBlocked]);
 
     const monitorError = useCallback(
         (error: unknown) =>

--- a/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
+++ b/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
@@ -56,13 +56,27 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
 
     const [isSubmitted, setIsSubmitted] = useState(false);
 
-    // Once the transaction is submitted, unblock navigation so that clicking the success link does
-    // not trigger the confirm-exit guard of the still-dirty wizard form behind the dialog.
+    const { mutate: sendTransaction, status: sendStatus } =
+        useSendTransaction();
+
+    // A rejection that comes back straight away (e.g. an RPC issue or an instant wallet reject)
+    // flips the send mutation to "error"; surface that instead of the optimistic success state.
+    const sendFailed = sendStatus === 'error';
+
+    const submitState: TransactionStatusState = sendFailed
+        ? 'error'
+        : isSubmitted
+          ? 'success'
+          : 'idle';
+
+    // Once the transaction is successfully submitted, unblock navigation so that clicking the
+    // success link does not trigger the confirm-exit guard of the still-dirty wizard form behind
+    // the dialog.
     useEffect(() => {
-        if (isSubmitted) {
+        if (submitState === 'success') {
             setIsBlocked(false);
         }
-    }, [isSubmitted, setIsBlocked]);
+    }, [submitState, setIsBlocked]);
 
     const monitorError = useCallback(
         (error: unknown) =>
@@ -98,8 +112,6 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
         onError: monitorError,
     });
 
-    const { mutate: sendTransaction } = useSendTransaction();
-
     // Auto-prepare the transaction once the DAO is loaded.
     useEffect(() => {
         if (dao == null || prepareStatus !== 'idle') {
@@ -124,10 +136,6 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
     const isPreparing = prepareStatus === 'pending';
     const isReady = prepareStatus === 'success';
 
-    const submitState: TransactionStatusState = isSubmitted
-        ? 'success'
-        : 'idle';
-
     const steps: ITransactionStatusStep[] = [
         {
             id: ExecuteActionsStep.PREPARE,
@@ -149,6 +157,9 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
                 label: t(
                     'app.governance.executeActionsDialog.step.submit.label',
                 ),
+                errorLabel: t(
+                    'app.governance.executeActionsDialog.step.submit.errorLabel',
+                ),
                 state: submitState,
                 addon: {
                     label: t(
@@ -160,24 +171,30 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
         },
     ];
 
-    const primaryAction = isSubmitted
+    const primaryAction = sendFailed
         ? {
-              label: t('app.governance.executeActionsDialog.button.success'),
-              href: daoUtils.getDaoUrl(dao, 'transactions'),
-              onClick: () => close(),
+              label: t('app.shared.transactionDialog.footer.retry'),
+              iconLeft: IconType.RELOAD,
+              onClick: handleSend,
           }
-        : prepareStatus === 'error'
+        : isSubmitted
           ? {
-                label: t('app.shared.transactionDialog.footer.retry'),
-                iconLeft: IconType.RELOAD,
-                onClick: () => prepare(),
+                label: t('app.governance.executeActionsDialog.button.success'),
+                href: daoUtils.getDaoUrl(dao, 'transactions'),
+                onClick: () => close(),
             }
-          : {
-                label: t('app.governance.executeActionsDialog.button.submit'),
-                onClick: handleSend,
-                isLoading: isPreparing,
-                disabled: !isReady,
-            };
+          : prepareStatus === 'error'
+            ? {
+                  label: t('app.shared.transactionDialog.footer.retry'),
+                  iconLeft: IconType.RELOAD,
+                  onClick: () => prepare(),
+              }
+            : {
+                  label: t('app.governance.executeActionsDialog.button.submit'),
+                  onClick: handleSend,
+                  isLoading: isPreparing,
+                  disabled: !isReady,
+              };
 
     return (
         <>
@@ -201,7 +218,7 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
                 secondaryAction={{
                     label: t('app.shared.transactionDialog.footer.cancel'),
                     onClick: () => close(),
-                    disabled: isSubmitted,
+                    disabled: submitState === 'success',
                 }}
             />
         </>


### PR DESCRIPTION
# Description

Follow-up to #1164. Clicking the success button in `ExecuteActionsDialog` triggered the confirm-wizard-exit guard because the wizard form behind the dialog was still dirty and navigation remained blocked. The dialog now unblocks navigation once the transaction is submitted, mirroring what `TransactionDialogFooter` does for its success link.

Also updates the execute flow copies:
- Transactions page action: "New transaction" → "Execution"
- Execute dialog success button: "View transactions" → "Done" (now also closes the dialog)

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Confirmed that changes follow the code style guidelines of this project