### PR TITLE
feat(APP-816): validate Aragon profile fields and show all socials

### DIFF
--- a/.changeset/validate-aragon-profile-fields.md
+++ b/.changeset/validate-aragon-profile-fields.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Validate Aragon profile contact and social fields (email, website, GitHub, X, Telegram, Discord) before they are saved to ENS, surfacing inline errors and blocking malformed values. The member profile now also displays Email, Telegram and Discord alongside Website, X and GitHub, and the Links card is hidden when a member has no links instead of rendering empty.

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,12 @@
+# Reviewed false positives, pinned to a historical commit. The workspace
+# pre-push hook scans the full branch history on the first push of a new
+# branch, so any secret-looking string that ever landed in history must be
+# allowlisted or every new branch fails to push.
+#
+# In commit 7dd0e6c, ensDelegateKey.test.ts used fake ERC-20 token addresses
+# whose 40-hex form tripped gitleaks' generic-api-key rule. They are not
+# secrets. The live fixture has since been changed to a low-entropy repeating
+# pattern that no longer matches, but the original commit is immutable (it is
+# on main), so these fingerprints stay to keep new-branch pushes green.
+7dd0e6cbeebb9cae103c2b56afd00a37970373e6:src/modules/ens/constants/ensDelegateKey.test.ts:generic-api-key:62
+7dd0e6cbeebb9cae103c2b56afd00a37970373e6:src/modules/ens/constants/ensDelegateKey.test.ts:generic-api-key:66

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -549,6 +549,14 @@
             "website": "Website"
           }
         },
