### PR TITLE
feat(APP-974): Integrate Vercel Speed Insights and Analytics

### DIFF
--- a/.changeset/app-974-vercel-insights.md
+++ b/.changeset/app-974-vercel-insights.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Integrate Vercel Speed Insights and Web Analytics to collect Web Vitals and page-view metrics on deployments.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "@sentry/nextjs": "^10.58.0",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-query-devtools": "^5.101.0",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "@walletconnect/core": "^2.23.9",
     "@walletconnect/utils": "^2.23.9",
     "classnames": "^2.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,12 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.101.0
         version: 5.101.0(@tanstack/react-query@5.101.0(react@19.2.7))(react@19.2.7)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@walletconnect/core':
         specifier: ^2.23.9
         version: 2.23.9(@vercel/blob@2.3.0)(typescript@5.9.3)(zod@3.25.76)
@@ -3625,6 +3631,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
   '@vercel/backends@0.2.0':
     resolution: {integrity: sha512-7J0nJCd7h29CXG0jeejS8DnI4qAF96Fo6qibAPG7nbbJ5v0ZpWZhzeL8XwvvT3du6S50bRGcQCPJQNcShw6pEQ==}
     peerDependencies:
@@ -3725,6 +3760,32 @@ packages:
 
   '@vercel/sandbox@1.9.0':
     resolution: {integrity: sha512-zgr1ad0tkT1xZn/8Vxo60wOUOLqMAVGo4WqJQ8/UDcUtWynNJsBjI2tiMdWZrAo9EKH1MIqEzJNkcclF0UT1EQ==}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/static-build@2.9.21':
     resolution: {integrity: sha512-LnaroK/z97iAwg0vNHECQHAm2oaFLSWiKqCZIETnv5RpIqDXgj/URBD8v+DNNSXWGXsYOk7ezLRuQnlpq3Jx5w==}
@@ -11849,6 +11910,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vercel/analytics@2.0.1(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    optionalDependencies:
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+
   '@vercel/backends@0.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)(rollup@4.62.0)(typescript@5.9.3)':
     dependencies:
       '@vercel/build-utils': 13.20.0
@@ -12140,6 +12206,11 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  '@vercel/speed-insights@2.0.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    optionalDependencies:
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
 
   '@vercel/static-build@2.9.21':
     dependencies:

--- a/src/modules/application/components/layouts/layoutRoot/layoutRoot.test.tsx
+++ b/src/modules/application/components/layouts/layoutRoot/layoutRoot.test.tsx
@@ -7,6 +7,11 @@ import { translations } from '@/shared/constants/translations';
 import { testLogger } from '@/test/utils';
 import { type ILayoutRootProps, LayoutRoot } from './layoutRoot';
 
+jest.mock('@vercel/analytics/next', () => ({ Analytics: () => null }));
+jest.mock('@vercel/speed-insights/next', () => ({
+    SpeedInsights: () => null,
+}));
+
 jest.mock('../../providers', () => ({
     Providers: (props: {
         translations: unknown;

--- a/src/modules/application/components/layouts/layoutRoot/layoutRoot.tsx
+++ b/src/modules/application/components/layouts/layoutRoot/layoutRoot.tsx
@@ -1,4 +1,6 @@
 import { dehydrate, QueryClient } from '@tanstack/react-query';
+import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import { headers } from 'next/headers';
 import NextTopLoader from 'nextjs-toploader';
 import type { ReactNode } from 'react';
@@ -77,6 +79,8 @@ export const LayoutRoot: React.FC<ILayoutRootProps> = async (props) => {
                     </ErrorBoundary>
                     <Footer />
                 </Providers>
+                <Analytics />
+                <SpeedInsights />
             </body>
         </html>
     );


### PR DESCRIPTION
Installs and mounts Vercel's official App Router components so the [Speed Insights](https://vercel.com/aragon-app/app-next/speed-insights) and [Web Analytics](https://vercel.com/aragon-app/app-next/analytics) dashboards start receiving data on deployments. Previously both were empty because the collection packages were not wired into the app.

## Changes

- **Added dependencies** — `@vercel/analytics@2.0.1` and `@vercel/speed-insights@2.0.0`.
- **Mounted collectors** — `<Analytics />` and `<SpeedInsights />` (App Router variants) rendered inside `<body>` of the root layout (`layoutRoot.tsx`), after `<Providers>`. They run in `auto` mode and no-op outside Vercel/dev, so no env gating is needed.
- **Test isolation** — mocked both Vercel modules in `layoutRoot.test.tsx` (same pattern as the existing `Providers` mock) to avoid Jest ESM transform errors.

## CSP

No CSP changes required. In production/staging `'strict-dynamic'` propagates trust to the script the (nonce'd) app bundle injects; in preview/local `'self'`/`https:` cover the same-origin `/_vercel/.../script.js`; beacons hit same-origin `/_vercel/*` and are also allowed by `connect-src *`.

## Verification

- `pnpm type-check` — clean
- `pnpm test:changed` — 4 passed
- `ultracite`/lint-staged — clean

Post-deploy, confirm data lands on the Vercel dashboards (needs real traffic).

Closes APP-974

🤖 Generated with [Claude Code](https://claude.com/claude-code)