### PR TITLE
feat(APP-962): route Sentry signal, suppress only true noise

### DIFF
--- a/.agents/shared/metrics/hits.jsonl
+++ b/.agents/shared/metrics/hits.jsonl
@@ -32,3 +32,6 @@
 {"ts":"2026-06-10T10:36:11.106Z","tool":"Edit","file":"src/modules/finance/constants/financeDialogsDefinitions.ts","rule":"dialog-conventions","bytes":3499,"elapsed_ms":1,"adapter":"generic"}
 {"ts":"2026-06-10T10:36:11.149Z","tool":"Edit","file":"src/plugins/tokenPlugin/index.ts","rule":"plugin-slot-registration","bytes":3795,"elapsed_ms":1,"adapter":"generic"}
 {"ts":"2026-06-09T11:03:40.976Z","tool":"Write","file":"src/shared/api/daoService/domain/enum/network.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-23T12:49:35.098Z","tool":"Edit","file":"src/shared/api/aragonBackendService/aragonBackendServiceError.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":0,"adapter":"claude"}
+{"ts":"2026-06-23T12:49:49.841Z","tool":"Edit","file":"src/shared/api/aragonBackendService/aragonBackendServiceError.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-23T12:50:57.800Z","tool":"Edit","file":"src/shared/api/aragonBackendService/aragonBackendServiceError.test.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":1,"adapter":"claude"}

--- a/.agents/shared/metrics/hits.jsonl
+++ b/.agents/shared/metrics/hits.jsonl
@@ -35,3 +35,7 @@
 {"ts":"2026-06-23T12:49:35.098Z","tool":"Edit","file":"src/shared/api/aragonBackendService/aragonBackendServiceError.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":0,"adapter":"claude"}
 {"ts":"2026-06-23T12:49:49.841Z","tool":"Edit","file":"src/shared/api/aragonBackendService/aragonBackendServiceError.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":1,"adapter":"claude"}
 {"ts":"2026-06-23T12:50:57.800Z","tool":"Edit","file":"src/shared/api/aragonBackendService/aragonBackendServiceError.test.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-23T13:21:20.049Z","tool":"Edit","file":"src/shared/api/aragonBackendService/aragonBackendService.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-23T13:21:32.293Z","tool":"Edit","file":"src/shared/utils/daoVisibilityUtils/daoVisibilityUtils.ts","rule":"plugin-visibility","bytes":2379,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-23T13:21:53.621Z","tool":"Edit","file":"src/shared/utils/daoVisibilityUtils/daoVisibilityUtils.test.ts","rule":"plugin-visibility","bytes":2379,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-23T13:22:34.983Z","tool":"Edit","file":"src/shared/api/aragonBackendService/aragonBackendService.client.test.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":2,"adapter":"claude"}

