### PR TITLE
feat(APP-167): Enable running inside Safe{Wallet} as a Safe App

### DIFF
--- a/.changeset/app-167-safe-app.md
+++ b/.changeset/app-167-safe-app.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Enable the app to run inside Safe{Wallet} as a Safe App

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -91,16 +91,8 @@ const nextConfig = {
             {
                 source: '/:path*',
                 headers: [
-                    // Allow embedding only within Safe{Wallet} so the app can run
-                    // as a Safe App (auto-connects via the Safe connector). All
-                    // other origins are still blocked from framing (clickjacking).
-                    // X-Frame-Options is intentionally dropped: it cannot express
-                    // an external allowlist, and browsers that honour it would
-                    // override frame-ancestors and block Safe.
-                    {
-                        key: 'Content-Security-Policy',
-                        value: "frame-ancestors 'self' https://app.safe.global",
-                    },
+                    // Do not allow usage of application inside iframes
+                    { key: 'X-Frame-Options', value: 'DENY' },
                     // Enforce HTTPS access
                     {
                         key: 'Strict-Transport-Security',
@@ -116,12 +108,6 @@ const nextConfig = {
                     // Allow browsers to proactively perform domain name resolution on extenal resources (links, CSS, ..)
                     { key: 'X-DNS-Prefetch-Control', value: 'on' },
                 ],
-            },
-            // The Safe App registry fetches the manifest cross-origin, so it
-            // must be readable from any origin.
-            {
-                source: '/manifest.json',
-                headers: [{ key: 'Access-Control-Allow-Origin', value: '*' }],
             },
             // CORS headers for api routes
             {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -91,8 +91,16 @@ const nextConfig = {
             {
                 source: '/:path*',
                 headers: [
-                    // Do not allow usage of application inside iframes
-                    { key: 'X-Frame-Options', value: 'DENY' },
+                    // Allow embedding only within Safe{Wallet} so the app can run
+                    // as a Safe App (auto-connects via the Safe connector). All
+                    // other origins are still blocked from framing (clickjacking).
+                    // X-Frame-Options is intentionally dropped: it cannot express
+                    // an external allowlist, and browsers that honour it would
+                    // override frame-ancestors and block Safe.
+                    {
+                        key: 'Content-Security-Policy',
+                        value: "frame-ancestors 'self' https://app.safe.global",
+                    },
                     // Enforce HTTPS access
                     {
                         key: 'Strict-Transport-Security',
@@ -108,6 +116,12 @@ const nextConfig = {
                     // Allow browsers to proactively perform domain name resolution on extenal resources (links, CSS, ..)
                     { key: 'X-DNS-Prefetch-Control', value: 'on' },
                 ],
+            },
+            // The Safe App registry fetches the manifest cross-origin, so it
+            // must be readable from any origin.
+            {
+                source: '/manifest.json',
+                headers: [{ key: 'Access-Control-Allow-Origin', value: '*' }],
             },
             // CORS headers for api routes
             {

--- a/src/app/manifest.json
+++ b/src/app/manifest.json
@@ -1,4 +1,7 @@
 {
+  "name": "Aragon",
+  "description": "Explore the organizations using our modular governance stack to secure their onchain governance.",
+  "iconPath": "icon-512.png",
   "icons": [
     { "sizes": "192x192", "src": "/icon-192.png", "type": "image/png" },
     { "sizes": "512x512", "src": "/icon-512.png", "type": "image/png" }

--- a/src/app/manifest.json
+++ b/src/app/manifest.json
@@ -1,7 +1,4 @@
 {
-  "name": "Aragon",
-  "description": "Explore the organizations using our modular governance stack to secure their onchain governance.",
-  "iconPath": "icon-512.png",
   "icons": [
     { "sizes": "192x192", "src": "/icon-192.png", "type": "image/png" },
     { "sizes": "512x512", "src": "/icon-512.png", "type": "image/png" }

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -3052,7 +3052,7 @@
           "approve": "Approve proposal",
           "approved": "Approved",
           "helpText": "If you are an owner of this address you can connect with WalletConnect to vote on this proposal.",
-          "helpTextSafe": "If you are an owner of this Safe, you can connect with WalletConnect to vote on this proposal. For a smoother experience, open the Aragon App inside Safe{Wallet} by clicking \"Add custom Safe App\".",
+          "helpTextSafe": "To approve this proposal from the Safe{Wallet} UI, add Aragon as a custom Safe App or connect directly with a WalletConnect QR code.",
           "veto": "Veto proposal",
           "vetoed": "Vetoed"
         },

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -3052,6 +3052,7 @@
           "approve": "Approve proposal",
           "approved": "Approved",
           "helpText": "If you are an owner of this address you can connect with WalletConnect to vote on this proposal.",
+          "helpTextSafe": "If you are an owner of this Safe, you can connect with WalletConnect to vote on this proposal. For a smoother experience, open the Aragon App inside Safe{Wallet} by clicking \"Add custom Safe App\".",
           "veto": "Veto proposal",
           "vetoed": "Vetoed"
         },

--- a/src/modules/application/utils/proxyUtils/proxyUtils.ts
+++ b/src/modules/application/utils/proxyUtils/proxyUtils.ts
@@ -30,7 +30,7 @@ class ProxyUtils {
 
         // Hosts allowed to embed THIS app in an iframe → frame-ancestors.
         // Currently only Common Ground (one-off experiment).
-        const iframeEmbedders = ['https://app.cg'];
+        const iframeEmbedders = ['https://app.cg', 'https://app.safe.global'];
         const iframeEmbeddersNonProd: string[] = [];
 
         // Third-party iframes THIS app is allowed to render → frame-src.

--- a/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppVotingTerminalBodyContent.tsx
+++ b/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppVotingTerminalBodyContent.tsx
@@ -131,6 +131,11 @@ export const SppVotingTerminalBodyContent: React.FC<
                         <div className="flex flex-col gap-y-4 pt-6 md:pt-8">
                             {canVote && (
                                 <PluginSingleComponent
+                                    brandId={
+                                        isExternalBody
+                                            ? plugin.brandId
+                                            : undefined
+                                    }
                                     daoId={daoId}
                                     externalAddress={
                                         isExternalBody

--- a/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppVotingTerminalBodyVoteDefault.tsx
+++ b/src/plugins/sppPlugin/components/sppVotingTerminal/components/sppVotingTerminalBodyVoteDefault.tsx
@@ -4,7 +4,11 @@ import { useConnectedWalletGuard } from '@/modules/application/hooks/useConnecte
 import { useWalletAccount } from '@/modules/application/hooks/useWalletAccount';
 import { SppPluginDialogId } from '@/plugins/sppPlugin/constants/sppPluginDialogId';
 import type { ISppReportProposalResultDialogParams } from '@/plugins/sppPlugin/dialogs/sppReportProposalResultDialog';
-import type { ISppProposal, ISppStage } from '@/plugins/sppPlugin/types';
+import {
+    type ISppProposal,
+    type ISppStage,
+    VotingBodyBrandIdentity,
+} from '@/plugins/sppPlugin/types';
 import { sppStageUtils } from '@/plugins/sppPlugin/utils/sppStageUtils';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
@@ -23,6 +27,10 @@ export interface ISppVotingTerminalBodyVoteDefaultProps {
      */
     externalAddress: string;
     /**
+     * Branded identity of the external body, used to tailor the help text.
+     */
+    brandId?: VotingBodyBrandIdentity;
+    /**
      * Stage on which the body is setup.
      */
     stage: ISppStage;
@@ -31,7 +39,7 @@ export interface ISppVotingTerminalBodyVoteDefaultProps {
 export const SppVotingTerminalBodyVoteDefault: React.FC<
     ISppVotingTerminalBodyVoteDefaultProps
 > = (props) => {
-    const { daoId, proposal, externalAddress, stage } = props;
+    const { daoId, proposal, externalAddress, brandId, stage } = props;
 
     const { t } = useTranslations();
     const { open } = useDialogContext();
@@ -84,6 +92,8 @@ export const SppVotingTerminalBodyVoteDefault: React.FC<
     const handleVoteClick = () =>
         checkWalletConnection({ onSuccess: checkPermissions });
 
+    const isSafe = brandId === VotingBodyBrandIdentity.SAFE;
+
     return (
         <div className="flex w-full flex-col gap-3">
             <Button
@@ -100,7 +110,9 @@ export const SppVotingTerminalBodyVoteDefault: React.FC<
             {!voted && (
                 <p className="text-center font-normal text-neutral-500 text-sm leading-normal md:text-left">
                     {t(
-                        'app.plugins.spp.sppVotingTerminalBodyVoteDefault.helpText',
+                        `app.plugins.spp.sppVotingTerminalBodyVoteDefault.${
+                            isSafe ? 'helpTextSafe' : 'helpText'
+                        }`,
                     )}
                 </p>
             )}


### PR DESCRIPTION
## Description

Enables the Aragon app to run inside [Safe{Wallet}](https://app.safe.global) as a Safe App, which auto-connects via the Safe connector — no WalletConnect codes needed.

Two changes required:

1. **iframe embedder allowlist** — Added `https://app.safe.global` to the `iframeEmbedders` list in `proxyUtils`, so Safe{Wallet} can embed the app while all other origins remain blocked.

2. **Safe App manifest fields** — Added `name`, `description`, and `iconPath` to `manifest.json` as required by the Safe App manifest spec.

Closes [APP-167](https://linear.app/aragon/issue/APP-167/safe-app-sdk-for-quickly-connecting-safes-to-the-app-without-needing)

## Type of Change

- [x] Minor: Feature (non-breaking change which adds new functionality)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project