### PR TITLE
feat: Collapse transaction linked-account filter into a dropdown

### DIFF
--- a/.changeset/transactions-account-filter-dropdown.md
+++ b/.changeset/transactions-account-filter-dropdown.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Filter DAO transactions by linked account via a dropdown beside the transaction-type toggles

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -1764,6 +1764,9 @@
           "heading": "Error loading transactions"
         },
         "groupTab": "All transactions",
+        "accountFilter": {
+          "all": "All accounts"
+        },
         "typeFilter": {
           "all": "All transactions",
           "executions": "Executions",

--- a/src/modules/finance/components/transactionList/transactionList.test.tsx
+++ b/src/modules/finance/components/transactionList/transactionList.test.tsx
@@ -328,4 +328,95 @@ describe('<TransactionList.Default /> component', () => {
         await user.click(screen.getByText('Executed'));
         expect(onTransactionClick).toHaveBeenCalledWith(executionTransaction);
     });
+
+    const accountOptions = [
+        { id: 'all', label: '', isAll: true, isParent: false, daoId: 'dao-1' },
+        {
+            id: 'dao-1',
+            label: 'Parent DAO',
+            isAll: false,
+            isParent: true,
+            daoId: 'dao-1',
+        },
+        {
+            id: 'sub-1',
+            label: 'Rewards SubDAO',
+            isAll: false,
+            isParent: false,
+            daoId: 'sub-1',
+        },
+    ];
+
+    const mockListData = () =>
+        useTransactionListDataSpy.mockReturnValue({
+            onLoadMore: jest.fn(),
+            transactionList: [],
+            state: 'idle' as const,
+            pageSize: 10,
+            itemsCount: 0,
+            emptyState: { heading: '', description: '' },
+            errorState: { heading: '', description: '' },
+        });
+
+    it('renders the linked-account dropdown when there are 2+ non-all options', () => {
+        mockListData();
+        render(
+            createTestComponent({
+                bodyFilter: {
+                    options: accountOptions,
+                    value: accountOptions[0],
+                    onSelect: jest.fn(),
+                },
+            }),
+        );
+
+        expect(
+            screen.getByRole('button', {
+                name: 'app.finance.transactionList.accountFilter.all',
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it('hides the linked-account dropdown when there are fewer than 2 non-all options', () => {
+        mockListData();
+        render(
+            createTestComponent({
+                bodyFilter: {
+                    options: [accountOptions[0], accountOptions[1]],
+                    value: accountOptions[0],
+                    onSelect: jest.fn(),
+                },
+            }),
+        );
+
+        expect(
+            screen.queryByRole('button', {
+                name: 'app.finance.transactionList.accountFilter.all',
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('calls onSelect with the chosen account', async () => {
+        const user = userEvent.setup();
+        const onSelect = jest.fn();
+        mockListData();
+        render(
+            createTestComponent({
+                bodyFilter: {
+                    options: accountOptions,
+                    value: accountOptions[0],
+                    onSelect,
+                },
+            }),
+        );
+
+        await user.click(
+            screen.getByRole('button', {
+                name: 'app.finance.transactionList.accountFilter.all',
+            }),
+        );
+        await user.click(screen.getByText('Rewards SubDAO'));
+
+        expect(onSelect).toHaveBeenCalledWith(accountOptions[2]);
+    });
 });

--- a/src/modules/finance/components/transactionList/transactionListContainer.test.tsx
+++ b/src/modules/finance/components/transactionList/transactionListContainer.test.tsx
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react';
 import type { IDaoFilterOption } from '@/shared/hooks/useDaoFilterUrlParam';
-import * as useDaoFilterUrlParamModule from '@/shared/hooks/useDaoFilterUrlParam';
 import {
     type ITransactionListContainerProps,
     TransactionListContainer,
@@ -9,17 +8,12 @@ import type { ITransactionListDefaultProps } from './transactionListDefault';
 import * as transactionListDefaultModule from './transactionListDefault';
 
 describe('<TransactionListContainer /> component', () => {
-    const useDaoFilterUrlParamSpy = jest.spyOn(
-        useDaoFilterUrlParamModule,
-        'useDaoFilterUrlParam',
-    );
-
     const transactionListDefaultSpy = jest.spyOn(
         transactionListDefaultModule,
         'TransactionListDefault',
     );
 
-    const setActiveOption = jest.fn();
+    const onSelect = jest.fn();
 
     const allOption: IDaoFilterOption = {
         id: 'all',
@@ -48,11 +42,6 @@ describe('<TransactionListContainer /> component', () => {
             capturedProps = props;
             return null;
         });
-        useDaoFilterUrlParamSpy.mockReturnValue({
-            activeOption: subDaoOption,
-            setActiveOption,
-            options: defaultOptions,
-        });
     });
 
     afterEach(() => {
@@ -63,15 +52,19 @@ describe('<TransactionListContainer /> component', () => {
         props?: Partial<ITransactionListContainerProps>,
     ) => {
         const completeProps: ITransactionListContainerProps = {
-            daoId: 'parent-dao',
             initialParams: { queryParams: { daoId: 'parent-dao' } },
+            bodyFilter: {
+                options: defaultOptions,
+                value: subDaoOption,
+                onSelect,
+            },
             ...props,
         };
 
         return <TransactionListContainer {...completeProps} />;
     };
 
-    it('merges activeOption daoId and onlyParent into initialParams.queryParams, and forces address to undefined', () => {
+    it('merges the active bodyFilter value daoId and onlyParent into initialParams.queryParams, and forces address to undefined', () => {
         render(createTestComponent());
 
         expect(capturedProps?.initialParams.queryParams).toEqual(
@@ -83,24 +76,18 @@ describe('<TransactionListContainer /> component', () => {
         );
     });
 
-    it('constructs bodyFilter from hook options, activeOption, and setActiveOption when both are present', () => {
+    it('forwards the bodyFilter to the list component', () => {
         render(createTestComponent());
 
         expect(capturedProps?.bodyFilter).toEqual({
             options: defaultOptions,
             value: subDaoOption,
-            onSelect: setActiveOption,
+            onSelect,
         });
     });
 
-    it('passes bodyFilter as undefined when activeOption and options are absent', () => {
-        useDaoFilterUrlParamSpy.mockReturnValue({
-            activeOption: undefined,
-            setActiveOption: jest.fn(),
-            options: undefined,
-        });
-
-        render(createTestComponent());
+    it('forwards an absent bodyFilter as undefined', () => {
+        render(createTestComponent({ bodyFilter: undefined }));
 
         expect(capturedProps?.bodyFilter).toBeUndefined();
     });

--- a/src/modules/finance/components/transactionList/transactionListContainer.test.tsx
+++ b/src/modules/finance/components/transactionList/transactionListContainer.test.tsx
@@ -1,0 +1,107 @@
+import { render } from '@testing-library/react';
+import type { IDaoFilterOption } from '@/shared/hooks/useDaoFilterUrlParam';
+import * as useDaoFilterUrlParamModule from '@/shared/hooks/useDaoFilterUrlParam';
+import {
+    type ITransactionListContainerProps,
+    TransactionListContainer,
+} from './transactionListContainer';
+import type { ITransactionListDefaultProps } from './transactionListDefault';
+import * as transactionListDefaultModule from './transactionListDefault';
+
+describe('<TransactionListContainer /> component', () => {
+    const useDaoFilterUrlParamSpy = jest.spyOn(
+        useDaoFilterUrlParamModule,
+        'useDaoFilterUrlParam',
+    );
+
+    const transactionListDefaultSpy = jest.spyOn(
+        transactionListDefaultModule,
+        'TransactionListDefault',
+    );
+
+    const setActiveOption = jest.fn();
+
+    const allOption: IDaoFilterOption = {
+        id: 'all',
+        label: 'All',
+        daoId: 'parent-dao',
+        isAll: true,
+        isParent: false,
+    };
+
+    const subDaoOption: IDaoFilterOption = {
+        id: 'sub-1',
+        label: 'Rewards SubDAO',
+        daoId: 'sub-1',
+        isAll: false,
+        isParent: false,
+        onlyParent: false,
+    };
+
+    const defaultOptions: IDaoFilterOption[] = [allOption, subDaoOption];
+
+    let capturedProps: ITransactionListDefaultProps | undefined;
+
+    beforeEach(() => {
+        capturedProps = undefined;
+        transactionListDefaultSpy.mockImplementation((props) => {
+            capturedProps = props;
+            return null;
+        });
+        useDaoFilterUrlParamSpy.mockReturnValue({
+            activeOption: subDaoOption,
+            setActiveOption,
+            options: defaultOptions,
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const createTestComponent = (
+        props?: Partial<ITransactionListContainerProps>,
+    ) => {
+        const completeProps: ITransactionListContainerProps = {
+            daoId: 'parent-dao',
+            initialParams: { queryParams: { daoId: 'parent-dao' } },
+            ...props,
+        };
+
+        return <TransactionListContainer {...completeProps} />;
+    };
+
+    it('merges activeOption daoId and onlyParent into initialParams.queryParams, and forces address to undefined', () => {
+        render(createTestComponent());
+
+        expect(capturedProps?.initialParams.queryParams).toEqual(
+            expect.objectContaining({
+                daoId: 'sub-1',
+                address: undefined,
+                onlyParent: false,
+            }),
+        );
+    });
+
+    it('constructs bodyFilter from hook options, activeOption, and setActiveOption when both are present', () => {
+        render(createTestComponent());
+
+        expect(capturedProps?.bodyFilter).toEqual({
+            options: defaultOptions,
+            value: subDaoOption,
+            onSelect: setActiveOption,
+        });
+    });
+
+    it('passes bodyFilter as undefined when activeOption and options are absent', () => {
+        useDaoFilterUrlParamSpy.mockReturnValue({
+            activeOption: undefined,
+            setActiveOption: jest.fn(),
+            options: undefined,
+        });
+
+        render(createTestComponent());
+
+        expect(capturedProps?.bodyFilter).toBeUndefined();
+    });
+});

--- a/src/modules/finance/components/transactionList/transactionListContainer.tsx
+++ b/src/modules/finance/components/transactionList/transactionListContainer.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react';
 import type { IDao } from '@/shared/api/daoService';
-import { useDaoFilterUrlParam } from '@/shared/hooks/useDaoFilterUrlParam';
+import type { IDaoFilterOption } from '@/shared/hooks/useDaoFilterUrlParam';
 import type { NestedOmit } from '@/shared/types/nestedOmit';
 import type {
     IGetTransactionListParams,
@@ -12,8 +12,16 @@ import { TransactionListDefault } from './transactionListDefault';
 
 export interface ITransactionListContainerProps {
     initialParams: NestedOmit<IGetTransactionListParams, 'queryParams.address'>;
-    /** Parent DAO id that drives useDaoFilterUrlParam to build linked-account filter options. */
-    daoId: string;
+    /**
+     * Linked-account (SubDAO) filter state. Owned by the page so a single
+     * source of truth survives transient list unmounts (the container is
+     * controlled and holds no filter state of its own).
+     */
+    bodyFilter?: {
+        options: IDaoFilterOption[];
+        value: IDaoFilterOption;
+        onSelect: (option: IDaoFilterOption) => void;
+    };
     hidePagination?: boolean;
     children?: ReactNode;
     onTransactionClick?: (transaction: ITransactionExecution) => void;
@@ -25,28 +33,17 @@ export const transactionListFilterParam = 'linkedaccount';
 export const TransactionListContainer: React.FC<
     ITransactionListContainerProps
 > = (props) => {
-    const { initialParams, daoId, ...otherProps } = props;
-
-    const { activeOption, setActiveOption, options } = useDaoFilterUrlParam({
-        daoId,
-        includeAllOption: true,
-        name: transactionListFilterParam,
-    });
+    const { initialParams, bodyFilter, ...otherProps } = props;
 
     const mergedParams: IGetTransactionListParams = {
         ...initialParams,
         queryParams: {
             ...initialParams.queryParams,
-            daoId: activeOption?.daoId,
+            daoId: bodyFilter?.value.daoId,
             address: undefined,
-            onlyParent: activeOption?.onlyParent,
+            onlyParent: bodyFilter?.value.onlyParent,
         },
     };
-
-    const bodyFilter =
-        activeOption != null && options != null
-            ? { options, value: activeOption, onSelect: setActiveOption }
-            : undefined;
 
     return (
         <TransactionListDefault

--- a/src/modules/finance/components/transactionList/transactionListContainer.tsx
+++ b/src/modules/finance/components/transactionList/transactionListContainer.tsx
@@ -12,6 +12,7 @@ import { TransactionListDefault } from './transactionListDefault';
 
 export interface ITransactionListContainerProps {
     initialParams: NestedOmit<IGetTransactionListParams, 'queryParams.address'>;
+    /** Parent DAO id that drives useDaoFilterUrlParam to build linked-account filter options. */
     daoId: string;
     hidePagination?: boolean;
     children?: ReactNode;

--- a/src/modules/finance/components/transactionList/transactionListContainer.tsx
+++ b/src/modules/finance/components/transactionList/transactionListContainer.tsx
@@ -2,8 +2,6 @@
 
 import type { ReactNode } from 'react';
 import type { IDao } from '@/shared/api/daoService';
-import { DaoFilterComponent } from '@/shared/components/daoFilterComponent';
-import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoFilterUrlParam } from '@/shared/hooks/useDaoFilterUrlParam';
 import type { NestedOmit } from '@/shared/types/nestedOmit';
 import type {
@@ -13,29 +11,11 @@ import type {
 import { TransactionListDefault } from './transactionListDefault';
 
 export interface ITransactionListContainerProps {
-    /**
-     * Initial parameters to use for fetching the transaction list.
-     */
     initialParams: NestedOmit<IGetTransactionListParams, 'queryParams.address'>;
-    /**
-     * ID of the DAO.
-     */
     daoId: string;
-    /**
-     * Hides the pagination when set to true.
-     */
     hidePagination?: boolean;
-    /**
-     * Children of the component.
-     */
     children?: ReactNode;
-    /**
-     * Callback called on execution transaction click.
-     */
     onTransactionClick?: (transaction: ITransactionExecution) => void;
-    /**
-     * DAO the transactions belong to.
-     */
     dao?: IDao;
 }
 
@@ -46,24 +26,31 @@ export const TransactionListContainer: React.FC<
 > = (props) => {
     const { initialParams, daoId, ...otherProps } = props;
 
-    const { t } = useTranslations();
-
     const { activeOption, setActiveOption, options } = useDaoFilterUrlParam({
         daoId,
         includeAllOption: true,
         name: transactionListFilterParam,
     });
 
+    const mergedParams: IGetTransactionListParams = {
+        ...initialParams,
+        queryParams: {
+            ...initialParams.queryParams,
+            daoId: activeOption?.daoId,
+            address: undefined,
+            onlyParent: activeOption?.onlyParent,
+        },
+    };
+
+    const bodyFilter =
+        activeOption != null && options != null
+            ? { options, value: activeOption, onSelect: setActiveOption }
+            : undefined;
+
     return (
-        <DaoFilterComponent
-            allOptionLabel={t('app.finance.transactionList.groupTab')}
-            Fallback={TransactionListDefault}
-            initialParams={initialParams}
-            onValueChange={setActiveOption}
-            options={options}
-            searchParamName={transactionListFilterParam}
-            slotId="FINANCE_TRANSACTION_LIST"
-            value={activeOption}
+        <TransactionListDefault
+            bodyFilter={bodyFilter}
+            initialParams={mergedParams}
             {...otherProps}
         />
     );

--- a/src/modules/finance/components/transactionList/transactionListDefault.tsx
+++ b/src/modules/finance/components/transactionList/transactionListDefault.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import {
+    Button,
     DataListContainer,
     DataListPagination,
     DataListRoot,
     Dropdown,
+    IconType,
     Toggle,
     ToggleGroup,
     TransactionDataListItem,
@@ -213,9 +215,23 @@ export const TransactionListDefault: React.FC<ITransactionListDefaultProps> = (
             state={state}
         >
             {(showAccountFilter || showTypeFilters) && (
-                <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+                <div className="flex flex-col items-start gap-2 md:gap-3">
                     {showAccountFilter && bodyFilter && (
-                        <Dropdown.Container label={activeAccountLabel}>
+                        <Dropdown.Container
+                            constrainContentWidth={false}
+                            customTrigger={
+                                <Button
+                                    className="min-w-0 max-w-full md:max-w-64"
+                                    iconRight={IconType.CHEVRON_DOWN}
+                                    size="md"
+                                    variant="tertiary"
+                                >
+                                    <span className="truncate">
+                                        {activeAccountLabel}
+                                    </span>
+                                </Button>
+                            }
+                        >
                             {bodyFilter.options.map((option) => (
                                 <Dropdown.Item
                                     key={option.id}

--- a/src/modules/finance/components/transactionList/transactionListDefault.tsx
+++ b/src/modules/finance/components/transactionList/transactionListDefault.tsx
@@ -11,7 +11,7 @@ import {
     ToggleGroup,
     TransactionDataListItem,
 } from '@aragon/gov-ui-kit';
-import type { ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
 import type {
     IGetTransactionListParams,
     IGetTransactionListQueryParams,
@@ -179,6 +179,8 @@ export const TransactionListDefault: React.FC<ITransactionListDefaultProps> = (
         validValues: visibleTypeFilters,
     });
 
+    const [isAccountFilterOpen, setIsAccountFilterOpen] = useState(false);
+
     const allAccountsLabel = t('app.finance.transactionList.accountFilter.all');
     const nonAllAccountOptions =
         bodyFilter?.options.filter((option) => !option.isAll) ?? [];
@@ -222,13 +224,19 @@ export const TransactionListDefault: React.FC<ITransactionListDefaultProps> = (
                             customTrigger={
                                 <Button
                                     className="max-w-full md:max-w-64 [&>div]:min-w-0 [&>div]:truncate"
-                                    iconRight={IconType.CHEVRON_DOWN}
+                                    iconRight={
+                                        isAccountFilterOpen
+                                            ? IconType.CHEVRON_UP
+                                            : IconType.CHEVRON_DOWN
+                                    }
                                     size="md"
                                     variant="tertiary"
                                 >
                                     {activeAccountLabel}
                                 </Button>
                             }
+                            onOpenChange={setIsAccountFilterOpen}
+                            open={isAccountFilterOpen}
                         >
                             {bodyFilter.options.map((option) => (
                                 <Dropdown.Item

--- a/src/modules/finance/components/transactionList/transactionListDefault.tsx
+++ b/src/modules/finance/components/transactionList/transactionListDefault.tsx
@@ -214,7 +214,7 @@ export const TransactionListDefault: React.FC<ITransactionListDefaultProps> = (
         >
             {(showAccountFilter || showTypeFilters) && (
                 <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
-                    {showAccountFilter && bodyFilter != null && (
+                    {showAccountFilter && bodyFilter && (
                         <Dropdown.Container label={activeAccountLabel}>
                             {bodyFilter.options.map((option) => (
                                 <Dropdown.Item

--- a/src/modules/finance/components/transactionList/transactionListDefault.tsx
+++ b/src/modules/finance/components/transactionList/transactionListDefault.tsx
@@ -4,6 +4,7 @@ import {
     DataListContainer,
     DataListPagination,
     DataListRoot,
+    Dropdown,
     Toggle,
     ToggleGroup,
     TransactionDataListItem,
@@ -25,6 +26,7 @@ import type {
     IPluginSettings,
 } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import type { IDaoFilterOption } from '@/shared/hooks/useDaoFilterUrlParam';
 import { useFilterUrlParam } from '@/shared/hooks/useFilterUrlParam';
 import { dataListUtils } from '@/shared/utils/dataListUtils';
 import { TransactionListItem } from './transactionListItem';
@@ -83,13 +85,28 @@ export interface ITransactionListDefaultProps<
      * Children of the component.
      */
     children?: ReactNode;
+    /**
+     * Linked-account (SubDAO) filter state. When present with 2+ non-"All"
+     * options, renders a dropdown beside the type filters.
+     */
+    bodyFilter?: {
+        options: IDaoFilterOption[];
+        value: IDaoFilterOption;
+        onSelect: (option: IDaoFilterOption) => void;
+    };
 }
 
 export const TransactionListDefault: React.FC<ITransactionListDefaultProps> = (
     props,
 ) => {
-    const { initialParams, hidePagination, children, onTransactionClick, dao } =
-        props;
+    const {
+        initialParams,
+        hidePagination,
+        children,
+        onTransactionClick,
+        dao,
+        bodyFilter,
+    } = props;
 
     const { t } = useTranslations();
 
@@ -160,6 +177,15 @@ export const TransactionListDefault: React.FC<ITransactionListDefaultProps> = (
         validValues: visibleTypeFilters,
     });
 
+    const allAccountsLabel = t('app.finance.transactionList.accountFilter.all');
+    const nonAllAccountOptions =
+        bodyFilter?.options.filter((option) => !option.isAll) ?? [];
+    const showAccountFilter =
+        bodyFilter != null && nonAllAccountOptions.length >= 2;
+    const activeAccountLabel = bodyFilter?.value.isAll
+        ? allAccountsLabel
+        : (bodyFilter?.value.label ?? allAccountsLabel);
+
     const filteredParams: IGetTransactionListParams = {
         ...initialParams,
         queryParams: {
@@ -186,26 +212,45 @@ export const TransactionListDefault: React.FC<ITransactionListDefaultProps> = (
             pageSize={pageSize}
             state={state}
         >
-            {showTypeFilters && (
-                <ToggleGroup
-                    isMultiSelect={false}
-                    onChange={(value) => {
-                        if (typeof value === 'string') {
-                            setActiveTypeFilter(value);
-                        }
-                    }}
-                    value={activeTypeFilter}
-                >
-                    {visibleTypeFilters.map((filter) => (
-                        <Toggle
-                            key={filter}
-                            label={t(
-                                `app.finance.transactionList.typeFilter.${filter}`,
-                            )}
-                            value={filter}
-                        />
-                    ))}
-                </ToggleGroup>
+            {(showAccountFilter || showTypeFilters) && (
+                <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+                    {showAccountFilter && bodyFilter != null && (
+                        <Dropdown.Container label={activeAccountLabel}>
+                            {bodyFilter.options.map((option) => (
+                                <Dropdown.Item
+                                    key={option.id}
+                                    onSelect={() => bodyFilter.onSelect(option)}
+                                    selected={option.id === bodyFilter.value.id}
+                                >
+                                    {option.isAll
+                                        ? allAccountsLabel
+                                        : option.label}
+                                </Dropdown.Item>
+                            ))}
+                        </Dropdown.Container>
+                    )}
+                    {showTypeFilters && (
+                        <ToggleGroup
+                            isMultiSelect={false}
+                            onChange={(value) => {
+                                if (typeof value === 'string') {
+                                    setActiveTypeFilter(value);
+                                }
+                            }}
+                            value={activeTypeFilter}
+                        >
+                            {visibleTypeFilters.map((filter) => (
+                                <Toggle
+                                    key={filter}
+                                    label={t(
+                                        `app.finance.transactionList.typeFilter.${filter}`,
+                                    )}
+                                    value={filter}
+                                />
+                            ))}
+                        </ToggleGroup>
+                    )}
+                </div>
             )}
             <DataListContainer
                 emptyState={emptyState}

--- a/src/modules/finance/components/transactionList/transactionListDefault.tsx
+++ b/src/modules/finance/components/transactionList/transactionListDefault.tsx
@@ -221,14 +221,12 @@ export const TransactionListDefault: React.FC<ITransactionListDefaultProps> = (
                             constrainContentWidth={false}
                             customTrigger={
                                 <Button
-                                    className="min-w-0 max-w-full md:max-w-64"
+                                    className="max-w-full md:max-w-64 [&>div]:min-w-0 [&>div]:truncate"
                                     iconRight={IconType.CHEVRON_DOWN}
                                     size="md"
                                     variant="tertiary"
                                 >
-                                    <span className="truncate">
-                                        {activeAccountLabel}
-                                    </span>
+                                    {activeAccountLabel}
                                 </Button>
                             }
                         >

--- a/src/modules/finance/pages/daoTransactionsPage/daoTransactionsPageClient.test.tsx
+++ b/src/modules/finance/pages/daoTransactionsPage/daoTransactionsPageClient.test.tsx
@@ -174,7 +174,7 @@ describe('<DaoTransactionsPageClient /> component', () => {
         );
     });
 
-    it('renders the page title, Transactions list tabs and stats for all transactions', () => {
+    it('renders the page title, Transactions list filters and stats for all transactions', () => {
         render(createTestComponent());
 
         expect(

--- a/src/modules/finance/pages/daoTransactionsPage/daoTransactionsPageClient.test.tsx
+++ b/src/modules/finance/pages/daoTransactionsPage/daoTransactionsPageClient.test.tsx
@@ -171,6 +171,7 @@ describe('<DaoTransactionsPageClient /> component', () => {
         render(createTestComponent({ id }));
         expect(useDaoSpy).toHaveBeenCalledWith(
             expect.objectContaining({ urlParams: { id } }),
+            expect.objectContaining({ placeholderData: expect.anything() }),
         );
     });
 

--- a/src/modules/finance/pages/daoTransactionsPage/daoTransactionsPageClient.tsx
+++ b/src/modules/finance/pages/daoTransactionsPage/daoTransactionsPageClient.tsx
@@ -43,11 +43,19 @@ export const DaoTransactionsPageClient: React.FC<
     const { open } = useDialogContext();
     const isAutomationEnabled = isEnabled('capitalFlowAutomation');
 
-    const { activeOption } = useDaoFilterUrlParam({
+    const { activeOption, setActiveOption, options } = useDaoFilterUrlParam({
         daoId: id,
         includeAllOption: true,
         name: transactionListFilterParam,
     });
+
+    // Own the linked-account filter here (single source of truth). The page
+    // never unmounts on a filter refetch, so the selection can't be wiped by
+    // useFilterUrlParam's unmount cleanup the way a container-owned instance was.
+    const bodyFilter =
+        activeOption != null && options != null
+            ? { options, value: activeOption, onSelect: setActiveOption }
+            : undefined;
 
     // Keep the previous DAO while an onlyParent-driven refetch is in flight so
     // the page never transiently returns null on a filter change — unmounting
@@ -104,8 +112,8 @@ export const DaoTransactionsPageClient: React.FC<
                 title={t('app.finance.daoTransactionsPage.main.title')}
             >
                 <TransactionList.Container
+                    bodyFilter={bodyFilter}
                     dao={dao}
-                    daoId={id}
                     initialParams={initialParams}
                     onTransactionClick={(transaction) =>
                         open(FinanceDialogId.TRANSACTION_DETAIL, {

--- a/src/modules/finance/pages/daoTransactionsPage/daoTransactionsPageClient.tsx
+++ b/src/modules/finance/pages/daoTransactionsPage/daoTransactionsPageClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { keepPreviousData } from '@tanstack/react-query';
 import { DispatchPanel } from '@/modules/capitalFlow/components/dispatchPanel';
 import {
     useAssetList,
@@ -48,10 +49,16 @@ export const DaoTransactionsPageClient: React.FC<
         name: transactionListFilterParam,
     });
 
-    const { data: dao } = useDao({
-        urlParams: { id },
-        queryParams: { onlyParent: activeOption?.onlyParent },
-    });
+    // Keep the previous DAO while an onlyParent-driven refetch is in flight so
+    // the page never transiently returns null on a filter change — unmounting
+    // the list would trigger useFilterUrlParam's cleanup and wipe the selection.
+    const { data: dao } = useDao(
+        {
+            urlParams: { id },
+            queryParams: { onlyParent: activeOption?.onlyParent },
+        },
+        { placeholderData: keepPreviousData },
+    );
 
     const { hasPermission } = useDaoExecutePermission({ dao });
 


### PR DESCRIPTION
# Description

Collapses the transactions list's Linked-Account/SubDAO filter from a wrapping row of tabs into a dropdown, placed above the transaction-type toggles.

- Frontend only — reuses the existing `linkedaccount` URL param and `useDaoFilterUrlParam`; no API/backend changes.
- Drops the `DaoFilterComponent`/`FINANCE_TRANSACTION_LIST` slot indirection for transactions (nothing registered that slot; it always fell back to `TransactionListDefault`).
- Dropdown shows only with 2+ linked accounts; defaults to "All accounts". Trigger is `md` size with a truncating label so long SubDAO names don't wrap.
- Transaction-type availability stays scoped to the selected account (params merged before the availability queries).
- Scope: transactions list only — assets list, proposals, and the shared filter components are untouched.

## Type of Change

- [x] Patch: Enhancement (non-breaking change to an existing feature)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