+        "errors": {
+          "email": "Enter a valid email address.",
+          "website": "Enter a valid http or https URL.",
+          "github": "Enter a valid GitHub username.",
+          "twitter": "Enter a valid X username.",
+          "telegram": "Enter a valid Telegram username (5–32 characters).",
+          "discord": "Enter a valid Discord username."
+        },
         "alert": {
           "description": "Changes are saved to your primary ENS profile and may appear in other ENS-compatible apps.",
           "title": "Editing your primary ENS",
@@ -1932,7 +1940,10 @@
             "title": "Links",
             "website": "Website",
             "twitter": "X",
-            "github": "GitHub"
+            "github": "GitHub",
+            "email": "Email",
+            "telegram": "Telegram",
+            "discord": "Discord"
           }
         },
         "error": {

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -546,7 +546,15 @@
             "label": "Links",
             "telegram": "Telegram",
             "twitter": "X",
-            "website": "Website"
+            "website": "Website",
+            "placeholders": {
+              "discord": "username",
+              "email": "name@example.com",
+              "github": "username",
+              "telegram": "@username",
+              "twitter": "@handle",
+              "website": "https://example.com"
+            }
           }
         },
         "errors": {

--- a/src/modules/application/dialogs/aragonProfileDialog/aragonProfileDialog.tsx
+++ b/src/modules/application/dialogs/aragonProfileDialog/aragonProfileDialog.tsx
@@ -30,6 +30,7 @@ import {
 import { AvatarInput } from '@/shared/components/forms/avatarInput';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useFormField } from '@/shared/hooks/useFormField';
+import { socialHandleUtils } from '@/shared/utils/socialHandleUtils';
 import { ApplicationDialogId } from '../../constants/applicationDialogId';
 import { useWalletAccount } from '../../hooks/useWalletAccount';
 import { AragonProfileSocialFieldRow } from './aragonProfileSocialFieldRow';
@@ -180,12 +181,10 @@ export const AragonProfileDialog: React.FC<IAragonProfileDialogProps> = (
         }
 
         // Store clean handles without a leading `@` for username-style records.
-        const stripLeadingAt = (value: string) =>
-            value.startsWith('@') ? value.slice(1) : value;
         const normalizedData = {
             ...data,
-            twitter: stripLeadingAt(data.twitter),
-            telegram: stripLeadingAt(data.telegram),
+            twitter: socialHandleUtils.stripLeadingAt(data.twitter),
+            telegram: socialHandleUtils.stripLeadingAt(data.telegram),
         };
 
         const updates: Record<string, string> = {};

--- a/src/modules/application/dialogs/aragonProfileDialog/aragonProfileDialog.tsx
+++ b/src/modules/application/dialogs/aragonProfileDialog/aragonProfileDialog.tsx
@@ -179,10 +179,20 @@ export const AragonProfileDialog: React.FC<IAragonProfileDialogProps> = (
             return;
         }
 
+        // Store clean handles without a leading `@` for username-style records.
+        const stripLeadingAt = (value: string) =>
+            value.startsWith('@') ? value.slice(1) : value;
+        const normalizedData = {
+            ...data,
+            twitter: stripLeadingAt(data.twitter),
+            telegram: stripLeadingAt(data.telegram),
+        };
+
         const updates: Record<string, string> = {};
 
         for (const [field, ensKey] of Object.entries(fieldToEnsKey)) {
-            const formValue = data[field as keyof typeof fieldToEnsKey] ?? '';
+            const formValue =
+                normalizedData[field as keyof typeof fieldToEnsKey] ?? '';
             const existing = ensRecords?.[ensKey as TEnsRecordKey] ?? '';
             if (formValue !== existing) {
                 updates[ensKey] = formValue;

--- a/src/modules/application/dialogs/aragonProfileDialog/aragonProfileSocialFieldRow.tsx
+++ b/src/modules/application/dialogs/aragonProfileDialog/aragonProfileSocialFieldRow.tsx
@@ -35,7 +35,13 @@ export const AragonProfileSocialFieldRow: React.FC<
 
     const socialField = useFormField<IAragonProfileDialogFormData, SocialKey>(
         fieldName,
-        { trimOnBlur: true, rules: socialFieldRules[fieldName] },
+        // `sanitizeOnBlur` is required for `trimOnBlur` to run, so pasted values like
+        // `alice@example.com ` or `@aragon ` are normalized before validation.
+        {
+            trimOnBlur: true,
+            sanitizeOnBlur: true,
+            rules: socialFieldRules[fieldName],
+        },
     );
 
     return (
@@ -45,7 +51,7 @@ export const AragonProfileSocialFieldRow: React.FC<
                 iconLeft={socialKeyToIconType[fieldName]}
                 id={`aragon-profile-social-${fieldName}`}
                 placeholder={t(
-                    `app.application.aragonProfileDialog.fields.socials.${fieldName}`,
+                    `app.application.aragonProfileDialog.fields.socials.placeholders.${fieldName}`,
                 )}
                 {...socialField}
             />

--- a/src/modules/application/dialogs/aragonProfileDialog/aragonProfileSocialFieldRow.tsx
+++ b/src/modules/application/dialogs/aragonProfileDialog/aragonProfileSocialFieldRow.tsx
@@ -7,6 +7,7 @@ import type {
     IAragonProfileDialogFormData,
     SocialKey,
 } from './aragonProfileDialog';
+import { socialFieldRules } from './aragonProfileValidation';
 
 export interface IAragonProfileSocialFieldRowProps {
     /** Form field name. */
@@ -34,7 +35,7 @@ export const AragonProfileSocialFieldRow: React.FC<
 
     const socialField = useFormField<IAragonProfileDialogFormData, SocialKey>(
         fieldName,
-        { trimOnBlur: true },
+        { trimOnBlur: true, rules: socialFieldRules[fieldName] },
     );
 
     return (

--- a/src/modules/application/dialogs/aragonProfileDialog/aragonProfileValidation.test.ts
+++ b/src/modules/application/dialogs/aragonProfileDialog/aragonProfileValidation.test.ts
@@ -1,0 +1,140 @@
+import type { SocialKey } from './aragonProfileDialog';
+import { socialFieldRules } from './aragonProfileValidation';
+
+/** Invokes the single `validate` function defined for a social field. */
+const runValidate = (field: SocialKey, value: string) => {
+    const validate = socialFieldRules[field].validate as (
+        value: string,
+    ) => true | string;
+    return validate(value);
+};
+
+describe('socialFieldRules', () => {
+    const fields: SocialKey[] = [
+        'email',
+        'website',
+        'github',
+        'twitter',
+        'telegram',
+        'discord',
+    ];
+
+    it.each(fields)('treats an empty %s value as valid', (field) => {
+        expect(runValidate(field, '')).toBe(true);
+    });
+
+    describe('email', () => {
+        it('accepts a valid email', () => {
+            expect(runValidate('email', 'alice@example.com')).toBe(true);
+        });
+
+        it.each([
+            'alice',
+            'alice@',
+            'alice@example',
+            'a b@example.com',
+        ])('rejects malformed email "%s"', (value) => {
+            expect(runValidate('email', value)).toBe(
+                'app.application.aragonProfileDialog.errors.email',
+            );
+        });
+    });
+
+    describe('website', () => {
+        it.each([
+            'https://aragon.org',
+            'http://aragon.org/path',
+        ])('accepts http(s) URL "%s"', (value) => {
+            expect(runValidate('website', value)).toBe(true);
+        });
+
+        it.each([
+            'not a url',
+            'ftp://aragon.org',
+            'javascript:alert(1)',
+        ])('rejects non-http(s) value "%s"', (value) => {
+            expect(runValidate('website', value)).toBe(
+                'app.application.aragonProfileDialog.errors.website',
+            );
+        });
+    });
+
+    describe('github', () => {
+        it.each([
+            'octocat',
+            'my-user',
+        ])('accepts valid username "%s"', (value) => {
+            expect(runValidate('github', value)).toBe(true);
+        });
+
+        it.each([
+            '-octocat',
+            'octocat-',
+            'user/repo',
+            'foo bar',
+        ])('rejects invalid username "%s"', (value) => {
+            expect(runValidate('github', value)).toBe(
+                'app.application.aragonProfileDialog.errors.github',
+            );
+        });
+    });
+
+    describe('twitter', () => {
+        it.each([
+            'vitalik',
+            '@vitalik',
+            'vitalik_eth',
+        ])('accepts valid handle "%s"', (value) => {
+            expect(runValidate('twitter', value)).toBe(true);
+        });
+
+        it.each([
+            'foo bar',
+            'waytoolonghandle12345',
+            'a.b',
+        ])('rejects invalid handle "%s"', (value) => {
+            expect(runValidate('twitter', value)).toBe(
+                'app.application.aragonProfileDialog.errors.twitter',
+            );
+        });
+    });
+
+    describe('telegram', () => {
+        it.each([
+            'aragon',
+            '@aragon_dao',
+        ])('accepts valid handle "%s"', (value) => {
+            expect(runValidate('telegram', value)).toBe(true);
+        });
+
+        it.each([
+            'abc',
+            'foo bar',
+            'a'.repeat(33),
+        ])('rejects invalid handle "%s"', (value) => {
+            expect(runValidate('telegram', value)).toBe(
+                'app.application.aragonProfileDialog.errors.telegram',
+            );
+        });
+    });
+
+    describe('discord', () => {
+        it.each([
+            'aragon',
+            'aragon.dao',
+            'a_b.c',
+        ])('accepts valid username "%s"', (value) => {
+            expect(runValidate('discord', value)).toBe(true);
+        });
+
+        it.each([
+            'a',
+            'foo bar',
+            'a'.repeat(33),
+        ])('rejects invalid username "%s"', (value) => {
+            expect(runValidate('discord', value)).toBe(
+                'app.application.aragonProfileDialog.errors.discord',
+            );
+        });
+    });
+});

--- a/src/modules/application/dialogs/aragonProfileDialog/aragonProfileValidation.ts
+++ b/src/modules/application/dialogs/aragonProfileDialog/aragonProfileValidation.ts
@@ -1,0 +1,67 @@
+import type { RegisterOptions } from 'react-hook-form';
+import { sanitizeExternalHttpUrl } from '@/shared/security';
+import type {
+    IAragonProfileDialogFormData,
+    SocialKey,
+} from './aragonProfileDialog';
+
+const errorKey = (field: SocialKey) =>
+    `app.application.aragonProfileDialog.errors.${field}`;
+
+/** Strips a single leading `@` so handles validate the same with or without it. */
+const stripLeadingAt = (value: string): string =>
+    value.startsWith('@') ? value.slice(1) : value;
+
+/**
+ * Validation patterns for the supported ENS profile/contact fields, aligned with
+ * the ENS text-record (ENSIP-5) and profile text-record (ENSIP-18) expectations.
+ */
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// GitHub: 1-39 chars, alphanumeric with non-consecutive single hyphens, no leading/trailing hyphen.
+const githubPattern = /^[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}$/;
+// X (Twitter): 1-15 word characters (letters, digits, underscore).
+const twitterPattern = /^\w{1,15}$/;
+// Telegram: 5-32 word characters.
+const telegramPattern = /^\w{5,32}$/;
+// Discord: 2-32 chars, lowercase letters, digits, dot and underscore (new username format).
+const discordPattern = /^[a-z\d._]{2,32}$/i;
+
+/**
+ * react-hook-form validation rules for each social/contact field. Empty values are
+ * always valid because the fields are optional and can be removed by the user.
+ */
+export const socialFieldRules: Record<
+    SocialKey,
+    RegisterOptions<IAragonProfileDialogFormData, SocialKey>
+> = {
+    email: {
+        validate: (value) =>
+            !value || emailPattern.test(value) || errorKey('email'),
+    },
+    website: {
+        validate: (value) =>
+            !value ||
+            sanitizeExternalHttpUrl(value) != null ||
+            errorKey('website'),
+    },
+    github: {
+        validate: (value) =>
+            !value || githubPattern.test(value) || errorKey('github'),
+    },
+    twitter: {
+        validate: (value) =>
+            !value ||
+            twitterPattern.test(stripLeadingAt(value)) ||
+            errorKey('twitter'),
+    },
+    telegram: {
+        validate: (value) =>
+            !value ||
+            telegramPattern.test(stripLeadingAt(value)) ||
+            errorKey('telegram'),
+    },
+    discord: {
+        validate: (value) =>
+            !value || discordPattern.test(value) || errorKey('discord'),
+    },
+};

--- a/src/modules/application/dialogs/aragonProfileDialog/aragonProfileValidation.ts
+++ b/src/modules/application/dialogs/aragonProfileDialog/aragonProfileValidation.ts
@@ -1,5 +1,6 @@
 import type { RegisterOptions } from 'react-hook-form';
 import { sanitizeExternalHttpUrl } from '@/shared/security';
+import { socialHandleUtils } from '@/shared/utils/socialHandleUtils';
 import type {
     IAragonProfileDialogFormData,
     SocialKey,
@@ -7,24 +8,6 @@ import type {
 
 const errorKey = (field: SocialKey) =>
     `app.application.aragonProfileDialog.errors.${field}`;
-
-/** Strips a single leading `@` so handles validate the same with or without it. */
-const stripLeadingAt = (value: string): string =>
-    value.startsWith('@') ? value.slice(1) : value;
-
-/**
- * Validation patterns for the supported ENS profile/contact fields, aligned with
- * the ENS text-record (ENSIP-5) and profile text-record (ENSIP-18) expectations.
- */
-const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-// GitHub: 1-39 chars, alphanumeric with non-consecutive single hyphens, no leading/trailing hyphen.
-const githubPattern = /^[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}$/;
-// X (Twitter): 1-15 word characters (letters, digits, underscore).
-const twitterPattern = /^\w{1,15}$/;
-// Telegram: 5-32 word characters.
-const telegramPattern = /^\w{5,32}$/;
-// Discord: 2-32 chars, lowercase letters, digits, dot and underscore (new username format).
-const discordPattern = /^[a-z\d._]{2,32}$/i;
 
 /**
  * react-hook-form validation rules for each social/contact field. Empty values are
@@ -36,7 +19,7 @@ export const socialFieldRules: Record<
 > = {
     email: {
         validate: (value) =>
-            !value || emailPattern.test(value) || errorKey('email'),
+            !value || socialHandleUtils.isEmail(value) || errorKey('email'),
     },
     website: {
         validate: (value) =>
@@ -46,22 +29,26 @@ export const socialFieldRules: Record<
     },
     github: {
         validate: (value) =>
-            !value || githubPattern.test(value) || errorKey('github'),
+            !value ||
+            socialHandleUtils.isGithubHandle(value) ||
+            errorKey('github'),
     },
     twitter: {
         validate: (value) =>
             !value ||
-            twitterPattern.test(stripLeadingAt(value)) ||
+            socialHandleUtils.isTwitterHandle(value) ||
             errorKey('twitter'),
     },
     telegram: {
         validate: (value) =>
             !value ||
-            telegramPattern.test(stripLeadingAt(value)) ||
+            socialHandleUtils.isTelegramHandle(value) ||
             errorKey('telegram'),
     },
     discord: {
         validate: (value) =>
-            !value || discordPattern.test(value) || errorKey('discord'),
+            !value ||
+            socialHandleUtils.isDiscordHandle(value) ||
+            errorKey('discord'),
     },
 };

--- a/src/modules/ens/constants/ensDelegateKey.test.ts
+++ b/src/modules/ens/constants/ensDelegateKey.test.ts
@@ -59,11 +59,11 @@ describe('buildEnsDelegateKey', () => {
     it('lowercases mixed-case token addresses for canonical keys', () => {
         const a = buildEnsDelegateKey({
             network: Network.ETHEREUM_MAINNET,
-            tokenAddress: '0xABCDEF1234567890abcdef1234567890ABCDEF12',
+            tokenAddress: '0x1234ABCDef1234ABCDef1234ABCDef1234ABCDef',
         });
         const b = buildEnsDelegateKey({
             network: Network.ETHEREUM_MAINNET,
-            tokenAddress: '0xabcdef1234567890abcdef1234567890abcdef12',
+            tokenAddress: '0x1234abcdef1234abcdef1234abcdef1234abcdef',
         });
         expect(a).toBe(b);
     });

--- a/src/modules/governance/components/memberLinksCard/index.ts
+++ b/src/modules/governance/components/memberLinksCard/index.ts
@@ -1,1 +1,1 @@
-export { MemberLinksCard } from './memberLinksCard';
+export { buildMemberLinks, MemberLinksCard } from './memberLinksCard';

--- a/src/modules/governance/components/memberLinksCard/memberLinksCard.test.tsx
+++ b/src/modules/governance/components/memberLinksCard/memberLinksCard.test.tsx
@@ -32,6 +32,10 @@ describe('buildTwitterUrl', () => {
     it('rejects empty handle after stripping @', () => {
         expect(buildTwitterUrl('@')).toBeNull();
     });
+
+    it('rejects handles longer than 15 chars that the save path also rejects', () => {
+        expect(buildTwitterUrl('a'.repeat(16))).toBeNull();
+    });
 });
 
 describe('buildGithubUrl', () => {
@@ -39,10 +43,12 @@ describe('buildGithubUrl', () => {
         expect(buildGithubUrl('octocat')).toBe('https://github.com/octocat');
     });
 
-    it('allows hyphens and dots in handles', () => {
-        expect(buildGithubUrl('my-user.name')).toBe(
-            'https://github.com/my-user.name',
-        );
+    it('allows hyphens in handles', () => {
+        expect(buildGithubUrl('my-user')).toBe('https://github.com/my-user');
+    });
+
+    it('rejects handles with dots (not valid GitHub usernames)', () => {
+        expect(buildGithubUrl('my-user.name')).toBeNull();
     });
 
     it('rejects handles with slashes', () => {
@@ -69,6 +75,15 @@ describe('buildTelegramUrl', () => {
 
     it('rejects handles with slashes', () => {
         expect(buildTelegramUrl('../malicious')).toBeNull();
+    });
+
+    it('rejects too-short handles that the save path also rejects', () => {
+        expect(buildTelegramUrl('abc')).toBeNull();
+    });
+
+    it('rejects handles with dots or hyphens that the save path also rejects', () => {
+        expect(buildTelegramUrl('foo.bar')).toBeNull();
+        expect(buildTelegramUrl('foo-bar')).toBeNull();
     });
 });
 

--- a/src/modules/governance/components/memberLinksCard/memberLinksCard.test.tsx
+++ b/src/modules/governance/components/memberLinksCard/memberLinksCard.test.tsx
@@ -1,4 +1,10 @@
-import { buildGithubUrl, buildTwitterUrl } from './memberLinksCard';
+import {
+    buildEmailHref,
+    buildGithubUrl,
+    buildMemberLinks,
+    buildTelegramUrl,
+    buildTwitterUrl,
+} from './memberLinksCard';
 
 describe('buildTwitterUrl', () => {
     it('builds a valid X profile URL from a plain handle', () => {
@@ -45,5 +51,94 @@ describe('buildGithubUrl', () => {
 
     it('rejects handles with special characters', () => {
         expect(buildGithubUrl('user<script>')).toBeNull();
+    });
+});
+
+describe('buildTelegramUrl', () => {
+    it('builds a valid Telegram profile URL', () => {
+        expect(buildTelegramUrl('durov')).toBe('https://t.me/durov');
+    });
+
+    it('strips leading @ from handle', () => {
+        expect(buildTelegramUrl('@durov')).toBe('https://t.me/durov');
+    });
+
+    it('rejects handles with spaces', () => {
+        expect(buildTelegramUrl('foo bar')).toBeNull();
+    });
+
+    it('rejects handles with slashes', () => {
+        expect(buildTelegramUrl('../malicious')).toBeNull();
+    });
+});
+
+describe('buildEmailHref', () => {
+    it('builds a mailto href for a valid email', () => {
+        expect(buildEmailHref('alice@example.com')).toBe(
+            'mailto:alice%40example.com',
+        );
+    });
+
+    it('rejects an invalid email', () => {
+        expect(buildEmailHref('not-an-email')).toBeNull();
+    });
+});
+
+describe('buildMemberLinks', () => {
+    it('returns an empty array when no records resolve', () => {
+        expect(buildMemberLinks({})).toEqual([]);
+        expect(
+            buildMemberLinks({
+                url: '',
+                twitter: null,
+                github: undefined,
+                email: '',
+                telegram: null,
+                discord: '',
+            }),
+        ).toEqual([]);
+    });
+
+    it('drops malformed values', () => {
+        expect(
+            buildMemberLinks({
+                url: 'not a url',
+                twitter: 'foo bar',
+                email: 'nope',
+            }),
+        ).toEqual([]);
+    });
+
+    it('resolves all supported fields', () => {
+        const links = buildMemberLinks({
+            url: 'https://aragon.org',
+            twitter: '@aragonproject',
+            github: 'aragon',
+            email: 'hi@aragon.org',
+            telegram: '@aragon',
+            discord: 'aragon',
+        });
+
+        expect(links).toHaveLength(6);
+        expect(links.map((link) => link.labelKey)).toEqual([
+            'app.governance.daoMemberDetailsPage.aside.links.website',
+            'app.governance.daoMemberDetailsPage.aside.links.twitter',
+            'app.governance.daoMemberDetailsPage.aside.links.github',
+            'app.governance.daoMemberDetailsPage.aside.links.email',
+            'app.governance.daoMemberDetailsPage.aside.links.telegram',
+            'app.governance.daoMemberDetailsPage.aside.links.discord',
+        ]);
+    });
+
+    it('renders Discord as text without an href', () => {
+        const [discordLink] = buildMemberLinks({ discord: 'aragon' });
+        expect(discordLink.href).toBeUndefined();
+        expect(discordLink.display).toBe('aragon');
+    });
+
+    it('uses the raw email as the display value with a mailto href', () => {
+        const [emailLink] = buildMemberLinks({ email: 'hi@aragon.org' });
+        expect(emailLink.href).toBe('mailto:hi%40aragon.org');
+        expect(emailLink.display).toBe('hi@aragon.org');
     });
 });

--- a/src/modules/governance/components/memberLinksCard/memberLinksCard.tsx
+++ b/src/modules/governance/components/memberLinksCard/memberLinksCard.tsx
@@ -9,15 +9,23 @@ export interface IMemberLinksCardProps {
     twitter?: string | null;
     /** ENS `com.github` text record. */
     github?: string | null;
+    /** ENS `email` text record. */
+    email?: string | null;
+    /** ENS `org.telegram` text record. */
+    telegram?: string | null;
+    /** ENS `com.discord` text record. */
+    discord?: string | null;
 }
 
 interface ILinkEntry {
     labelKey: string;
-    href: string;
+    /** External href. Omitted for values without a canonical URL (e.g. Discord). */
+    href?: string;
     display: string;
 }
 
 const SAFE_HANDLE_RE = /^[\w.-]+$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /**
  * Builds a safe X (Twitter) profile URL from a handle.
@@ -43,21 +51,44 @@ export function buildGithubUrl(handle: string): string | null {
 }
 
 /**
- * Renders a list of external links (Website, X, GitHub) resolved from ENS text records.
- * Returns `null` when no links are available so the parent can skip rendering the card.
+ * Builds a safe Telegram profile URL from a handle.
+ * Strips a leading `@` if present and encodes the handle to prevent URL injection.
  */
-export const MemberLinksCard: React.FC<IMemberLinksCardProps> = (props) => {
-    const { url, twitter, github } = props;
-    const { t } = useTranslations();
+export function buildTelegramUrl(handle: string): string | null {
+    const cleaned = handle.startsWith('@') ? handle.slice(1) : handle;
+    if (!SAFE_HANDLE_RE.test(cleaned)) {
+        return null;
+    }
+    return `https://t.me/${encodeURIComponent(cleaned)}`;
+}
 
+/**
+ * Builds a safe `mailto:` href from an email address.
+ * Returns `null` when the value is not a valid email.
+ */
+export function buildEmailHref(email: string): string | null {
+    if (!EMAIL_RE.test(email)) {
+        return null;
+    }
+    return `mailto:${encodeURIComponent(email)}`;
+}
+
+const labelPrefix = 'app.governance.daoMemberDetailsPage.aside.links';
+
+/**
+ * Resolves the supported ENS profile/contact records into displayable link entries,
+ * filtering out missing or malformed values. Shared by the card and its parent so the
+ * "Links" card is only shown when at least one entry resolves.
+ */
+export function buildMemberLinks(props: IMemberLinksCardProps): ILinkEntry[] {
+    const { url, twitter, github, email, telegram, discord } = props;
     const links: ILinkEntry[] = [];
 
     if (url) {
         const safe = sanitizeExternalHttpUrl(url);
         if (safe) {
             links.push({
-                labelKey:
-                    'app.governance.daoMemberDetailsPage.aside.links.website',
+                labelKey: `${labelPrefix}.website`,
                 href: safe,
                 display: safe,
             });
@@ -68,8 +99,7 @@ export const MemberLinksCard: React.FC<IMemberLinksCardProps> = (props) => {
         const safe = buildTwitterUrl(twitter);
         if (safe) {
             links.push({
-                labelKey:
-                    'app.governance.daoMemberDetailsPage.aside.links.twitter',
+                labelKey: `${labelPrefix}.twitter`,
                 href: safe,
                 display: safe,
             });
@@ -80,13 +110,55 @@ export const MemberLinksCard: React.FC<IMemberLinksCardProps> = (props) => {
         const safe = buildGithubUrl(github);
         if (safe) {
             links.push({
-                labelKey:
-                    'app.governance.daoMemberDetailsPage.aside.links.github',
+                labelKey: `${labelPrefix}.github`,
                 href: safe,
                 display: safe,
             });
         }
     }
+
+    if (email) {
+        const safe = buildEmailHref(email);
+        if (safe) {
+            links.push({
+                labelKey: `${labelPrefix}.email`,
+                href: safe,
+                display: email,
+            });
+        }
+    }
+
+    if (telegram) {
+        const safe = buildTelegramUrl(telegram);
+        if (safe) {
+            links.push({
+                labelKey: `${labelPrefix}.telegram`,
+                href: safe,
+                display: safe,
+            });
+        }
+    }
+
+    if (discord && SAFE_HANDLE_RE.test(discord)) {
+        // Discord usernames have no canonical public profile URL, so render as text.
+        links.push({
+            labelKey: `${labelPrefix}.discord`,
+            display: discord,
+        });
+    }
+
+    return links;
+}
+
+/**
+ * Renders a list of external links (Website, X, GitHub, Email, Telegram, Discord)
+ * resolved from ENS text records. Returns `null` when no links are available so the
+ * parent can skip rendering the card.
+ */
+export const MemberLinksCard: React.FC<IMemberLinksCardProps> = (props) => {
+    const { t } = useTranslations();
+
+    const links = buildMemberLinks(props);
 
     if (links.length === 0) {
         return null;
@@ -96,9 +168,15 @@ export const MemberLinksCard: React.FC<IMemberLinksCardProps> = (props) => {
         <div className="flex flex-col gap-3">
             {links.map((link) => (
                 <div className="flex flex-col gap-1" key={link.labelKey}>
-                    <Link href={link.href} isExternal={true}>
-                        {t(link.labelKey)}
-                    </Link>
+                    {link.href ? (
+                        <Link href={link.href} isExternal={true}>
+                            {t(link.labelKey)}
+                        </Link>
+                    ) : (
+                        <p className="font-normal text-neutral-800">
+                            {t(link.labelKey)}
+                        </p>
+                    )}
                     <p className="truncate text-neutral-400 text-sm">
                         {link.display}
                     </p>

--- a/src/modules/governance/components/memberLinksCard/memberLinksCard.tsx
+++ b/src/modules/governance/components/memberLinksCard/memberLinksCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@aragon/gov-ui-kit';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { sanitizeExternalHttpUrl } from '@/shared/security';
+import { socialHandleUtils } from '@/shared/utils/socialHandleUtils';
 
 export interface IMemberLinksCardProps {
     /** ENS `url` text record. */
@@ -24,41 +25,39 @@ interface ILinkEntry {
     display: string;
 }
 
-const SAFE_HANDLE_RE = /^[\w.-]+$/;
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
 /**
- * Builds a safe X (Twitter) profile URL from a handle.
- * Strips a leading `@` if present and encodes the handle to prevent URL injection.
+ * Builds a safe X (Twitter) profile URL from a handle. Strips a leading `@`, then
+ * enforces the same format as the edit-profile validation so records that could never
+ * be saved (or were written elsewhere) don't become dead links.
  */
 export function buildTwitterUrl(handle: string): string | null {
-    const cleaned = handle.startsWith('@') ? handle.slice(1) : handle;
-    if (!SAFE_HANDLE_RE.test(cleaned)) {
+    if (!socialHandleUtils.isTwitterHandle(handle)) {
         return null;
     }
+    const cleaned = socialHandleUtils.stripLeadingAt(handle);
     return `https://x.com/${encodeURIComponent(cleaned)}`;
 }
 
 /**
- * Builds a safe GitHub profile URL from a username.
- * Encodes the handle to prevent URL injection.
+ * Builds a safe GitHub profile URL from a username, enforcing the same format as the
+ * edit-profile validation.
  */
 export function buildGithubUrl(handle: string): string | null {
-    if (!SAFE_HANDLE_RE.test(handle)) {
+    if (!socialHandleUtils.isGithubHandle(handle)) {
         return null;
     }
     return `https://github.com/${encodeURIComponent(handle)}`;
 }
 
 /**
- * Builds a safe Telegram profile URL from a handle.
- * Strips a leading `@` if present and encodes the handle to prevent URL injection.
+ * Builds a safe Telegram profile URL from a handle. Strips a leading `@`, then enforces
+ * the same format as the edit-profile validation.
  */
 export function buildTelegramUrl(handle: string): string | null {
-    const cleaned = handle.startsWith('@') ? handle.slice(1) : handle;
-    if (!SAFE_HANDLE_RE.test(cleaned)) {
+    if (!socialHandleUtils.isTelegramHandle(handle)) {
         return null;
     }
+    const cleaned = socialHandleUtils.stripLeadingAt(handle);
     return `https://t.me/${encodeURIComponent(cleaned)}`;
 }
 
@@ -67,7 +66,7 @@ export function buildTelegramUrl(handle: string): string | null {
  * Returns `null` when the value is not a valid email.
  */
 export function buildEmailHref(email: string): string | null {
-    if (!EMAIL_RE.test(email)) {
+    if (!socialHandleUtils.isEmail(email)) {
         return null;
     }
     return `mailto:${encodeURIComponent(email)}`;
@@ -139,7 +138,7 @@ export function buildMemberLinks(props: IMemberLinksCardProps): ILinkEntry[] {
         }
     }
 
-    if (discord && SAFE_HANDLE_RE.test(discord)) {
+    if (discord && socialHandleUtils.isDiscordHandle(discord)) {
         // Discord usernames have no canonical public profile URL, so render as text.
         links.push({
             labelKey: `${labelPrefix}.discord`,

--- a/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.tsx
@@ -18,7 +18,10 @@ import {
 import { DaoList } from '@/modules/explore/components/daoList';
 import { useEfpStats } from '@/modules/governance/api/efpService';
 import { EfpCard } from '@/modules/governance/components/efpCard';
-import { MemberLinksCard } from '@/modules/governance/components/memberLinksCard';
+import {
+    buildMemberLinks,
+    MemberLinksCard,
+} from '@/modules/governance/components/memberLinksCard';
 import { useDao } from '@/shared/api/daoService';
 import { Page } from '@/shared/components/page';
 import { useTranslations } from '@/shared/components/translationsProvider';
@@ -151,6 +154,9 @@ export const DaoMemberDetailsPageClient: React.FC<
         github: ensRecords?.[ensRecordKeys.github],
         twitter: ensRecords?.[ensRecordKeys.twitter],
         url: ensRecords?.[ensRecordKeys.url],
+        email: ensRecords?.[ensRecordKeys.email],
+        telegram: ensRecords?.[ensRecordKeys.telegram],
+        discord: ensRecords?.[ensRecordKeys.discord],
     };
 
     if (dao == null || bodyPlugin == null) {
@@ -317,16 +323,17 @@ export const DaoMemberDetailsPageClient: React.FC<
                             </DefinitionList.Item>
                         </DefinitionList.Container>
                     </Page.AsideCard>
-                    {(memberLinks.url ||
-                        memberLinks.twitter ||
-                        memberLinks.github) && (
+                    {buildMemberLinks(memberLinks).length > 0 && (
                         <Page.AsideCard
                             title={t(
                                 'app.governance.daoMemberDetailsPage.aside.links.title',
                             )}
                         >
                             <MemberLinksCard
+                                discord={memberLinks.discord}
+                                email={memberLinks.email}
                                 github={memberLinks.github}
+                                telegram={memberLinks.telegram}
                                 twitter={memberLinks.twitter}
                                 url={memberLinks.url}
                             />

--- a/src/shared/utils/socialHandleUtils/index.ts
+++ b/src/shared/utils/socialHandleUtils/index.ts
@@ -1,0 +1,1 @@
+export { socialHandleUtils } from './socialHandleUtils';

--- a/src/shared/utils/socialHandleUtils/socialHandleUtils.test.ts
+++ b/src/shared/utils/socialHandleUtils/socialHandleUtils.test.ts
@@ -1,0 +1,86 @@
+import { socialHandleUtils } from './socialHandleUtils';
+
+describe('socialHandleUtils', () => {
+    describe('stripLeadingAt', () => {
+        it('strips a single leading @', () => {
+            expect(socialHandleUtils.stripLeadingAt('@handle')).toBe('handle');
+        });
+
+        it('leaves values without a leading @ untouched', () => {
+            expect(socialHandleUtils.stripLeadingAt('handle')).toBe('handle');
+        });
+    });
+
+    describe('isEmail', () => {
+        it('accepts a valid email', () => {
+            expect(socialHandleUtils.isEmail('alice@example.com')).toBe(true);
+        });
+
+        it.each([
+            'not-an-email',
+            'a@b',
+            'a b@c.com',
+            '',
+        ])('rejects %p', (value) => {
+            expect(socialHandleUtils.isEmail(value)).toBe(false);
+        });
+    });
+
+    describe('isGithubHandle', () => {
+        it('accepts a plain username with hyphens', () => {
+            expect(socialHandleUtils.isGithubHandle('my-user')).toBe(true);
+        });
+
+        it.each([
+            'my-user.name',
+            '-user',
+            'user-',
+            'user/repo',
+            '',
+        ])('rejects %p', (value) => {
+            expect(socialHandleUtils.isGithubHandle(value)).toBe(false);
+        });
+    });
+
+    describe('isTwitterHandle', () => {
+        it('accepts a handle with or without a leading @', () => {
+            expect(socialHandleUtils.isTwitterHandle('vitalik')).toBe(true);
+            expect(socialHandleUtils.isTwitterHandle('@vitalik')).toBe(true);
+        });
+
+        it.each([
+            'a'.repeat(16),
+            'foo bar',
+            'foo.bar',
+            '@',
+        ])('rejects %p', (value) => {
+            expect(socialHandleUtils.isTwitterHandle(value)).toBe(false);
+        });
+    });
+
+    describe('isTelegramHandle', () => {
+        it('accepts a handle with or without a leading @', () => {
+            expect(socialHandleUtils.isTelegramHandle('durov')).toBe(true);
+            expect(socialHandleUtils.isTelegramHandle('@durov')).toBe(true);
+        });
+
+        it.each([
+            'abc',
+            'a'.repeat(33),
+            'foo.bar',
+            'foo-bar',
+        ])('rejects %p', (value) => {
+            expect(socialHandleUtils.isTelegramHandle(value)).toBe(false);
+        });
+    });
+
+    describe('isDiscordHandle', () => {
+        it('accepts a valid username', () => {
+            expect(socialHandleUtils.isDiscordHandle('aragon')).toBe(true);
+        });
+
+        it.each(['a', 'foo bar', 'foo-bar', ''])('rejects %p', (value) => {
+            expect(socialHandleUtils.isDiscordHandle(value)).toBe(false);
+        });
+    });
+});

--- a/src/shared/utils/socialHandleUtils/socialHandleUtils.ts
+++ b/src/shared/utils/socialHandleUtils/socialHandleUtils.ts
@@ -1,0 +1,49 @@
+/**
+ * Format rules for social/contact handles, aligned with each service's own username
+ * expectations. Domain-neutral on purpose: this is the single source of truth for any
+ * place that validates or displays these handles (edit-profile form, member profile,
+ * DAO profiles, …) so a value that fails validation is never turned into a dead link,
+ * and vice versa.
+ */
+class SocialHandleUtils {
+    // Email: local@domain.tld with no whitespace.
+    private readonly emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    // GitHub: 1-39 chars, alphanumeric with non-consecutive single hyphens, no leading/trailing hyphen.
+    private readonly githubPattern =
+        /^[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}$/;
+    // X (Twitter): 1-15 word characters (letters, digits, underscore).
+    private readonly twitterPattern = /^\w{1,15}$/;
+    // Telegram: 5-32 word characters.
+    private readonly telegramPattern = /^\w{5,32}$/;
+    // Discord: 2-32 chars, lowercase letters, digits, dot and underscore (new username format).
+    private readonly discordPattern = /^[a-z\d._]{2,32}$/i;
+
+    /** Strips a single leading `@` so handles validate and display the same with or without it. */
+    stripLeadingAt(value: string): string {
+        return value.startsWith('@') ? value.slice(1) : value;
+    }
+
+    isEmail(value: string): boolean {
+        return this.emailPattern.test(value);
+    }
+
+    isGithubHandle(value: string): boolean {
+        return this.githubPattern.test(value);
+    }
+
+    /** Accepts an optional leading `@`. */
+    isTwitterHandle(value: string): boolean {
+        return this.twitterPattern.test(this.stripLeadingAt(value));
+    }
+
+    /** Accepts an optional leading `@`. */
+    isTelegramHandle(value: string): boolean {
+        return this.telegramPattern.test(this.stripLeadingAt(value));
+    }
+
+    isDiscordHandle(value: string): boolean {
+        return this.discordPattern.test(value);
+    }
+}
+
+export const socialHandleUtils = new SocialHandleUtils();


### PR DESCRIPTION
# Description

Resolves **APP-816** — Aragon profile fields are not updated correctly / no form validation.

Aragon member profiles write contact/social fields to ENS text records (ENSIP-5 / ENSIP-18) and read them back for display. This PR makes that round-trip consistent and safe:

### Edit profile validation
Added react-hook-form validation rules for **all** supported profile/contact fields, surfacing inline errors (via the existing `useFormField` alert plumbing) and blocking submission of malformed values:

- **Email** — validated as an email address
- **Website** — validated as an http/https URL (reuses `sanitizeExternalHttpUrl`)
- **GitHub / X / Telegram / Discord** — validated as service usernames per ENS profile-text-record expectations

Empty values stay valid (fields are optional/removable). Twitter/Telegram handles are normalized (leading `@` stripped) before being written to ENS.

### Profile display
- The member profile page now displays **Email, Telegram and Discord** when present, alongside the existing **Website / X / GitHub** (Email → `mailto:`, Telegram → `t.me`, Discord → plain text since usernames have no canonical URL).
- The **Links** card is now only rendered when at least one link resolves — fixing the bug where it showed as an **empty card**. A shared `buildMemberLinks` helper is the single source of truth for both the card and the parent's render gate.
- All values are fetched from ENS the same way as the existing fields (`useEnsProfileRecords` already fetched all six keys).

## Type of Change

- [x] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Followed the code style guidelines of this project

**Verification done:** `pnpm jest` (memberLinksCard + aragonProfileValidation → 60 passing, incl. new tests), `pnpm type-check` clean, `pnpm lint:check` clean. Manual smoke test in a preview still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
