### PR TITLE
Release v1.33.0

### DIFF
--- a/.changeset/app-954-permissions-page.md
+++ b/.changeset/app-954-permissions-page.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Add a permissions overview subpage to DAO settings (list view): linked-account tabs, permission rows (who/where/permission/condition) with expandable details and a per-condition slot system, plus a "Permissions" entry link on the settings page

--- a/.changeset/big-networks-simulate.md
+++ b/.changeset/big-networks-simulate.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Enable Tenderly for Monad network.

--- a/.changeset/fix-duplicate-proposal-warning.md
+++ b/.changeset/fix-duplicate-proposal-warning.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Fix stale "duplicate proposal" warnings on the create-proposal page: pending wallet requests that were interrupted (page reloaded mid-sign) or already mined are no longer counted as in-flight, and settled transactions are reconciled and cleared on reload. When a creation for the same DAO + plugin is genuinely in flight, the warning now lets you resume the existing transaction or start a new one.

--- a/.changeset/reduce-duplicate-pending-transactions.md
+++ b/.changeset/reduce-duplicate-pending-transactions.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Reduce the chance of duplicate pending wallet transactions: the in-flight send is now owned outside the transaction dialog, so closing and reopening (or reloading) resumes the existing request instead of re-sending it.

--- a/.changeset/tidy-moles-love.md
+++ b/.changeset/tidy-moles-love.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Implement Aragon profile renaming

--- a/.changeset/validate-aragon-profile-fields.md
+++ b/.changeset/validate-aragon-profile-fields.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Validate Aragon profile contact and social fields (email, website, GitHub, X, Telegram, Discord) before they are saved to ENS, surfacing inline errors and blocking malformed values. The member profile now also displays Email, Telegram and Discord alongside Website, X and GitHub, and the Links card is hidden when a member has no links instead of rendering empty.

--- a/.changeset/warn-duplicate-proposal-creation.md
+++ b/.changeset/warn-duplicate-proposal-creation.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Rename the transaction dialog's "Cancel" button to "Close" to reflect that the transaction keeps being tracked in the background. Warn before publishing a proposal when another proposal creation for the same DAO and plugin is still in flight, so editing the form after closing the dialog no longer risks creating two proposals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @aragon/app
 
