### PR TITLE
fix: Enable Tenderly support in network definitions for monad

### DIFF
--- a/.changeset/big-networks-simulate.md
+++ b/.changeset/big-networks-simulate.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Enable Tenderly for Monad network.

--- a/src/shared/constants/networkDefinitions.ts
+++ b/src/shared/constants/networkDefinitions.ts
@@ -343,7 +343,7 @@ export const networkDefinitions: Record<Network, INetworkDefinition> = {
         },
         order: 7,
         protocolVersion: latestProtocolVersion,
-        tenderlySupport: false,
+        tenderlySupport: true,
         addresses: {
             dao: '0xe16516d16602C45D7f1A7e7874CE9F35850B40B5',
             daoFactory: '0xc3a857B614D5B79B936Ce6640E5351dF8fA262eD',


### PR DESCRIPTION
# Description

Monad supports tenderly, but if was flagged as disabled for some reason.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
