### PR TITLE
feat(APP-820): frontend release Slack improvements

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Slack thread ts to reply in
     required: false
     default: ""
+  update_ts:
+    description: Slack message ts to EDIT (chat.update) instead of posting a new message
+    required: false
+    default: ""
 
 outputs:
   ts:
@@ -30,6 +34,7 @@ runs:
         SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}
         SLACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}
         SLACK_THREAD_TS: ${{ inputs.thread_ts }}
+        SLACK_UPDATE_TS: ${{ inputs.update_ts }}
         MESSAGE: ${{ inputs.message }}
       run: |
         set -euo pipefail

--- a/.github/workflows/app-production.yml
+++ b/.github/workflows/app-production.yml
@@ -109,6 +109,47 @@ jobs:
           TS="${{ steps.ts.outputs.ts || steps.notify-new.outputs.ts }}"
           echo "ts=$TS" >> "$GITHUB_OUTPUT"
 
+  # CI Gate ping — runs in PARALLEL with `deploy` (NOT in its needs), so a skip
+  # here can never block the deploy. The actual pause is the `production`
+  # Environment's Required-reviewers rule on the deploy job (configure it in repo
+  # Settings → Environments → production). Until that's set, prod won't pause and
+  # this message is informational; once set, the gate works with the team ping + link.
+  notify-gate:
+    needs: [validate, notify-start]
+    if: ${{ !cancelled() && needs.notify-start.outputs.slack-ts != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0 (https://github.com/1Password/load-secrets-action/releases/tag/v4.0.0)
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: '${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
+          SLACK_BOT_TOKEN: op://kv_app_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_app_infra/SLACK_CHANNEL_ID/credential
+          SLACK_CODEOWNERS_GROUP_ID: op://kv_app_infra/SLACK_CODEOWNERS_GROUP_ID/credential
+
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/workflows/scripts/slackNotify.js
+            .github/actions/slack-notify
+
+      - name: Notify Slack — waiting for CI Gate
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack_bot_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack_channel_id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread_ts: ${{ needs.notify-start.outputs.slack-ts }}
+          message: |
+            ⏸️ *Waiting CI Gate — deploy to production* ${{ steps.secrets.outputs.SLACK_CODEOWNERS_GROUP_ID && format('<!subteam^{0}>', steps.secrets.outputs.SLACK_CODEOWNERS_GROUP_ID) || '' }}
+            *Tag:* `${{ github.event.release.tag_name || inputs.tag }}`
+            Approve the deploy: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>
+
   deploy:
     needs: [validate, notify-start]
     if: ${{ !cancelled() && (needs.validate.result == 'success' || needs.validate.result == 'skipped') }}
@@ -209,6 +250,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: '${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
           SLACK_BOT_TOKEN: op://kv_app_infra/SLACK_BOT_TOKEN/credential
           SLACK_CHANNEL_ID: op://kv_app_infra/SLACK_CHANNEL_ID/credential
+          SLACK_CODEOWNERS_GROUP_ID: op://kv_app_infra/SLACK_CODEOWNERS_GROUP_ID/credential
 
       - name: Checkout
         uses: actions/checkout@v6.0.3
@@ -232,3 +274,41 @@ jobs:
             *Production:* <https://app.aragon.org|app.aragon.org>
 
             If there are issues with the release, use hotfix or rollback.
+
+      # Mark the lifecycle complete in the head message itself (chat.update).
+      # Re-reads the changelog from the release body (minus the slack_ts marker)
+      # so the rich head is preserved while the status flips to Completed.
+      - name: Build changelog block for head message
+        id: changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # Only release events carry a changelog; manual workflow_dispatch has
+          # none. Emit a SELF-SEPARATING block (leading blank line) only when
+          # there's content, so the head message has no dangling empty section
+          # on dispatch.
+          BODY=""
+          if [ "$EVENT_NAME" = "release" ]; then
+            BODY="$(gh release view "$TAG" --json body -q .body 2>/dev/null | sed '/<!-- slack_ts:/d' || echo "")"
+          fi
+          {
+            echo 'text<<CHANGELOG_EOF'
+            if [ -n "$(printf '%s' "$BODY" | tr -d '[:space:]')" ]; then
+              printf '\n\n%s\n' "$BODY"
+            fi
+            echo 'CHANGELOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update head message — Completed (production)
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN && needs.notify-start.outputs.slack-ts
+        uses: ./.github/actions/slack-notify
+        with:
+          slack_bot_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack_channel_id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          update_ts: ${{ needs.notify-start.outputs.slack-ts }}
+          message: |
+            🎉 *Release ${{ github.event.release.tag_name || inputs.tag }} — Completed (production)* ✅ ${{ steps.secrets.outputs.SLACK_CODEOWNERS_GROUP_ID && format('<!subteam^{0}>', steps.secrets.outputs.SLACK_CODEOWNERS_GROUP_ID) || '' }}
+            *Production:* <https://app.aragon.org|app.aragon.org>${{ steps.changelog.outputs.text }}

--- a/.github/workflows/app-release-v2.yml
+++ b/.github/workflows/app-release-v2.yml
@@ -30,6 +30,9 @@ jobs:
           SLACK_CHANNEL_ID: op://kv_app_infra/SLACK_CHANNEL_ID/credential
           LINEAR_API_TOKEN: op://kv_app_infra/LINEAR_API_TOKEN/credential
           LINEAR_PIPELINE_ACCESS_KEY: op://kv_app_infra/LINEAR_PIPELINE_ACCESS_KEY/credential
+          # Code-owner team Slack group (same key as backend, app vault). Used to
+          # @-mention the release team in the head message when a release starts.
+          SLACK_CODEOWNERS_GROUP_ID: op://kv_app_infra/SLACK_CODEOWNERS_GROUP_ID/credential
 
       - name: Checkout actions
         uses: actions/checkout@v6.0.3
@@ -123,7 +126,7 @@ jobs:
           slack_bot_token: ${{ steps.load-secrets.outputs.SLACK_BOT_TOKEN }}
           slack_channel_id: ${{ steps.load-secrets.outputs.SLACK_CHANNEL_ID }}
           message: |
-            🚀 *Release v${{ steps.package-version.outputs.current-version }} Started*
+            🚀 *Release v${{ steps.package-version.outputs.current-version }} — Started* ${{ steps.load-secrets.outputs.SLACK_CODEOWNERS_GROUP_ID && format('<!subteam^{0}>', steps.load-secrets.outputs.SLACK_CODEOWNERS_GROUP_ID) || '' }}
             *PR:* ${{ steps.create-pr.outputs.url }}
 
             ${{ steps.release-summary.outputs.summary }}

--- a/.github/workflows/release-pr-cancel.yml
+++ b/.github/workflows/release-pr-cancel.yml
@@ -25,6 +25,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: '${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}'
           SLACK_BOT_TOKEN: op://kv_app_infra/SLACK_BOT_TOKEN/credential
           SLACK_CHANNEL_ID: op://kv_app_infra/SLACK_CHANNEL_ID/credential
+          SLACK_CODEOWNERS_GROUP_ID: op://kv_app_infra/SLACK_CODEOWNERS_GROUP_ID/credential
           LINEAR_PIPELINE_ACCESS_KEY: op://kv_app_infra/LINEAR_PIPELINE_ACCESS_KEY/credential
 
       - name: Checkout
@@ -79,3 +80,31 @@ jobs:
           thread_ts: ${{ steps.ts.outputs.ts }}
           message: |
             🛑 *Release cancelled*${{ steps.linear-cancel.outcome == 'success' && ' — Linear release moved to Canceled stage' || '' }}
+
+      # Reflect the lifecycle status in the head message itself (chat.update).
+      # Re-uses the changelog from the PR body (minus the slack_ts marker) so the
+      # rich head is preserved while only the status line changes.
+      - name: Strip slack_ts marker from PR body (clean changelog)
+        id: changelog
+        env:
+          BODY: ${{ steps.pr.outputs.body }}
+        run: |
+          CLEAN="$(printf '%s' "$BODY" | sed '/<!-- slack_ts:/d')"
+          {
+            echo 'text<<CHANGELOG_EOF'
+            echo "$CLEAN"
+            echo 'CHANGELOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update head message — Cancelled
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN && steps.ts.outputs.ts
+        uses: ./.github/actions/slack-notify
+        with:
+          slack_bot_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack_channel_id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          update_ts: ${{ steps.ts.outputs.ts }}
+          message: |
+            🛑 *Release ${{ steps.version.outputs.name || 'PR' }} — Cancelled* ${{ steps.secrets.outputs.SLACK_CODEOWNERS_GROUP_ID && format('<!subteam^{0}>', steps.secrets.outputs.SLACK_CODEOWNERS_GROUP_ID) || '' }}
+            *PR:* <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>
+
+            ${{ steps.changelog.outputs.text }}

--- a/.github/workflows/scripts/slackNotify.js
+++ b/.github/workflows/scripts/slackNotify.js
@@ -20,13 +20,16 @@ const markdownToMrkdwn = (text) => {
     );
 };
 
-const postMessage = (token, channel, text, threadTs) =>
+// Posts a new message, or edits an existing one when `updateTs` is set
+// (chat.update) — used to reflect lifecycle status (started → cancelled →
+// completed) in the release's head message rather than only as thread replies.
+const sendMessage = (token, channel, text, threadTs, updateTs) =>
     new Promise((resolve, reject) => {
-        const payload = {
-            channel,
-            text,
-        };
-        if (threadTs) {
+        const isUpdate = Boolean(updateTs);
+        const payload = isUpdate
+            ? { channel, ts: updateTs, text }
+            : { channel, text };
+        if (!isUpdate && threadTs) {
             payload.thread_ts = threadTs;
         }
 
@@ -35,7 +38,7 @@ const postMessage = (token, channel, text, threadTs) =>
         const options = {
             hostname: 'slack.com',
             port: 443,
-            path: '/api/chat.postMessage',
+            path: isUpdate ? '/api/chat.update' : '/api/chat.postMessage',
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -79,6 +82,7 @@ if (require.main === module) {
     const token = process.env.SLACK_BOT_TOKEN;
     const channel = process.env.SLACK_CHANNEL_ID;
     const threadTs = process.env.SLACK_THREAD_TS;
+    const updateTs = process.env.SLACK_UPDATE_TS;
 
     // Get message from args (3rd arg)
     const message = process.argv[2];
@@ -95,7 +99,7 @@ if (require.main === module) {
 
     console.log('Sending Slack notification.');
 
-    postMessage(token, channel, markdownToMrkdwn(message), threadTs)
+    sendMessage(token, channel, markdownToMrkdwn(message), threadTs, updateTs)
         .then((ts) => {
             if (!isValidSlackTs(ts)) {
                 console.error('Slack returned an invalid ts.');


### PR DESCRIPTION
Improvements to the frontend release Slack notifications, mirroring the backend flow.

## Changes
- **Team @-mention on release start** — the release-start head message (`app-release-v2.yml`) now pings the code-owner team via `op://kv_app_infra/SLACK_CODEOWNERS_GROUP_ID` (same key as backend, app vault).
- **Lifecycle status in the head message** — the root message is now edited in place (Slack `chat.update`) to show **Started → Cancelled / Completed (production)**, instead of status living only in thread replies:
  - `slack-notify` action + `slackNotify.js` gain an optional `update_ts` input (chat.update path).
  - On cancel (`release-pr-cancel.yml`) and on prod success (`app-production.yml`) the changelog is re-read from the PR/release body (slack_ts marker stripped) so the **rich head is preserved** while only the status flips.
- **Production CI Gate** — new `notify-gate` job in `app-production.yml`, running **parallel** to `deploy` (never blocks it), posting a "Waiting CI Gate" ping with the team mention + run link into the release thread, mirroring backend.

## ⚠️ Requires before this runs
- **CI Gate pause** is the GitHub **production Environment → Required reviewers** rule (repo Settings). Until configured, prod won't actually pause; the gate ping is informational. The wiring (mention, links) is ready so it "just works" once the Environment is gated.