+## 1.33.0
+
+### Minor Changes
+
+- [#1199](https://github.com/aragon/app/pull/1199) [`4731a48`](https://github.com/aragon/app/commit/4731a481ef1b13841c87fb230ee9429fcd70d92c) Thanks [@evanaronson](https://github.com/evanaronson)! - Enable Tenderly for Monad network.
+
+- [#1189](https://github.com/aragon/app/pull/1189) [`7dd0e6c`](https://github.com/aragon/app/commit/7dd0e6cbeebb9cae103c2b56afd00a37970373e6) Thanks [@harryburger](https://github.com/harryburger)! - Reduce the chance of duplicate pending wallet transactions: the in-flight send is now owned outside the transaction dialog, so closing and reopening (or reloading) resumes the existing request instead of re-sending it.
+
+- [#1175](https://github.com/aragon/app/pull/1175) [`802a4ce`](https://github.com/aragon/app/commit/802a4cebb3642353fd00d1b4db9584c54b57c18b) Thanks [@milosh86](https://github.com/milosh86)! - Implement Aragon profile renaming
+
+- [#1200](https://github.com/aragon/app/pull/1200) [`8ebf2de`](https://github.com/aragon/app/commit/8ebf2de86bbebfa438dda775c09726b637d177d0) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Validate Aragon profile contact and social fields (email, website, GitHub, X, Telegram, Discord) before they are saved to ENS, surfacing inline errors and blocking malformed values. The member profile now also displays Email, Telegram and Discord alongside Website, X and GitHub, and the Links card is hidden when a member has no links instead of rendering empty.
+
+- [#1201](https://github.com/aragon/app/pull/1201) [`cf77b16`](https://github.com/aragon/app/commit/cf77b16ea9cf28a17c9102ea3d0387db49ac455f) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Rename the transaction dialog's "Cancel" button to "Close" to reflect that the transaction keeps being tracked in the background. Warn before publishing a proposal when another proposal creation for the same DAO and plugin is still in flight, so editing the form after closing the dialog no longer risks creating two proposals.
+
+### Patch Changes
+
+- [#1198](https://github.com/aragon/app/pull/1198) [`65ca4d5`](https://github.com/aragon/app/commit/65ca4d56ac99963e008f74a15a105fe5fba812cb) Thanks [@thekidnamedkd](https://github.com/thekidnamedkd)! - Add a permissions overview subpage to DAO settings (list view): linked-account tabs, permission rows (who/where/permission/condition) with expandable details and a per-condition slot system, plus a "Permissions" entry link on the settings page
+
+- [#1203](https://github.com/aragon/app/pull/1203) [`b17a84e`](https://github.com/aragon/app/commit/b17a84e8e2fd3e31b6dd0fe7860932defa3e2090) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Fix stale "duplicate proposal" warnings on the create-proposal page: pending wallet requests that were interrupted (page reloaded mid-sign) or already mined are no longer counted as in-flight, and settled transactions are reconciled and cleared on reload. When a creation for the same DAO + plugin is genuinely in flight, the warning now lets you resume the existing transaction or start a new one.
+
 ## 1.32.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@aragon/aragon-domain": "^0.3.1",
-    "@aragon/gov-ui-kit": "^2.8.0",
+    "@aragon/gov-ui-kit": "^2.8.1",
     "@floating-ui/react": "^0.27.19",
     "@number-flow/react": "^0.6.0",
     "@radix-ui/react-dialog": "^1.1.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/app",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Human-centered DAO infrastructure",
   "author": "Aragon Association",
   "homepage": "https://github.com/aragon/app#readme",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^0.3.1
         version: 0.3.1(typescript@5.9.3)
       '@aragon/gov-ui-kit':
-        specifier: ^2.8.0
-        version: 2.8.0(@emotion/is-prop-valid@1.4.0)(@floating-ui/dom@1.7.6)(@tailwindcss/typography@0.5.20(tailwindcss@4.3.1))(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.79.0(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(viem@2.52.2(typescript@5.9.3)(zod@3.25.76))(wagmi@3.6.17(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@3.25.76))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(viem@2.52.2(typescript@5.9.3)(zod@3.25.76)))
+        specifier: ^2.8.1
+        version: 2.8.1(@emotion/is-prop-valid@1.4.0)(@floating-ui/dom@1.7.6)(@tailwindcss/typography@0.5.20(tailwindcss@4.3.1))(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.79.0(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(viem@2.52.2(typescript@5.9.3)(zod@3.25.76))(wagmi@3.6.17(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@3.25.76))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(viem@2.52.2(typescript@5.9.3)(zod@3.25.76)))
       '@floating-ui/react':
         specifier: ^0.27.19
         version: 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -260,8 +260,8 @@ packages:
     resolution: {integrity: sha512-KV30X9uSM0vcX1EsbrKoE0DMxe0NsqTlW+2YoOJND2iKHgjnX8SnlZtO5f5HS6MIQkb/ihHUoRe/9Jjnin9uFA==}
     engines: {node: '>=24.13.0', pnpm: '>=11.0.0'}
 
-  '@aragon/gov-ui-kit@2.8.0':
-    resolution: {integrity: sha512-K0CYcnh/nds7+4ShPv+fuRPaBuMTpUxJ6XMck/Va/Nuz5dQhrGO4uLGJ2Sy+DdTx5RTwC9N/ZYHwEB+wtQ5GlA==}
+  '@aragon/gov-ui-kit@2.8.1':
+    resolution: {integrity: sha512-DdIKN00F4JEffKenbsAGH+U4RXS5xCciYnsrf/FIvPCzDdnCbB/+pkRlDgwwcXxzdmqQtZnbsrueloQoOC2oTg==}
     engines: {node: '>=24.16.0', pnpm: '>=11.0.0'}
     peerDependencies:
       '@tailwindcss/typography': ^0.5.0
@@ -7826,7 +7826,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@aragon/gov-ui-kit@2.8.0(@emotion/is-prop-valid@1.4.0)(@floating-ui/dom@1.7.6)(@tailwindcss/typography@0.5.20(tailwindcss@4.3.1))(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.79.0(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(viem@2.52.2(typescript@5.9.3)(zod@3.25.76))(wagmi@3.6.17(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@3.25.76))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(viem@2.52.2(typescript@5.9.3)(zod@3.25.76)))':
+  '@aragon/gov-ui-kit@2.8.1(@emotion/is-prop-valid@1.4.0)(@floating-ui/dom@1.7.6)(@tailwindcss/typography@0.5.20(tailwindcss@4.3.1))(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.79.0(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(viem@2.52.2(typescript@5.9.3)(zod@3.25.76))(wagmi@3.6.17(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@3.25.76))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(viem@2.52.2(typescript@5.9.3)(zod@3.25.76)))':
     dependencies:
       '@radix-ui/react-accordion': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-alert-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -8358,7 +8358,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.52.2(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.53.1(typescript@5.9.3)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     transitivePeerDependencies:
       - '@types/react'
@@ -10531,7 +10531,7 @@ snapshots:
   '@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.52.2(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.53.1(typescript@5.9.3)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -580,7 +580,7 @@
         },
         "dangerZone": {
           "title": "Delete Aragon profile",
-          "description": "Once you delete your Aragon profile it's released and can be claimed by someone else. This can't be undone."
+          "description": "Once you delete your Aragon profile, the name is released and can be claimed by anyone else. This action cannot be undone."
         }
       },
       "aragonProfileReleaseAlertDialog": {

--- a/src/modules/application/dialogs/aragonProfileDialog/aragonProfileDialog.tsx
+++ b/src/modules/application/dialogs/aragonProfileDialog/aragonProfileDialog.tsx
@@ -287,7 +287,7 @@ export const AragonProfileDialog: React.FC<IAragonProfileDialogProps> = (
                             className="w-fit"
                             iconLeft={IconType.PEN}
                             onClick={handleRenameAragonName}
-                            size="md"
+                            size="sm"
                             variant="tertiary"
                         >
                             {t(
@@ -384,7 +384,7 @@ export const AragonProfileDialog: React.FC<IAragonProfileDialogProps> = (
                         <Button
                             className="w-fit"
                             onClick={handleRemoveAragonName}
-                            size="md"
+                            size="sm"
                             variant="critical"
                         >
                             {t(


### PR DESCRIPTION
## Features
- validate Aragon profile fields and show all socials ([#1200](https://github.com/aragon/app/pull/1200)) — [APP-816: Aragon profile fields are not updated correctly / no form validation](https://linear.app/aragon/issue/APP-816/aragon-profile-fields-are-not-updated-correctly-no-form-validation)
- Add permissions overview subpage to DAO settings ([#1198](https://github.com/aragon/app/pull/1198)) — [APP-954: Build UI for permission page](https://linear.app/aragon/issue/APP-954/build-ui-for-permission-page)
- Rename tx dialog Cancel to Close and warn on duplicate proposal creation ([#1201](https://github.com/aragon/app/pull/1201))
- Integrate Aragon subdomain and implement Aragon profile renaming ([#1175](https://github.com/aragon/app/pull/1175)) — [APP-795: Add rename action for Aragon names](https://linear.app/aragon/issue/APP-795/add-rename-action-for-aragon-names)
- Implement pending transaction management for transaction dialog ([#1189](https://github.com/aragon/app/pull/1189)) — [APP-666: Reduce chance of duplicate pending wallet actions](https://linear.app/aragon/issue/APP-666/reduce-chance-of-duplicate-pending-wallet-actions)

## Fixes
- Minor form sizing ([#1205](https://github.com/aragon/app/pull/1205))
- stop stale duplicate-proposal warnings, resume in-flight transactions ([#1203](https://github.com/aragon/app/pull/1203)) — [APP-970: Handle tx dialog close state for pending proposal transactions](https://linear.app/aragon/issue/APP-970/handle-tx-dialog-close-state-for-pending-proposal-transactions)
- Enable Tenderly support in network definitions for monad ([#1199](https://github.com/aragon/app/pull/1199))

## Other Changes
- Release v1.33.0
- Bump actions/cache from 5.0.5 to 6.1.0 ([#1196](https://github.com/aragon/app/pull/1196))
- Bump actions/checkout from 6.0.3 to 7.0.0 ([#1197](https://github.com/aragon/app/pull/1197))
- Merge pull request #1195 from aragon/release/2026-06-25_17-10



<!-- slack_ts: 1783016421.901769 -->
