### PR TITLE
Release v1.30.0

### DIFF
--- a/.changeset/app-327-direct-execute-on-dao.md
+++ b/.changeset/app-327-direct-execute-on-dao.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Add execute actions flow for users with execute permission to directly submit DAO transactions without creating a proposal

--- a/.changeset/app-713-nested-actions-view.md
+++ b/.changeset/app-713-nested-actions-view.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Show nested sub-actions decoded for `createProposal` and `execute` wrapper actions in the proposal details view

--- a/.changeset/loud-trails-sing.md
+++ b/.changeset/loud-trails-sing.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Add proposal read view for createCampaign capital distributor actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aragon/app
 
+## 1.30.0
+
+### Minor Changes
+
+- [#1164](https://github.com/aragon/app/pull/1164) [`12d9f42`](https://github.com/aragon/app/commit/12d9f428efae8fd39d8ceffa5074f4b14d9dcd48) Thanks [@milosh86](https://github.com/milosh86)! - Add execute actions flow for users with execute permission to directly submit DAO transactions without creating a proposal
+
+- [#1158](https://github.com/aragon/app/pull/1158) [`4d9e97c`](https://github.com/aragon/app/commit/4d9e97cd1aba7c74231d46a96981f779d2346508) Thanks [@milosh86](https://github.com/milosh86)! - Show nested sub-actions decoded for `createProposal` and `execute` wrapper actions in the proposal details view
+
+- [#1153](https://github.com/aragon/app/pull/1153) [`4434dab`](https://github.com/aragon/app/commit/4434dab0b2773f1eddc7e3c295431accead199d6) Thanks [@thekidnamedkd](https://github.com/thekidnamedkd)! - Add proposal read view for createCampaign capital distributor actions
+
 ## 1.29.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/app",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Human-centered DAO infrastructure",
   "author": "Aragon Association",
   "homepage": "https://github.com/aragon/app#readme",


### PR DESCRIPTION
## Features
- Add direct execute actions flow for DAO ([#1164](https://github.com/aragon/app/pull/1164)) — [APP-327: Direct execute on the DAO via another executor](https://linear.app/aragon/issue/APP-327/direct-execute-on-the-dao-via-another-executor)
- Add read view for create campaign proposals ([#1153](https://github.com/aragon/app/pull/1153)) — [APP-668: Add read view for create campaign proposals](https://linear.app/aragon/issue/APP-668/add-read-view-for-create-campaign-proposals)
- Improve view of nested actions inside createProposal and execute — [APP-713: Improved view of nested actions inside of createProposal() and execute()](https://linear.app/aragon/issue/APP-713/improved-view-of-nested-actions-inside-of-createproposal-and-execute)

## Fixes
- Fix ui layout

## Other Changes
- Release v1.30.0
- Bump the minor-and-patch group across 1 directory with 3 updates ([#1168](https://github.com/aragon/app/pull/1168))
- Merge pull request #1163 from aragon/release/2026-06-01_16-55
- Merge pull request #1165 from aragon/dependabot/github_actions/minor-and-patch-6a98abd9ac — patch-6
- Merge pull request #1167 from aragon/dependabot/npm_and_yarn/types/node-25.9.1 — node-25
- Bump @types/node from 24.12.4 to 25.9.1
- Bump actions/checkout
- Merge branch 'main' into app-713-improved-view-of-nested-actions-inside-of-createproposal-and — [app-713: Improved view of nested actions inside of createProposal() and execute()](https://linear.app/aragon/issue/APP-713/improved-view-of-nested-actions-inside-of-createproposal-and-execute)
- Merge branch 'main' into app-713-improved-view-of-nested-actions-inside-of-createproposal-and
- Add start and end date to decoded view
- Add changeset
- Implement details components
- Merge branch 'main' into app-713-improved-view-of-nested-actions-inside-of-createproposal-and
- execute and createProposal basic actions WIP



<!-- slack_ts: 1780999606.257079 -->