--- a/.agents/shared/metrics/hits.jsonl
+++ b/.agents/shared/metrics/hits.jsonl
@@ -42,3 +42,17 @@
 {"ts":"2026-06-23T13:45:24.983Z","tool":"Write","file":".agents/shared/skills/rules/error-and-monitoring.md","rule":"rule-authoring","bytes":2654,"elapsed_ms":1,"adapter":"claude"}
 {"ts":"2026-06-23T13:45:48.603Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"generic"}
 {"ts":"2026-06-23T13:45:48.630Z","tool":"Edit","file":"src/modules/governance/utils/governanceMetadataUtils/governanceMetadataUtils.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"generic"}
+{"ts":"2026-06-25T11:41:00.686Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":2,"adapter":"claude"}
+{"ts":"2026-06-25T11:41:09.003Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-25T11:41:16.378Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-25T11:41:24.147Z","tool":"Edit","file":"src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-25T11:41:58.234Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.test.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":0,"adapter":"claude"}
+{"ts":"2026-06-25T11:42:06.246Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.test.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":0,"adapter":"claude"}
+{"ts":"2026-06-25T12:20:18.121Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.test.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-25T12:20:30.852Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.test.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-25T12:21:20.172Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.test.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-25T12:21:53.277Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.test.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-25T12:22:01.531Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.test.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-25T12:37:42.551Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-25T12:37:48.897Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-25T12:38:05.017Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.test.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"claude"}

--- a/.agents/shared/metrics/hits.jsonl
+++ b/.agents/shared/metrics/hits.jsonl
@@ -39,3 +39,6 @@
 {"ts":"2026-06-23T13:21:32.293Z","tool":"Edit","file":"src/shared/utils/daoVisibilityUtils/daoVisibilityUtils.ts","rule":"plugin-visibility","bytes":2379,"elapsed_ms":1,"adapter":"claude"}
 {"ts":"2026-06-23T13:21:53.621Z","tool":"Edit","file":"src/shared/utils/daoVisibilityUtils/daoVisibilityUtils.test.ts","rule":"plugin-visibility","bytes":2379,"elapsed_ms":1,"adapter":"claude"}
 {"ts":"2026-06-23T13:22:34.983Z","tool":"Edit","file":"src/shared/api/aragonBackendService/aragonBackendService.client.test.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":2,"adapter":"claude"}
+{"ts":"2026-06-23T13:45:24.983Z","tool":"Write","file":".agents/shared/skills/rules/error-and-monitoring.md","rule":"rule-authoring","bytes":2654,"elapsed_ms":1,"adapter":"claude"}
+{"ts":"2026-06-23T13:45:48.603Z","tool":"Edit","file":"src/shared/utils/monitoringUtils/monitoringUtils.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"generic"}
+{"ts":"2026-06-23T13:45:48.630Z","tool":"Edit","file":"src/modules/governance/utils/governanceMetadataUtils/governanceMetadataUtils.ts","rule":"error-and-monitoring","bytes":2525,"elapsed_ms":1,"adapter":"generic"}

--- a/.agents/shared/skills/rules/error-and-monitoring.md
+++ b/.agents/shared/skills/rules/error-and-monitoring.md
@@ -1,0 +1,29 @@
+---
+name: error-and-monitoring
+description: How to report errors/info to Sentry — route through monitoringUtils, classify by what a failure IS, don't dress expected/external/not-found as bugs.
+globs: src/shared/utils/monitoringUtils/**, src/shared/utils/errorUtils/**, src/shared/utils/responseUtils/**, src/shared/api/aragonBackendService/**, src/shared/components/transactionDialog/**, src/**/pageError/**, src/**/errorBoundary/**, src/**/globalError/**, src/**/error.tsx, src/**/global-error.tsx, src/**/*MetadataUtils/**
+kind: rule
+---
+
+# error-and-monitoring
+
+`monitoringUtils` (`src/shared/utils/monitoringUtils/monitoringUtils.ts`) is the **only** Sentry boundary. Never import `@sentry/*` in feature code — go through `logError`, `logMessage`, `identifyUser`.
+
+## When a feature can fail, classify what the failure IS
+
+- **Real bug** (our code/contract broken, actionable) → let it surface: throw to the nearest error boundary or `monitoringUtils.logError(error, { context })` with enough context to debug. This is the only tier that should reach error-level alerts.
+- **Expected user/wallet behaviour** (rejection, insufficient balance, not connected, WalletConnect stale session) and **non-actionable external** failures (ENS off-chain/CCIP gateway) → NOT a bug. Don't dress it as an error, but don't silently swallow it either. Report normally; `beforeSend` auto-tags `noise_class=expected` and demotes it to `info`, so it stays searchable per user but never alerts. New phrase / EIP-1193 code not yet caught? Add it to `expectedErrorPatterns` / `nonActionableExternalPatterns` / `expectedProviderErrorCodes`.
+- **Backend/RPC/proxy failure** (502, RPC error, HTML instead of JSON) → real signal, not our code; auto-tagged `noise_class=infra`. Keep visible, don't retry-swallow.
+- **Resource gone / stale link / bot URL** (404, removed plugin) → render a clean not-found state and do NOT report. Gate logging with `AragonBackendServiceError.isExpectedNotFoundError(error)`.
+
+## Principles
+
+- **Route, don't hide.** Only zero-signal third-party junk (browser extensions, mail crawlers, WebView DOM serialization) is dropped at source. Anything that could aid an investigation stays in Sentry, tagged — never `ignoreErrors` a real or user error.
+- **info vs error.** `logMessage(name, { level: 'info' | 'warning' })` for non-bug signals; `logError` only for actual errors. Don't re-raise an expected event as an error to "make it visible" — it's already kept and searchable by `user.id:0x...`.
+- **Self-explanatory events.** Pass `context`/tags that let someone debug from the event alone.
+- **Never `JSON.stringify` an error/DOM/cyclic object.** Use `errorUtils.serialize` (WeakSet-safe); for backend payloads use `responseUtils.safeJsonParseForResponse`.
+
+## Canon
+- `monitoringUtils.ts` — `logError` / `logMessage` / `identifyUser` / `beforeSend` (the `noise_class` taxonomy + info demotion).
+- `aragonBackendServiceError.ts` — `isExpectedNotFoundError` (`notFound` + `pluginNotFound`).
+- `pageError.tsx` — suppresses expected not-found, reports the rest.

--- a/.changeset/app-962-conscious-sentry.md
+++ b/.changeset/app-962-conscious-sentry.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Make Sentry error reporting conscious. Route bot/scanner, expected-user, and backend/RPC noise out of the alert stream (tagged via `noise_class`, expected events demoted to `info`) while keeping everything searchable for investigation, and attach the connected wallet as the Sentry user. Render a clean not-found page for stale links to DAOs whose plugins were removed instead of reporting them. Also fixes two crashes: a null pagination page on the landing page and an undefined plugin list during DAO navigation.

--- a/src/modules/application/components/notFound/notFoundBase/notFoundBase.tsx
+++ b/src/modules/application/components/notFound/notFoundBase/notFoundBase.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { EmptyState } from '@aragon/gov-ui-kit';
-import { useTranslations } from '@/shared/components/translationsProvider';
+import { useSafeTranslations } from '@/shared/components/translationsProvider';
 
 export interface INotFoundBaseProps {}
 
 export const NotFoundBase: React.FC<INotFoundBaseProps> = () => {
-    const { t } = useTranslations();
+    // not-found can render outside TranslationsProvider (e.g. notFound() during a
+    // POST/server-action), so use the safe variant to avoid throwing there.
+    const { t } = useSafeTranslations();
 
     return (
         <div className="flex grow items-center justify-center">

--- a/src/modules/application/components/providers/providers.tsx
+++ b/src/modules/application/components/providers/providers.tsx
@@ -25,6 +25,7 @@ import { ensureAppKit, wagmiConfig } from '../../constants/wagmi';
 import { fetchInterceptorUtils } from '../../utils/fetchInterceptorUtils';
 import { queryClientUtils } from '../../utils/queryClientUtils';
 import { DesyncWatcher } from '../desyncWatcher';
+import { SentryUserSync } from '../sentryUserSync';
 import { providersDialogs } from './providersDialogs';
 
 // Boot AppKit before any descendant renders. AppKit and wagmi must share the
@@ -93,6 +94,7 @@ export const Providers: React.FC<IProvidersProps> = (props) => {
                                 >
                                     <DialogProvider>
                                         <DesyncWatcher />
+                                        <SentryUserSync />
                                         {children}
                                         <DialogRoot
                                             dialogs={providersDialogs}

--- a/src/modules/application/components/sentryUserSync/index.ts
+++ b/src/modules/application/components/sentryUserSync/index.ts
@@ -1,0 +1,1 @@
+export { SentryUserSync } from './sentryUserSync';

--- a/src/modules/application/components/sentryUserSync/sentryUserSync.tsx
+++ b/src/modules/application/components/sentryUserSync/sentryUserSync.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useAppKitAccount } from '@reown/appkit/react';
-import { setUser } from '@sentry/nextjs';
 import { useEffect } from 'react';
+import { monitoringUtils } from '@/shared/utils/monitoringUtils';
 
 /**
  * Attaches the connected wallet address as the Sentry user id so that errors stop
@@ -15,11 +15,9 @@ export const SentryUserSync: React.FC = () => {
     const { address, isConnected } = useAppKitAccount({ namespace: 'eip155' });
 
     useEffect(() => {
-        if (isConnected && address != null) {
-            setUser({ id: address });
-        } else {
-            setUser(null);
-        }
+        monitoringUtils.identifyUser(
+            isConnected && address != null ? address : null,
+        );
     }, [address, isConnected]);
 
     return null;

--- a/src/modules/application/components/sentryUserSync/sentryUserSync.tsx
+++ b/src/modules/application/components/sentryUserSync/sentryUserSync.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useAppKitAccount } from '@reown/appkit/react';
+import { setUser } from '@sentry/nextjs';
+import { useEffect } from 'react';
+
+/**
+ * Attaches the connected wallet address as the Sentry user id so that errors stop
+ * reporting "Users: 0" and a specific person's session (events + Session Replay) can
+ * be looked up by `user.id:0x...` when triaging a complaint. The address is public
+ * on-chain data used here purely as a pseudonymous identifier. Clears the user on
+ * disconnect so anonymous traffic is not misattributed.
+ */
+export const SentryUserSync: React.FC = () => {
+    const { address, isConnected } = useAppKitAccount({ namespace: 'eip155' });
+
+    useEffect(() => {
+        if (isConnected && address != null) {
+            setUser({ id: address });
+        } else {
+            setUser(null);
+        }
+    }, [address, isConnected]);
+
+    return null;
+};

--- a/src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.ts
+++ b/src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.ts
@@ -29,7 +29,16 @@ class ApplicationMetadataUtils {
                 // fixing. Tag both via `noise_class` so they route out of the default alert
                 // stream (internal-broken-link → triage, security-probe → security review).
                 const referer = (await headers()).get('referer') ?? '';
-                const isInternalLink = referer.includes('aragon.org');
+                let isInternalLink = false;
+
+                try {
+                    const refererHost = new URL(referer).hostname.toLowerCase();
+                    isInternalLink =
+                        refererHost === 'aragon.org' ||
+                        refererHost.endsWith('.aragon.org');
+                } catch {
+                    isInternalLink = false;
+                }
 
                 monitoringUtils.logMessage('Invalid DAO URL', {
                     level: isInternalLink ? 'warning' : 'info',

--- a/src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.ts
+++ b/src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import { AragonBackendServiceError } from '@/shared/api/aragonBackendService';
 import { daoService } from '@/shared/api/daoService';
 import type { IDaoPageParams } from '@/shared/types';
@@ -23,10 +24,22 @@ class ApplicationMetadataUtils {
             const daoPageParams = await params;
 
             if (!networkUtils.isValidNetwork(daoPageParams.network)) {
+                // A bad network param is almost always external bot/scanner traffic, but
+                // when the referer is our own app it signals a broken internal link worth
+                // fixing. Tag both via `noise_class` so they route out of the default alert
+                // stream (internal-broken-link → triage, security-probe → security review).
+                const referer = (await headers()).get('referer') ?? '';
+                const isInternalLink = referer.includes('aragon.org');
+
                 monitoringUtils.logMessage('Invalid DAO URL', {
+                    level: isInternalLink ? 'warning' : 'info',
                     context: {
                         network: daoPageParams.network,
                         addressOrEns: daoPageParams.addressOrEns,
+                        referer,
+                        noise_class: isInternalLink
+                            ? 'internal-broken-link'
+                            : 'security-probe',
                     },
                 });
 
@@ -51,9 +64,10 @@ class ApplicationMetadataUtils {
                 image,
             });
         } catch (error: unknown) {
-            // Suppress notFound: the page renders an empty/404 state for arbitrary URLs
-            // (bots, stale links) — these aren't bugs and would flood Sentry.
-            if (!AragonBackendServiceError.isNotFoundError(error)) {
+            // Suppress notFound / pluginNotFound: the page renders an empty/404 state
+            // for arbitrary URLs (bots, stale links to removed plugins) — not bugs, and
+            // would flood Sentry.
+            if (!AragonBackendServiceError.isExpectedNotFoundError(error)) {
                 monitoringUtils.logError(error);
             }
 

--- a/src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.ts
+++ b/src/modules/application/utils/applicationMetadataUtils/applicationMetadataUtils.ts
@@ -42,13 +42,13 @@ class ApplicationMetadataUtils {
 
                 monitoringUtils.logMessage('Invalid DAO URL', {
                     level: isInternalLink ? 'warning' : 'info',
+                    noiseClass: isInternalLink
+                        ? 'internal-broken-link'
+                        : 'security-probe',
                     context: {
                         network: daoPageParams.network,
                         addressOrEns: daoPageParams.addressOrEns,
                         referer,
-                        noise_class: isInternalLink
-                            ? 'internal-broken-link'
-                            : 'security-probe',
                     },
                 });
 

--- a/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
+++ b/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
@@ -242,13 +242,21 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
     ]);
 
     useEffect(() => {
-        const transferParams = [receiverAddress, weiAmount];
-        const newData = isNativeToken
-            ? '0x'
-            : encodeFunctionData({
-                  abi: [erc20TransferAbi],
-                  args: transferParams,
-              });
+        let newData: string | undefined = '0x';
+
+        if (!isNativeToken) {
+            try {
+                newData = encodeFunctionData({
+                    abi: [erc20TransferAbi],
+                    args: [receiverAddress, weiAmount],
+                });
+            } catch {
+                // An absurd amount can exceed the uint256 range and make encoding throw.
+                // Leave data unset so amount-field validation surfaces the error to the
+                // user instead of crashing the whole create-proposal form.
+                newData = undefined;
+            }
+        }
 
         setValue(`${fieldName}.data`, newData);
     }, [isNativeToken, receiverAddress, weiAmount, fieldName, setValue]);

--- a/src/modules/governance/dialogs/publishProposalDialog/publishProposalDialog.tsx
+++ b/src/modules/governance/dialogs/publishProposalDialog/publishProposalDialog.tsx
@@ -109,7 +109,11 @@ export const PublishProposalDialog: React.FC<IPublishProposalDialogProps> = (
     const getProposalsLink = ({
         slug,
     }: IBuildTransactionDialogSuccessLinkHref) => {
-        const proposalPath = `proposals/${slug!.toUpperCase()}`;
+        // The slug can be absent if the success link is built before the proposal
+        // slug resolves — fall back to the proposals list instead of crashing.
+        const proposalPath = slug
+            ? `proposals/${slug.toUpperCase()}`
+            : 'proposals';
 
         if (daoUtils.isLinkedAccountPlugin(plugin, dao)) {
             return `/dao/${dao!.network}/${plugin.daoAddress}/${proposalPath}`;

--- a/src/modules/governance/utils/governanceMetadataUtils/governanceMetadataUtils.ts
+++ b/src/modules/governance/utils/governanceMetadataUtils/governanceMetadataUtils.ts
@@ -44,9 +44,10 @@ class GovernanceMetadataUtils {
                 type: 'article',
             });
         } catch (error: unknown) {
-            // Suppress notFound: the page renders an empty/404 state for arbitrary URLs
-            // (bots, stale links) — these aren't bugs and would flood Sentry.
-            if (!AragonBackendServiceError.isNotFoundError(error)) {
+            // Suppress notFound / pluginNotFound: the page renders an empty/404 state
+            // for arbitrary URLs (bots, stale links to removed plugins) — not bugs, and
+            // would flood Sentry.
+            if (!AragonBackendServiceError.isExpectedNotFoundError(error)) {
                 monitoringUtils.logError(error);
             }
 

--- a/src/plugins/gaugeVoterPlugin/utils/gaugeVoterLockUtils/gaugeVoterLockUtils.tsx
+++ b/src/plugins/gaugeVoterPlugin/utils/gaugeVoterLockUtils/gaugeVoterLockUtils.tsx
@@ -90,8 +90,8 @@ class GaugeVoterLockUtils {
         if (
             amount == null ||
             votingEscrow?.slope == null ||
-            votingEscrow.bias == null ||
-            votingEscrow.maxTime == null
+            votingEscrow?.bias == null ||
+            votingEscrow?.maxTime == null
         ) {
             return '0';
         }

--- a/src/plugins/gaugeVoterPlugin/utils/gaugeVoterLockUtils/gaugeVoterLockUtils.tsx
+++ b/src/plugins/gaugeVoterPlugin/utils/gaugeVoterLockUtils/gaugeVoterLockUtils.tsx
@@ -84,7 +84,19 @@ class GaugeVoterLockUtils {
         settings: IGaugeVoterPluginSettings,
     ) => {
         const { token, votingEscrow } = settings;
-        const { slope, maxTime, bias } = votingEscrow!;
+
+        // votingEscrow (and its slope/bias/maxTime) or the locked amount can be missing
+        // for not-yet-initialised plugins — no escrow params means no voting power.
+        if (
+            amount == null ||
+            votingEscrow?.slope == null ||
+            votingEscrow.bias == null ||
+            votingEscrow.maxTime == null
+        ) {
+            return '0';
+        }
+
+        const { slope, maxTime, bias } = votingEscrow;
 
         const processedTime = Math.min(time, maxTime);
 

--- a/src/shared/api/aragonBackendService/aragonBackendService.client.test.ts
+++ b/src/shared/api/aragonBackendService/aragonBackendService.client.test.ts
@@ -18,6 +18,12 @@ describe('AragonBackend service (client)', () => {
     });
 
     describe('getNextPageParams', () => {
+        it('returns undefined when the last page is null (failed/empty fetch)', () => {
+            expect(
+                serviceTest.getNextPageParams(null, [], { queryParams: {} }),
+            ).toBeUndefined();
+        });
+
         it('returns undefined when there are no more items to fetch', () => {
             const previousPageMeta = generatePaginatedResponseMetadata({
                 page: 10,

--- a/src/shared/api/aragonBackendService/aragonBackendService.ts
+++ b/src/shared/api/aragonBackendService/aragonBackendService.ts
@@ -21,11 +21,19 @@ export class AragonBackendService extends HttpService {
         TParams extends IRequestQueryParams<object>,
         TData = unknown,
     >(
-        lastPage: IPaginatedResponse<TData>,
+        lastPage: IPaginatedResponse<TData> | null,
         _allPages: IPaginatedResponse<TData>[],
         previousParams: TParams,
     ): TParams | undefined => {
-        const { page, totalPages } = lastPage.metadata;
+        // A page can be null/empty (e.g. a failed or skipped fetch); treat it as the end
+        // of the list instead of throwing on `lastPage.metadata`.
+        const metadata = lastPage?.metadata;
+
+        if (metadata == null) {
+            return;
+        }
+
+        const { page, totalPages } = metadata;
 
         if (page >= totalPages) {
             return;

--- a/src/shared/api/aragonBackendService/aragonBackendServiceError.test.ts
+++ b/src/shared/api/aragonBackendService/aragonBackendServiceError.test.ts
@@ -91,4 +91,37 @@ describe('AragonBackendServiceError class', () => {
             ).toBeFalsy();
         });
     });
+
+    describe('isPluginNotFoundError / isExpectedNotFoundError', () => {
+        it('isPluginNotFoundError is true only for the pluginNotFound code', () => {
+            expect(
+                AragonBackendServiceError.isPluginNotFoundError({
+                    code: AragonBackendServiceError.pluginNotFoundCode,
+                }),
+            ).toBeTruthy();
+            expect(
+                AragonBackendServiceError.isPluginNotFoundError({
+                    code: AragonBackendServiceError.notFoundCode,
+                }),
+            ).toBeFalsy();
+        });
+
+        it('isExpectedNotFoundError covers both notFound and pluginNotFound', () => {
+            expect(
+                AragonBackendServiceError.isExpectedNotFoundError({
+                    code: AragonBackendServiceError.notFoundCode,
+                }),
+            ).toBeTruthy();
+            expect(
+                AragonBackendServiceError.isExpectedNotFoundError({
+                    code: AragonBackendServiceError.pluginNotFoundCode,
+                }),
+            ).toBeTruthy();
+            expect(
+                AragonBackendServiceError.isExpectedNotFoundError({
+                    code: 'other',
+                }),
+            ).toBeFalsy();
+        });
+    });
 });

--- a/src/shared/api/aragonBackendService/aragonBackendServiceError.ts
+++ b/src/shared/api/aragonBackendService/aragonBackendServiceError.ts
@@ -3,6 +3,7 @@ import type { IErrorResponse } from './domain';
 
 export class AragonBackendServiceError extends Error {
     static notFoundCode = 'notFound';
+    static pluginNotFoundCode = 'pluginNotFound';
 
     static parseErrorCode = 'parseError';
     static parseErrorDescription = 'Error parsing response';
@@ -56,9 +57,26 @@ export class AragonBackendServiceError extends Error {
         );
     };
 
-    static isNotFoundError = (error: unknown) =>
+    private static hasCode = (
+        error: unknown,
+        code: string,
+    ): error is { code: string } =>
         error != null &&
         typeof error === 'object' &&
         'code' in error &&
-        error.code === this.notFoundCode;
+        (error as { code: unknown }).code === code;
+
+    static isNotFoundError = (error: unknown) =>
+        this.hasCode(error, this.notFoundCode);
+
+    static isPluginNotFoundError = (error: unknown) =>
+        this.hasCode(error, this.pluginNotFoundCode);
+
+    /**
+     * Expected "resource is gone" errors: a genuine 404 or a stale link to a DAO
+     * whose plugin has since been removed. These render a clean not-found state and
+     * must never be reported to Sentry (bots and dead links would otherwise flood it).
+     */
+    static isExpectedNotFoundError = (error: unknown) =>
+        this.isNotFoundError(error) || this.isPluginNotFoundError(error);
 }

--- a/src/shared/components/page/pageError/pageError.tsx
+++ b/src/shared/components/page/pageError/pageError.tsx
@@ -33,13 +33,16 @@ export const PageError: React.FC<IPageErrorProps> = (props) => {
 
     const { t } = useTranslations();
 
+    const isNotFoundError =
+        AragonBackendServiceError.isExpectedNotFoundError(error);
+
     useEffect(() => {
-        if (error != null) {
+        // Don't report expected not-found errors (genuine 404s and stale links to
+        // removed plugins) — they render a clean not-found state, not a bug.
+        if (error != null && !isNotFoundError) {
             monitoringUtils.logError(error);
         }
-    }, [error]);
-
-    const isNotFoundError = AragonBackendServiceError.isNotFoundError(error);
+    }, [error, isNotFoundError]);
 
     const processedTitle = isNotFoundError
         ? `${errorNamespace}.notFound.title`

--- a/src/shared/components/transactionDialog/transactionDialogUtils.test.tsx
+++ b/src/shared/components/transactionDialog/transactionDialogUtils.test.tsx
@@ -30,58 +30,26 @@ describe('transactionDialog utils', () => {
         });
     });
 
-    describe('shouldIgnoreError', () => {
-        it('returns false when error is not an instance of Error class', () => {
-            expect(
-                transactionDialogUtils['shouldIgnoreError']('test'),
-            ).toBeFalsy();
-        });
-
-        it('returns false when error does not match any of the ignore error list', () => {
-            expect(
-                transactionDialogUtils['shouldIgnoreError']('unknown-error'),
-            ).toBeFalsy();
-        });
-
-        it.each([
-            { message: 'User rejected the request. stack: "Error: [...]' },
-            { message: 'Signing aborted by user. Details: ...' },
-            { message: 'User denied transaction signature.' },
-        ])('returns true when error message contains "$message"', ({
-            message,
-        }) => {
-            const error = new Error(message);
-            expect(
-                transactionDialogUtils['shouldIgnoreError'](error),
-            ).toBeTruthy();
-        });
-    });
-
     describe('monitorTransactionError', () => {
         const logErrorSpy = jest.spyOn(monitoringUtils, 'logError');
 
-        const shouldIgnoreErrorSpy = jest.spyOn(
-            transactionDialogUtils as any,
-            'shouldIgnoreError',
-        );
-
         afterEach(() => {
             logErrorSpy.mockReset();
-            shouldIgnoreErrorSpy.mockReset();
         });
 
-        it('does not monitor the error when error should be ignored', () => {
-            shouldIgnoreErrorSpy.mockReturnValue(true);
-            transactionDialogUtils.monitorTransactionError('error');
-            expect(logErrorSpy).not.toHaveBeenCalled();
-        });
-
-        it('monitors the error and passes the eventual error context when error should not be ignored', () => {
-            shouldIgnoreErrorSpy.mockReturnValue(false);
+        it('reports the error with the eventual error context', () => {
             const error = new Error('test-error');
             const context = { transactionId: 123 };
             transactionDialogUtils.monitorTransactionError(error, context);
             expect(logErrorSpy).toHaveBeenCalledWith(error, { context });
+        });
+
+        it('still reports expected wallet errors (kept for investigation, tagged by beforeSend)', () => {
+            const error = new Error('User rejected the request');
+            transactionDialogUtils.monitorTransactionError(error);
+            expect(logErrorSpy).toHaveBeenCalledWith(error, {
+                context: undefined,
+            });
         });
     });
 });

--- a/src/shared/components/transactionDialog/transactionDialogUtils.tsx
+++ b/src/shared/components/transactionDialog/transactionDialogUtils.tsx
@@ -3,12 +3,6 @@ import { monitoringUtils } from '@/shared/utils/monitoringUtils';
 import type { TransactionStatusState } from '../transactionStatus';
 
 export class TransactionDialogUtils {
-    private ignoreErrors = [
-        'User rejected the request', // Standard wallet rejection (MetaMask, WalletConnect, …)
-        'Signing aborted by user', // Opera wallet rejection
-        'User denied transaction signature', // Older wallet variants
-    ];
-
     queryToStepState = (
         status: UseQueryReturnType['status'],
         fetchStatus: UseQueryReturnType['fetchStatus'],
@@ -23,18 +17,11 @@ export class TransactionDialogUtils {
         error: unknown,
         context?: Record<string, unknown>,
     ) => {
-        if (this.shouldIgnoreError(error)) {
-            return;
-        }
-
+        // Always report — including expected wallet behaviour (rejection, insufficient
+        // balance, …). monitoringUtils.beforeSend tags those `noise_class=expected` so
+        // they stay out of alerts but remain searchable for a future investigation.
         monitoringUtils.logError(error, { context });
     };
-
-    private shouldIgnoreError = (error: unknown) =>
-        error instanceof Error &&
-        this.ignoreErrors.some((ignoreError) =>
-            error.message.includes(ignoreError),
-        );
 }
 
 export const transactionDialogUtils = new TransactionDialogUtils();

--- a/src/shared/utils/daoUtils/daoUtils.ts
+++ b/src/shared/utils/daoUtils/daoUtils.ts
@@ -62,10 +62,10 @@ export interface IDaoAvailableUpdates {
 
 class DaoUtils {
     hasPluginBody = (dao?: IDao): boolean =>
-        dao?.plugins.some((p) => p.isBody) ?? false;
+        dao?.plugins?.some((p) => p.isBody) ?? false;
 
     hasSupportedPlugins = (dao?: IDao): boolean => {
-        const pluginIds = dao?.plugins.map(
+        const pluginIds = dao?.plugins?.map(
             ({ interfaceType }) => interfaceType,
         );
 
@@ -109,7 +109,7 @@ class DaoUtils {
             slug,
         } = params ?? {};
 
-        return dao?.plugins.filter(
+        return dao?.plugins?.filter(
             (plugin) =>
                 this.filterPluginByAddress(plugin, pluginAddress) &&
                 this.filterPluginByType(plugin, type) &&
@@ -178,7 +178,7 @@ class DaoUtils {
     getAvailablePluginUpdates = (dao?: IDao): IDaoPlugin[] => {
         const registeredPlugins =
             pluginRegistryUtils.getPlugins() as IPluginInfo[];
-        const availablePluginUpdates = dao?.plugins.filter((plugin) => {
+        const availablePluginUpdates = dao?.plugins?.filter((plugin) => {
             // We need to get the registered plugin by subdomain, not by interfaceType!
             // There might be a plugin with the same interfaceType but from different repository, and we don't want to allow updating such plugins.
             const target = registeredPlugins.find(

--- a/src/shared/utils/daoUtils/daoUtils.ts
+++ b/src/shared/utils/daoUtils/daoUtils.ts
@@ -65,9 +65,8 @@ class DaoUtils {
         dao?.plugins?.some((p) => p.isBody) ?? false;
 
     hasSupportedPlugins = (dao?: IDao): boolean => {
-        const pluginIds = dao?.plugins?.map(
-            ({ interfaceType }) => interfaceType,
-        );
+        const pluginIds =
+            dao?.plugins?.map(({ interfaceType }) => interfaceType) ?? [];
 
         return pluginRegistryUtils.listContainsRegisteredPlugins(pluginIds);
     };

--- a/src/shared/utils/daoVisibilityUtils/daoVisibilityUtils.test.ts
+++ b/src/shared/utils/daoVisibilityUtils/daoVisibilityUtils.test.ts
@@ -4,6 +4,17 @@ import { daoVisibilityUtils } from './daoVisibilityUtils';
 
 describe('daoVisibilityUtils', () => {
     describe('filterHiddenPlugins', () => {
+        it('returns an empty array when plugins is undefined', () => {
+            expect(
+                daoVisibilityUtils.filterHiddenPlugins(undefined, undefined),
+            ).toEqual([]);
+            expect(
+                daoVisibilityUtils.filterHiddenPlugins(undefined, {
+                    pluginsToHide: [{ address: '0xAAA', name: 'Plugin A' }],
+                }),
+            ).toEqual([]);
+        });
+
         it('returns all plugins when override is undefined', () => {
             const plugins = [
                 generateDaoPlugin({ address: '0xAAA' }),

--- a/src/shared/utils/daoVisibilityUtils/daoVisibilityUtils.ts
+++ b/src/shared/utils/daoVisibilityUtils/daoVisibilityUtils.ts
@@ -10,20 +10,22 @@ class DaoVisibilityUtils {
      * Comparison is case-insensitive.
      */
     filterHiddenPlugins = (
-        plugins: IDaoPlugin[],
+        plugins: IDaoPlugin[] | undefined,
         override: IDaoOverride | undefined,
     ): IDaoPlugin[] => {
+        // A DAO may have no plugins array yet — guard against the undefined case.
+        const visiblePlugins = plugins ?? [];
         const hiddenPlugins = override?.pluginsToHide;
 
         if (hiddenPlugins == null || hiddenPlugins.length === 0) {
-            return plugins;
+            return visiblePlugins;
         }
 
         const hiddenSet = new Set(
             hiddenPlugins.map((plugin) => plugin.address.toLowerCase()),
         );
 
-        return plugins.filter(
+        return visiblePlugins.filter(
             (plugin) => !hiddenSet.has(plugin.address.toLowerCase()),
         );
     };

--- a/src/shared/utils/monitoringUtils/monitoringUtils.test.ts
+++ b/src/shared/utils/monitoringUtils/monitoringUtils.test.ts
@@ -126,6 +126,40 @@ describe('monitoring utils', () => {
             expect(result).not.toBeNull();
             expect(result?.tags?.noise_class).toBeUndefined();
         });
+
+        it('does not mis-tag a real bug when a broad phrase only appears in unrelated serialized data', () => {
+            const event = {
+                exception: {
+                    values: [
+                        { value: 'TypeError: cannot read properties of x' },
+                    ],
+                },
+                // A broad phrase buried in an arbitrary field must NOT classify the
+                // event — only the exception text / `.message` is matched.
+                extra: {
+                    __serialized__: {
+                        detail: 'the wallet must be connected to the gauge',
+                    },
+                },
+            } as never;
+            const result = monitoringUtils.beforeSend(event);
+            expect(result).not.toBeNull();
+            expect(result?.tags?.noise_class).toBeUndefined();
+        });
+
+        it('still tags plain-object wallet rejections that carry their text in .message', () => {
+            const event = {
+                exception: {
+                    values: [{ value: 'Object captured as promise rejection' }],
+                },
+                extra: {
+                    __serialized__: { message: 'User rejected the request' },
+                },
+            } as never;
+            const result = monitoringUtils.beforeSend(event);
+            expect(result).not.toBeNull();
+            expect(result?.tags?.noise_class).toEqual('expected');
+        });
     });
 
     describe('isEnabled', () => {

--- a/src/shared/utils/monitoringUtils/monitoringUtils.test.ts
+++ b/src/shared/utils/monitoringUtils/monitoringUtils.test.ts
@@ -66,12 +66,24 @@ describe('monitoring utils', () => {
             expect(result).not.toBeNull();
         });
 
-        it('keeps expected wallet behaviour but tags it expected (not hidden)', () => {
+        it('keeps expected wallet behaviour, tags it expected and demotes to info', () => {
             const result = monitoringUtils.beforeSend(
                 buildEvent('Error: User rejected the request'),
             );
             expect(result).not.toBeNull();
             expect(result?.tags?.noise_class).toEqual('expected');
+            expect(result?.level).toEqual('info');
+        });
+
+        it('treats non-actionable ENS gateway failures as expected/info', () => {
+            const result = monitoringUtils.beforeSend(
+                buildEvent(
+                    'ContractFunctionExecutionError: The contract function "resolveWithGateways" reverted',
+                ),
+            );
+            expect(result).not.toBeNull();
+            expect(result?.tags?.noise_class).toEqual('expected');
+            expect(result?.level).toEqual('info');
         });
 
         it('keeps unhandled wallet rejections (EIP-1193 code 4001) tagged expected', () => {

--- a/src/shared/utils/monitoringUtils/monitoringUtils.test.ts
+++ b/src/shared/utils/monitoringUtils/monitoringUtils.test.ts
@@ -32,6 +32,90 @@ describe('monitoring utils', () => {
         });
     });
 
+    describe('beforeSend', () => {
+        const buildEvent = (message: string, url?: string) =>
+            ({
+                exception: { values: [{ value: message }] },
+                request: url == null ? undefined : { url },
+            }) as never;
+
+        it('drops zero-signal browser-extension and crawler noise', () => {
+            expect(
+                monitoringUtils.beforeSend(
+                    buildEvent("Can't find variable: __firefox__"),
+                ),
+            ).toBeNull();
+            expect(
+                monitoringUtils.beforeSend(
+                    buildEvent('Object Not Found Matching Id:3'),
+                ),
+            ).toBeNull();
+            expect(
+                monitoringUtils.beforeSend(
+                    buildEvent(
+                        "Converting circular structure to JSON --> 'HTMLMetaElement' property '__reactFiber$abc'",
+                    ),
+                ),
+            ).toBeNull();
+        });
+
+        it('keeps a genuine cyclic error (no __reactFiber) so we never miss our own bug', () => {
+            const result = monitoringUtils.beforeSend(
+                buildEvent('TypeError: Converting circular structure to JSON'),
+            );
+            expect(result).not.toBeNull();
+        });
+
+        it('keeps expected wallet behaviour but tags it expected (not hidden)', () => {
+            const result = monitoringUtils.beforeSend(
+                buildEvent('Error: User rejected the request'),
+            );
+            expect(result).not.toBeNull();
+            expect(result?.tags?.noise_class).toEqual('expected');
+        });
+
+        it('keeps unhandled wallet rejections (EIP-1193 code 4001) tagged expected', () => {
+            const event = {
+                exception: {
+                    values: [{ value: 'Object captured as promise rejection' }],
+                },
+                extra: { __serialized__: { code: 4001, message: 'denied' } },
+            } as never;
+            const result = monitoringUtils.beforeSend(event);
+            expect(result).not.toBeNull();
+            expect(result?.tags?.noise_class).toEqual('expected');
+        });
+
+        it('tags backend/RPC failures as infra and keeps them', () => {
+            const result = monitoringUtils.beforeSend(
+                buildEvent('SyntaxError: Unexpected token \'<\', "<html>"'),
+            );
+            expect(result).not.toBeNull();
+            expect(result?.tags?.noise_class).toEqual('infra');
+        });
+
+        it('tags injection/scanner URLs as security-probe and keeps them', () => {
+            // SSTI probe payload; built by concatenation to avoid a literal `${}`.
+            const probeUrl = `https://app.aragon.org/dao/ethereum-mainnet/dfb__$${'{98991*97996}'}__::.x/dashboard`;
+            const result = monitoringUtils.beforeSend(
+                buildEvent('Error: Bad parameters', probeUrl),
+            );
+            expect(result).not.toBeNull();
+            expect(result?.tags?.noise_class).toEqual('security-probe');
+        });
+
+        it('passes a genuine error through untagged', () => {
+            const result = monitoringUtils.beforeSend(
+                buildEvent(
+                    'TypeError: Cannot read properties of null',
+                    'https://app.aragon.org/dao/base-mainnet/0x690C2e187c8254a887B35C0B4477ce6787F92855/proposals/DIP-17',
+                ),
+            );
+            expect(result).not.toBeNull();
+            expect(result?.tags?.noise_class).toBeUndefined();
+        });
+    });
+
     describe('isEnabled', () => {
         test.each([
             { env: 'staging', result: true },

--- a/src/shared/utils/monitoringUtils/monitoringUtils.ts
+++ b/src/shared/utils/monitoringUtils/monitoringUtils.ts
@@ -9,6 +9,7 @@ import {
     captureException,
     captureMessage,
     captureRequestError,
+    setUser,
     withServerActionInstrumentation,
 } from '@sentry/nextjs';
 
@@ -67,6 +68,19 @@ class MonitoringUtils {
      * serialized payload instead.
      */
     private expectedProviderErrorCodes = [4001, 4100, 4900, 4901];
+
+    /**
+     * Non-actionable failures from infrastructure outside our control that belongs to the
+     * user, not our backend: mainly ENS off-chain (CCIP) gateways returning malformed
+     * data when resolving a user's ENS avatar/name. We can't fix someone else's gateway and
+     * it only degrades an avatar, so — like expected user behaviour — these are kept at
+     * `info` level (searchable for investigation) but never alerted on.
+     */
+    private nonActionableExternalPatterns = [
+        'resolveWithGateways', // ENS forward resolution via off-chain gateway
+        'reverseWithGateways', // ENS reverse resolution via off-chain gateway
+        'OffchainLookupError', // viem CCIP-read lookup failure
+    ];
 
     /**
      * Objectively zero-signal noise injected by the user's environment, not our code:
@@ -132,6 +146,11 @@ class MonitoringUtils {
         const noiseClass = this.classifyNoise(event, message, hint);
         if (noiseClass != null) {
             event.tags = { ...event.tags, noise_class: noiseClass };
+            // Expected/non-actionable events are kept for investigation but demoted to
+            // `info` so they read as non-bugs and stay out of error-level alerts.
+            if (noiseClass === 'expected') {
+                event.level = 'info';
+            }
         }
 
         return event;
@@ -140,6 +159,14 @@ class MonitoringUtils {
     logError = (error: unknown, params?: ILogErrorParams) => {
         const { context } = params ?? {};
         captureException(error, { extra: context });
+    };
+
+    /**
+     * Attaches (or clears) the current user so events become searchable by `user.id`.
+     * Pass the connected wallet address, or null on disconnect.
+     */
+    identifyUser = (id: string | null) => {
+        setUser(id == null ? null : { id });
     };
 
     logMessage = (name: string, params?: ILogMessageParams) => {
@@ -156,9 +183,13 @@ class MonitoringUtils {
         message: string,
         hint?: EventHint,
     ): SentryNoiseClass | undefined => {
-        // Expected user/wallet behaviour: kept for investigation, out of alerts.
+        // Expected user/wallet behaviour and non-actionable external (ENS gateway)
+        // failures: kept for investigation, demoted to info, out of alerts.
         if (
             this.expectedErrorPatterns.some((pattern) =>
+                message.includes(pattern),
+            ) ||
+            this.nonActionableExternalPatterns.some((pattern) =>
                 message.includes(pattern),
             ) ||
             this.hasExpectedProviderErrorCode(hint, event)

--- a/src/shared/utils/monitoringUtils/monitoringUtils.ts
+++ b/src/shared/utils/monitoringUtils/monitoringUtils.ts
@@ -1,4 +1,10 @@
-import type { ClientOptions, ScopeContext } from '@sentry/core';
+import type {
+    ClientOptions,
+    ErrorEvent,
+    Event,
+    EventHint,
+    ScopeContext,
+} from '@sentry/core';
 import {
     captureException,
     captureMessage,
@@ -25,17 +31,111 @@ export interface ILogMessageParams {
     level?: ScopeContext['level'];
 }
 
+/**
+ * Classification of an event that we keep in Sentry but route out of the default
+ * alert stream by tagging it. Used as the value of the `noise_class` tag.
+ * - `expected`: normal user/wallet behaviour — kept so a complaint can still be
+ *   investigated (search `user.id:0x... noise_class:expected`), just not alerted on.
+ * - `infra`: backend/RPC/proxy failures — routed to devops/backend.
+ * - `security-probe`: scanner/injection traffic — kept for security review.
+ */
+export type SentryNoiseClass = 'expected' | 'infra' | 'security-probe';
+
 class MonitoringUtils {
+    /**
+     * Expected, non-actionable errors that represent normal user/wallet behaviour
+     * (rejections, missing connection, expected RPC param errors). We do NOT hide these:
+     * `beforeSend` tags them `noise_class=expected` and keeps them in Sentry so a future
+     * complaint can be investigated (search `user.id:0x...`), but they stay out of the
+     * default alert stream / bug board.
+     */
+    expectedErrorPatterns = [
+        'User rejected the request', // Standard wallet rejection (MetaMask, WalletConnect, …)
+        'Signing aborted by user', // Opera wallet rejection
+        'User denied transaction signature', // Older wallet variants
+        'must be connected', // Dialog invariants opened without a connected wallet
+        'wallet must has at least one account', // Wallet connected with no selected account
+        'exceeds the balance', // Insufficient balance for gas/value
+        "session topic doesn't exist", // WalletConnect: stale session
+        'No matching key. session topic', // WalletConnect: stale session
+    ];
+
+    /**
+     * EIP-1193 provider error codes that represent normal user behaviour rather than bugs.
+     * These often surface as unhandled rejections of plain `{ code, message }` objects
+     * (so the message-based `ignoreErrors` cannot catch them) — `beforeSend` matches the
+     * serialized payload instead.
+     */
+    private expectedProviderErrorCodes = [4001, 4100, 4900, 4901];
+
+    /**
+     * Objectively zero-signal noise injected by the user's environment, not our code:
+     * browser extensions and e-mail link crawlers. Safe to drop at the source.
+     */
+    private dropPatterns = [
+        '__firefox__', // Firefox extension internals
+        'window.ethereum.selectedAddress', // Wallet extension probing
+        'Object Not Found Matching Id', // Outlook SafeLink crawler artifact
+        // In-app-browser/WebView scripts JSON.stringify-ing a DOM node (React fiber).
+        // Deliberately narrow: a genuine cyclic-serialization bug in OUR data does NOT
+        // contain `__reactFiber`, so it is never dropped and will still surface.
+        '__reactFiber',
+    ];
+
+    /**
+     * Backend/RPC/proxy failures. Real signal, but the source is outside our codebase —
+     * tagged `infra` so devops/backend can pick them up, kept visible (never dropped).
+     */
+    private infraPatterns = [
+        "Unexpected token '<'", // Backend/proxy returned HTML instead of JSON
+        '<html>',
+        'Error parsing response',
+        'RPC endpoint returned error status',
+        'HTTP request failed',
+        'fetch failed',
+    ];
+
     getBaseConfig = (): Pick<
         ClientOptions,
-        'enabled' | 'dsn' | 'tracesSampleRate' | 'environment' | 'release'
+        | 'enabled'
+        | 'dsn'
+        | 'tracesSampleRate'
+        | 'environment'
+        | 'release'
+        | 'beforeSend'
     > => ({
         enabled: this.isEnabled(),
         dsn: process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN,
         tracesSampleRate: 0.1,
         environment: process.env.NEXT_PUBLIC_ENV,
         release: process.env.version,
+        beforeSend: this.beforeSend,
     });
+
+    /**
+     * Routes events instead of hiding them. Only objectively zero-value third-party junk
+     * (extensions, crawlers, WebView scripts serializing DOM nodes) is dropped. Everything
+     * that could ever aid an investigation is KEPT and, when noisy, tagged via `noise_class`
+     * so it can be filtered out of the default alert stream but still searched later:
+     * - expected user/wallet behaviour → `expected`
+     * - backend/RPC failures → `infra`
+     * - scanner/injection traffic → `security-probe`
+     */
+    beforeSend = (event: ErrorEvent, hint?: EventHint): ErrorEvent | null => {
+        const message = this.getEventMessage(event, hint);
+
+        // Drop only zero-signal third-party junk (never our users' or our own errors).
+        if (this.dropPatterns.some((pattern) => message.includes(pattern))) {
+            return null;
+        }
+
+        const noiseClass = this.classifyNoise(event, message, hint);
+        if (noiseClass != null) {
+            event.tags = { ...event.tags, noise_class: noiseClass };
+        }
+
+        return event;
+    };
 
     logError = (error: unknown, params?: ILogErrorParams) => {
         const { context } = params ?? {};
@@ -50,6 +150,110 @@ class MonitoringUtils {
     logRequestError = captureRequestError;
 
     serverActionWrapper = withServerActionInstrumentation;
+
+    private classifyNoise = (
+        event: Event,
+        message: string,
+        hint?: EventHint,
+    ): SentryNoiseClass | undefined => {
+        // Expected user/wallet behaviour: kept for investigation, out of alerts.
+        if (
+            this.expectedErrorPatterns.some((pattern) =>
+                message.includes(pattern),
+            ) ||
+            this.hasExpectedProviderErrorCode(hint, event)
+        ) {
+            return 'expected';
+        }
+
+        if (this.infraPatterns.some((pattern) => message.includes(pattern))) {
+            return 'infra';
+        }
+
+        if (this.isProbeUrl(event.request?.url)) {
+            return 'security-probe';
+        }
+
+        return undefined;
+    };
+
+    /**
+     * Detects scanner/probe traffic. Legitimate routes only ever contain a network slug,
+     * an address/ENS and path segments, so any of the following marks an attack/scan:
+     * double-encoding, a URL that fails to decode, or template/injection metacharacters
+     * (e.g. the SSTI probe `…/dfb__${98991*97996}__::.x/…`).
+     */
+    private isProbeUrl = (url?: string) => {
+        if (url == null) {
+            return false;
+        }
+
+        if (url.includes('%25')) {
+            // Double-encoded characters — almost always a scanner, not a real navigation.
+            return true;
+        }
+
+        let decoded: string;
+        try {
+            decoded = decodeURIComponent(url);
+        } catch {
+            return true;
+        }
+
+        // Metacharacters that never appear in a valid network/address/ENS/slug path.
+        return /[<>${}`;()|]|\]\]|\*\*/.test(decoded);
+    };
+
+    private getEventMessage = (event: Event, hint?: EventHint): string => {
+        const fromException =
+            hint?.originalException instanceof Error
+                ? hint.originalException.message
+                : '';
+        const fromEvent =
+            event.exception?.values
+                ?.map((value) => value.value ?? '')
+                .join(' ') ?? '';
+        // Unhandled rejections of plain objects carry their real text only here.
+        const fromSerialized = this.safeStringify(
+            hint?.originalException ?? event.extra?.__serialized__,
+        );
+
+        return [
+            fromException,
+            fromEvent,
+            event.message ?? '',
+            fromSerialized,
+        ].join(' ');
+    };
+
+    /**
+     * True when the captured payload is an EIP-1193 provider error with an expected
+     * (user-driven) code — e.g. an unhandled rejection of `{ code: 4001, message }`.
+     */
+    private hasExpectedProviderErrorCode = (
+        hint: EventHint | undefined,
+        event: Event,
+    ): boolean => {
+        const candidate = (hint?.originalException ??
+            event.extra?.__serialized__) as { code?: unknown } | undefined;
+        const code = candidate?.code;
+
+        return (
+            typeof code === 'number' &&
+            this.expectedProviderErrorCodes.includes(code)
+        );
+    };
+
+    private safeStringify = (value: unknown): string => {
+        if (value == null || typeof value !== 'object') {
+            return '';
+        }
+        try {
+            return JSON.stringify(value);
+        } catch {
+            return '';
+        }
+    };
 
     // Only enable error tracking for development, staging and production environments
     private isEnabled = () =>

--- a/src/shared/utils/monitoringUtils/monitoringUtils.ts
+++ b/src/shared/utils/monitoringUtils/monitoringUtils.ts
@@ -30,6 +30,13 @@ export interface ILogMessageParams {
      * @default info
      */
     level?: ScopeContext['level'];
+    /**
+     * Optional noise classification, applied as the `noise_class` tag using the same
+     * typed taxonomy `beforeSend` uses — so explicit (call-site) and pattern-based
+     * (`beforeSend`) tagging share one source of truth and never drift from the saved
+     * views / alert filters.
+     */
+    noiseClass?: SentryNoiseClass;
 }
 
 /**
@@ -39,8 +46,14 @@ export interface ILogMessageParams {
  *   investigated (search `user.id:0x... noise_class:expected`), just not alerted on.
  * - `infra`: backend/RPC/proxy failures — routed to devops/backend.
  * - `security-probe`: scanner/injection traffic — kept for security review.
+ * - `internal-broken-link`: a broken link inside our own app (e.g. a bad network
+ *   slug reached from an `aragon.org` referer) — worth triaging/fixing.
  */
-export type SentryNoiseClass = 'expected' | 'infra' | 'security-probe';
+export type SentryNoiseClass =
+    | 'expected'
+    | 'infra'
+    | 'security-probe'
+    | 'internal-broken-link';
 
 class MonitoringUtils {
     /**
@@ -170,8 +183,12 @@ class MonitoringUtils {
     };
 
     logMessage = (name: string, params?: ILogMessageParams) => {
-        const { context, level = 'info' } = params ?? {};
-        captureMessage(name, { level, tags: context });
+        const { context, level = 'info', noiseClass } = params ?? {};
+        const tags =
+            noiseClass != null
+                ? { ...context, noise_class: noiseClass }
+                : context;
+        captureMessage(name, { level, tags });
     };
 
     logRequestError = captureRequestError;
@@ -244,8 +261,11 @@ class MonitoringUtils {
             event.exception?.values
                 ?.map((value) => value.value ?? '')
                 .join(' ') ?? '';
-        // Unhandled rejections of plain objects carry their real text only here.
-        const fromSerialized = this.safeStringify(
+        // Unhandled rejections of plain objects carry their real text in `.message`.
+        // We match only that field — never a JSON dump of the whole object — so a broad
+        // phrase (e.g. `must be connected`) can't accidentally match unrelated nested
+        // data and mis-route a genuine bug into the `expected`/`infra` noise classes.
+        const fromSerializedMessage = this.getSerializedMessage(
             hint?.originalException ?? event.extra?.__serialized__,
         );
 
@@ -253,7 +273,7 @@ class MonitoringUtils {
             fromException,
             fromEvent,
             event.message ?? '',
-            fromSerialized,
+            fromSerializedMessage,
         ].join(' ');
     };
 
@@ -275,15 +295,12 @@ class MonitoringUtils {
         );
     };
 
-    private safeStringify = (value: unknown): string => {
+    private getSerializedMessage = (value: unknown): string => {
         if (value == null || typeof value !== 'object') {
             return '';
         }
-        try {
-            return JSON.stringify(value);
-        } catch {
-            return '';
-        }
+        const message = (value as { message?: unknown }).message;
+        return typeof message === 'string' ? message : '';
     };
 
     // Only enable error tracking for development, staging and production environments


### PR DESCRIPTION
## Context

Sentry for `app-next` was noisy: the top issues were bot/scanner traffic and expected user behaviour, real bugs were buried, every issue showed `Users: 0` (no `setUser`), and there was no written strategy for what to report. This makes Sentry conscious: it routes signal, suppresses only true noise, and keeps everything else searchable for investigation.

## What changed

**Monitoring (`monitoringUtils.beforeSend` — applies to client/server/edge)**
- **Drops only zero-signal third-party junk**: browser-extension internals, mail crawlers, and in-app-browser/WebView scripts that `JSON.stringify` DOM nodes (matched narrowly via `__reactFiber`, so a genuine cyclic bug in our own data still surfaces).
- **Routes, doesn't hide.** Everything that could aid investigation is kept and tagged via `noise_class`:
  - `expected` — user/wallet behaviour (rejection, insufficient balance, not connected, WalletConnect stale session, EIP-1193 codes) **and** non-actionable external failures (ENS off-chain/CCIP gateway). Demoted to `level: info` — searchable by `user.id:0x…` but never alerts.
  - `infra` — backend/RPC/proxy failures (502, RPC error, HTML-instead-of-JSON). Visible, for devops/backend.
  - `security-probe` — scanner/injection URLs (e.g. SSTI payloads). Kept for security review.
- **`setUser`** via new `SentryUserSync` (`monitoringUtils.identifyUser`) — fixes `Users: 0`, enables `user.id` lookup + Session Replay.

**Expected not-found (stale links to DAOs whose plugins were removed)**
- `AragonBackendServiceError.isExpectedNotFoundError` (`notFound` + `pluginNotFound`); `pageError` and the metadata utils render a clean not-found page and stop reporting these.

**Crash fixes**
- `getNextPageParams`: a null infinite-query page no longer throws on `.metadata` (APP-NEXT-217).
- `daoVisibilityUtils.filterHiddenPlugins`: undefined `dao.plugins` no longer throws on `.filter` (APP-NEXT-27Q).

**Convention**
- New `error-and-monitoring` rule-skill codifying the taxonomy so new features wire logging correctly.

## Sentry triage (done via MCP)
~24 issues archived with rationale (noise / expected / probe / external / stale-link / WebView-cyclic), real bugs kept/assigned, backend cluster annotated for hand-off, fixed crashes resolved.

## Follow-ups in Sentry UI (cannot be done via code/MCP)
- Saved views: `is:unresolved !noise_class:[expected,infra,security-probe]` (bugs), `noise_class:security-probe`, `noise_class:infra`, `noise_class:expected`.
- Add a `!noise_class:[...]` + `level:error` filter to the issue alert rules so tagged noise never notifies.
- Set issue priorities; route the `infra` + `Bad parameters` (248/24C) + N+1 (APP-388) cluster to backend.
- Tags populate on **new** events post-deploy.

## Verification
`pnpm type-check` ✓ · tests ✓ (203 app + 30 guardrails) · `ultracite` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)