### PR TITLE
Release v1.31.0

### DIFF
--- a/.changeset/app-167-safe-app.md
+++ b/.changeset/app-167-safe-app.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Enable the app to run inside Safe{Wallet} as a Safe App

--- a/.changeset/app-327-execute-actions-dialog-fixes.md
+++ b/.changeset/app-327-execute-actions-dialog-fixes.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Unblock navigation after submitting the execute actions transaction and update execute flow copies

--- a/.changeset/app-810-simulate-direct-execution.md
+++ b/.changeset/app-810-simulate-direct-execution.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Add optional action simulation to the direct execute actions flow

--- a/.changeset/floppy-bats-teach.md
+++ b/.changeset/floppy-bats-teach.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Update dependencies

--- a/.changeset/ipfs-optimisations-and-code-chunks.md
+++ b/.changeset/ipfs-optimisations-and-code-chunks.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Improve performance with image cache TTL, ISR revalidation, dynamic dialog imports and font cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @aragon/app
 
+## 1.31.0
+
+### Minor Changes
+
+- [#1180](https://github.com/aragon/app/pull/1180) [`909dd9b`](https://github.com/aragon/app/commit/909dd9b9d723bc2e128f3bcd68190e59a7b7ffab) Thanks [@milosh86](https://github.com/milosh86)! - Enable the app to run inside Safe{Wallet} as a Safe App
+
+- [#1171](https://github.com/aragon/app/pull/1171) [`8032855`](https://github.com/aragon/app/commit/8032855f987d023e143cf3d7c194592febad1127) Thanks [@milosh86](https://github.com/milosh86)! - Add optional action simulation to the direct execute actions flow
+
+### Patch Changes
+
+- [#1171](https://github.com/aragon/app/pull/1171) [`8032855`](https://github.com/aragon/app/commit/8032855f987d023e143cf3d7c194592febad1127) Thanks [@milosh86](https://github.com/milosh86)! - Unblock navigation after submitting the execute actions transaction and update execute flow copies
+
+- [#1178](https://github.com/aragon/app/pull/1178) [`6ff6eb4`](https://github.com/aragon/app/commit/6ff6eb465859d70fa53c9e2238df9996d81e697c) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Update dependencies
+
+- [#1169](https://github.com/aragon/app/pull/1169) [`a270445`](https://github.com/aragon/app/commit/a270445cd1ff54b938756defb4156ded5378149f) Thanks [@milosh86](https://github.com/milosh86)! - Improve performance with image cache TTL, ISR revalidation, dynamic dialog imports and font cleanup
+
 ## 1.30.0
 
 ### Minor Changes
@@ -245,6 +261,7 @@
 - [#986](https://github.com/aragon/app/pull/986) [`fb29e63`](https://github.com/aragon/app/commit/fb29e63531257a90e55800799e7dadbd3544183b) Thanks [@milosh86](https://github.com/milosh86)! - Add campaign creation basic view
 
 - [#994](https://github.com/aragon/app/pull/994) [`75259e0`](https://github.com/aragon/app/commit/75259e0b5b71e6126811c2343a2c225f830d0500) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Upgrade wagmi from v2.19.5 to v3.4.2, update viem to 2.45.2, and remove all v3 deprecations
+
     - **wagmi v3**: Connector dependencies are now optional peer dependencies, giving more control over the dependency tree
     - **Removed overrides**: Eliminated `@reown/appkit` version override and `@wagmi/connectors` pin that are no longer needed
     - **useBalance migration**: Replaced deprecated `useBalance({ token })` with `useReadContract({ abi: erc20Abi, functionName: 'balanceOf' })` for ERC20 token balance fetching

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/app",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Human-centered DAO infrastructure",
   "author": "Aragon Association",
   "homepage": "https://github.com/aragon/app#readme",

--- a/src/modules/governance/dialogs/permissionCheckDialog/permissionCheckDialog.tsx
+++ b/src/modules/governance/dialogs/permissionCheckDialog/permissionCheckDialog.tsx
@@ -12,6 +12,10 @@ import { useTranslations } from '@/shared/components/translationsProvider';
 import { useSlotSingleFunction } from '@/shared/hooks/useSlotSingleFunction';
 import { PermissionsDefinitionList } from '../../components/permissionsDefinitionList';
 import { GovernanceDialogId } from '../../constants/governanceDialogId';
+// APP-946 hotfix import (remove in APP-957)
+import { GovernanceSlotId } from '../../constants/moduleSlots';
+// APP-946 hotfix import (remove in APP-957)
+import { useCitreaCoreProposalCreationOverride } from '../../hooks/useCitreaCoreProposalCreationOverride';
 
 export interface IPermissionCheckDialogParams
     extends IPermissionCheckGuardParams {
@@ -75,17 +79,40 @@ export const PermissionCheckDialog: React.FC<IPermissionCheckDialogProps> = (
     const { hasPermission, isLoading, settings, isRestricted } =
         checkPermissions;
 
+    // --- APP-946 temporary hotfix START (remove in APP-957:
+    // https://linear.app/aragon/issue/APP-957) ---
+    // Gate the Citrea "core" process proposal creation by Core Team Safe
+    // ownership. No-op for every other DAO/process/slot. On removal: delete this
+    // block, the two imports above (GovernanceSlotId,
+    // useCitreaCoreProposalCreationOverride), and replace every
+    // `effectiveHasPermission`/`effectiveIsLoading` usage below with the original
+    // `hasPermission`/`isLoading`.
+    const citreaOverride = useCitreaCoreProposalCreationOverride({
+        daoId: otherParams.daoId,
+        plugin,
+    });
+    const isCitreaCoreCreationOverride =
+        slotId ===
+            GovernanceSlotId.GOVERNANCE_PERMISSION_CHECK_PROPOSAL_CREATION &&
+        citreaOverride.isActive;
+    const effectiveHasPermission = isCitreaCoreCreationOverride
+        ? citreaOverride.hasPermission
+        : hasPermission;
+    const effectiveIsLoading =
+        isLoading || (isCitreaCoreCreationOverride && citreaOverride.isLoading);
+    // --- APP-946 temporary hotfix END ---
+
     const handleDialogClose = useCallback(() => {
         onError?.();
         close(GovernanceDialogId.PERMISSION_CHECK);
     }, [close, onError]);
 
     useEffect(() => {
-        if (hasPermission) {
+        if (effectiveHasPermission) {
             onSuccess?.();
             close(GovernanceDialogId.PERMISSION_CHECK);
         }
-    }, [hasPermission, onSuccess, close]);
+    }, [effectiveHasPermission, onSuccess, close]);
 
     useEffect(() => {
         updateOptions({ onClose: handleDialogClose });
@@ -94,14 +121,14 @@ export const PermissionCheckDialog: React.FC<IPermissionCheckDialogProps> = (
     }, [handleDialogClose, updateOptions]);
 
     const keyNamespace = `app.governance.permissionCheckDialog.${permissionNamespace}`;
-    const title = isLoading
+    const title = effectiveIsLoading
         ? t('app.governance.permissionCheckDialog.loading')
         : t(`${keyNamespace}.title`);
-    const description = isLoading
+    const description = effectiveIsLoading
         ? undefined
         : t(`${keyNamespace}.description`);
 
-    const footerAction = isLoading
+    const footerAction = effectiveIsLoading
         ? undefined
         : {
               label: t('app.governance.permissionCheckDialog.action'),
@@ -113,7 +140,7 @@ export const PermissionCheckDialog: React.FC<IPermissionCheckDialogProps> = (
             <Dialog.Header description={description} title={title} />
             <Dialog.Content className="pb-3">
                 <PermissionsDefinitionList
-                    isLoading={isLoading}
+                    isLoading={effectiveIsLoading}
                     isRestricted={isRestricted}
                     settings={settings}
                 />

--- a/src/modules/governance/hooks/useCitreaCoreProposalCreationOverride/index.ts
+++ b/src/modules/governance/hooks/useCitreaCoreProposalCreationOverride/index.ts
@@ -1,0 +1,1 @@
+export * from './useCitreaCoreProposalCreationOverride';

--- a/src/modules/governance/hooks/useCitreaCoreProposalCreationOverride/useCitreaCoreProposalCreationOverride.ts
+++ b/src/modules/governance/hooks/useCitreaCoreProposalCreationOverride/useCitreaCoreProposalCreationOverride.ts
@@ -1,0 +1,105 @@
+import type { Hex } from 'viem';
+import { useReadContract } from 'wagmi';
+import { useWalletAccount } from '@/modules/application/hooks/useWalletAccount';
+import { type IDaoPlugin, Network } from '@/shared/api/daoService';
+import { networkDefinitions } from '@/shared/constants/networkDefinitions';
+
+/**
+ * APP-946 — TEMPORARY EMERGENCY HOTFIX.
+ *
+ * The Citrea DAO "core" governance process has a permission-deployment bug: its
+ * on-chain proposal-creation check effectively passes for everyone. Until the
+ * proper on-chain fix ships, this hook gates proposal creation on that single
+ * process at the UI level: it is disabled by default and only enabled when the
+ * connected wallet is an owner of the Core Team Safe that creates proposals in
+ * the process's first stage ("Core Team Proposal").
+ *
+ * Scope is intentionally narrow — only the Citrea "core" SPP process. The sibling
+ * "ga"/"poll" processes (and every other DAO) are untouched. This whole file is
+ * meant to be reverted as a single unit once the deployment is fixed.
+ *
+ * ⚠️ REMOVAL (APP-957: https://linear.app/aragon/issue/APP-957):
+ * Delete this entire directory
+ * (`src/modules/governance/hooks/useCitreaCoreProposalCreationOverride/`) and the
+ * two call sites flagged with the same APP-957 marker:
+ *   - src/modules/governance/hooks/usePermissionCheckGuard/usePermissionCheckGuard.ts
+ *   - src/modules/governance/dialogs/permissionCheckDialog/permissionCheckDialog.tsx
+ */
+const citreaCoreHotfix = {
+    // DAO id is `${network}-${address}`, lowercased for comparison.
+    daoId: 'citrea-mainnet-0xa941b1c1d9adc88c9241aa3aca59e8b8f0386419',
+    // SPP plugin for the "core" (Core Governance) process.
+    processAddress: '0x17f4d6c94782a8c9bb44f3c0f9f9ac3d77b84ad6',
+    // Gnosis Safe (Core Team) that creates proposals in stage 0 of the process.
+    safeAddress: '0xCEe28Dd08403bF94f7db5bB986722d5494636BB2' as Hex,
+} as const;
+
+const safeGetOwnersAbi = [
+    {
+        type: 'function',
+        name: 'getOwners',
+        inputs: [],
+        outputs: [{ name: '', type: 'address[]' }],
+        stateMutability: 'view',
+    },
+] as const;
+
+export interface IUseCitreaCoreProposalCreationOverrideParams {
+    /**
+     * ID of the DAO the proposal would be created in.
+     */
+    daoId?: string;
+    /**
+     * Plugin (governance process) the proposal would be created on.
+     */
+    plugin?: IDaoPlugin;
+}
+
+export interface IUseCitreaCoreProposalCreationOverrideResult {
+    /**
+     * Whether the hotfix applies to the current DAO/process. When false the
+     * hook is a no-op and callers must fall back to the normal permission check.
+     */
+    isActive: boolean;
+    /**
+     * Whether the connected wallet is allowed to create a proposal. Defaults to
+     * false (deny) while loading, when disconnected, or when not a Safe owner.
+     */
+    hasPermission: boolean;
+    /**
+     * Whether the Safe owners read is still in flight.
+     */
+    isLoading: boolean;
+}
+
+export const useCitreaCoreProposalCreationOverride = (
+    params: IUseCitreaCoreProposalCreationOverrideParams,
+): IUseCitreaCoreProposalCreationOverrideResult => {
+    const { daoId, plugin } = params;
+
+    const { address } = useWalletAccount();
+
+    const isActive =
+        daoId?.toLowerCase() === citreaCoreHotfix.daoId &&
+        plugin?.address?.toLowerCase() === citreaCoreHotfix.processAddress;
+
+    const { id: chainId } = networkDefinitions[Network.CITREA_MAINNET];
+
+    const { data: owners, isLoading } = useReadContract({
+        chainId,
+        address: citreaCoreHotfix.safeAddress,
+        abi: safeGetOwnersAbi,
+        functionName: 'getOwners',
+        query: { enabled: isActive && address != null },
+    });
+
+    const hasPermission =
+        isActive &&
+        address != null &&
+        (owners?.some(
+            (owner) => owner.toLowerCase() === address.toLowerCase(),
+        ) ??
+            false);
+
+    return { isActive, hasPermission, isLoading: isActive && isLoading };
+};

--- a/src/modules/governance/hooks/usePermissionCheckGuard/usePermissionCheckGuard.ts
+++ b/src/modules/governance/hooks/usePermissionCheckGuard/usePermissionCheckGuard.ts
@@ -8,7 +8,11 @@ import type { IDaoPlugin } from '@/shared/api/daoService';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useSlotSingleFunction } from '@/shared/hooks/useSlotSingleFunction';
 import { GovernanceDialogId } from '../../constants/governanceDialogId';
+// APP-946 hotfix import (remove in APP-957)
+import { GovernanceSlotId } from '../../constants/moduleSlots';
 import type { IPermissionCheckDialogParams } from '../../dialogs/permissionCheckDialog';
+// APP-946 hotfix import (remove in APP-957)
+import { useCitreaCoreProposalCreationOverride } from '../useCitreaCoreProposalCreationOverride';
 
 export interface IUsePermissionCheckGuardParams
     extends Omit<IPermissionCheckDialogParams, 'plugin'> {
@@ -46,6 +50,26 @@ export const usePermissionCheckGuard = (
         pluginId: plugin?.interfaceType ?? '',
         params: { plugin: plugin as IDaoPlugin, daoId, proposal },
     }) ?? { hasPermission: true };
+
+    // --- APP-946 temporary hotfix START (remove in APP-957:
+    // https://linear.app/aragon/issue/APP-957) ---
+    // Gate the Citrea "core" process proposal creation by Core Team Safe
+    // ownership. No-op for every other DAO/process/slot. On removal: delete this
+    // block, the two imports above (GovernanceSlotId,
+    // useCitreaCoreProposalCreationOverride), and restore
+    // `result: isConnected && hasPermission` in the return below.
+    const citreaOverride = useCitreaCoreProposalCreationOverride({
+        daoId,
+        plugin,
+    });
+    const isProposalCreationSlot =
+        slotId ===
+        GovernanceSlotId.GOVERNANCE_PERMISSION_CHECK_PROPOSAL_CREATION;
+    const effectiveHasPermission =
+        isProposalCreationSlot && citreaOverride.isActive
+            ? citreaOverride.hasPermission
+            : hasPermission;
+    // --- APP-946 temporary hotfix END ---
 
     const checkUserPermission = useCallback(
         (functionParams?: Partial<IUsePermissionCheckGuardParams>) => {
@@ -100,5 +124,9 @@ export const usePermissionCheckGuard = (
         ],
     );
 
-    return { check: checkFunction, result: isConnected && hasPermission };
+    return {
+        check: checkFunction,
+        // APP-946 hotfix (remove in APP-957): restore `isConnected && hasPermission`.
+        result: isConnected && effectiveHasPermission,
+    };
 };


### PR DESCRIPTION
## Features
- Implement temporary hotfix for Citrea core proposal creation permissions — [APP-946: Emergency hotfix for Citrea proposal creation permissions](https://linear.app/aragon/issue/APP-946/emergency-hotfix-for-citrea-proposal-creation-permissions)
- Add action simulation to the direct execute actions flow ([#1171](https://github.com/aragon/app/pull/1171)) — [APP-810: Add simulation to direct execution flow](https://linear.app/aragon/issue/APP-810/add-simulation-to-direct-execution-flow)
- Enable running inside Safe{Wallet} as a Safe App ([#1180](https://github.com/aragon/app/pull/1180)) — [APP-167: Safe App SDK for quickly connecting Safes to the app without needing to use WC codes](https://linear.app/aragon/issue/APP-167/safe-app-sdk-for-quickly-connecting-safes-to-the-app-without-needing)
- frontend release improvements ([#1177](https://github.com/aragon/app/pull/1177)) — [APP-820: Cleanup BE release workflows and improve FE release workflows](https://linear.app/aragon/issue/APP-820/cleanup-be-release-workflows-and-improve-fe-release-workflows)

## Other Changes
- Release v1.31.0
- Bump the minor-and-patch group across 1 directory with 5 updates ([#1185](https://github.com/aragon/app/pull/1185))
- Update dependencies ([#1178](https://github.com/aragon/app/pull/1178)) — [APP-818: Control dependencies [Platform] Tier 1](https://linear.app/aragon/issue/APP-818/control-dependencies-platform-tier-1)
- Improve image caching, ISR revalidation and dialog code splitting ([#1169](https://github.com/aragon/app/pull/1169)) — [APP-809: Clean up old PR from Jota](https://linear.app/aragon/issue/APP-809/clean-up-old-pr-from-jota)
- Bump the minor-and-patch group with 2 updates ([#1172](https://github.com/aragon/app/pull/1172))
- Merge pull request #1176 from aragon/release/2026-06-10_11-31



<!-- slack_ts: 1781715399.691529 -->
