### PR TITLE
feat(APP-919): Make link text optional and use shared link wrapper

### DIFF
--- a/.changeset/mandatory-fields-irritate.md
+++ b/.changeset/mandatory-fields-irritate.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Allow resource links to be saved and rendered without custom link text.

--- a/src/actions/capitalDistributor/components/capitalDistributorCreateCampaignActionDetails/capitalDistributorCreateCampaignActionDetails.tsx
+++ b/src/actions/capitalDistributor/components/capitalDistributorCreateCampaignActionDetails/capitalDistributorCreateCampaignActionDetails.tsx
@@ -10,12 +10,12 @@ import {
     formatterUtils,
     type IProposalAction,
     type IProposalActionComponentProps,
-    Link,
     NumberFormat,
 } from '@aragon/gov-ui-kit';
 import { formatUnits, type Hex, zeroAddress, zeroHash } from 'viem';
 import type { IProposalActionData } from '@/modules/governance/components/createProposalForm';
 import { useDao } from '@/shared/api/daoService';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import {
     type TranslationFunction,
     useTranslations,
@@ -147,14 +147,12 @@ export const CapitalDistributorCreateCampaignActionDetails: React.FC<
                 >
                     <div className="flex flex-col gap-3">
                         {resources.map((link) => (
-                            <Link
-                                href={link.url}
+                            <ResourceLink
                                 isExternal={true}
                                 key={link.url}
-                                showUrl={true}
-                            >
-                                {link.name}
-                            </Link>
+                                name={link.name}
+                                url={link.url}
+                            />
                         ))}
                     </div>
                 </DefinitionList.Item>

--- a/src/actions/core/createProposal/createProposalActionDetails.tsx
+++ b/src/actions/core/createProposal/createProposalActionDetails.tsx
@@ -8,10 +8,10 @@ import {
     InputContainer,
     type IProposalAction,
     type IProposalActionComponentProps,
-    Link,
 } from '@aragon/gov-ui-kit';
 import type { IProposalActionData } from '@/modules/governance/components/createProposalForm';
 import { NestedActionsList } from '@/modules/governance/components/nestedActionsList';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { SafeDocumentParser } from '@/shared/components/SafeDocumentParser';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import type { ICoreActionCreateProposal } from '../types/coreActionCreateProposal';
@@ -103,14 +103,12 @@ export const CreateProposalActionDetails: React.FC<
                                 >
                                     <div className="flex flex-col gap-3">
                                         {metadata.resources.map((resource) => (
-                                            <Link
-                                                href={resource.url}
+                                            <ResourceLink
                                                 isExternal={true}
                                                 key={resource.url}
-                                                showUrl={true}
-                                            >
-                                                {resource.name}
-                                            </Link>
+                                                name={resource.name}
+                                                url={resource.url}
+                                            />
                                         ))}
                                     </div>
                                 </DefinitionList.Item>

--- a/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionDetails/gaugeRegistrarRegisterGaugeActionDetails.tsx
+++ b/src/actions/gaugeRegistrar/components/gaugeRegistrarRegisterGaugeActionDetails/gaugeRegistrarRegisterGaugeActionDetails.tsx
@@ -8,10 +8,10 @@ import {
     type IProposalAction,
     type IProposalActionComponentProps,
     type IProposalActionInputDataParameter,
-    Link,
 } from '@aragon/gov-ui-kit';
 import type { IProposalActionData } from '@/modules/governance/components/createProposalForm';
 import { useDao } from '@/shared/api/daoService';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { ipfsUtils } from '@/shared/utils/ipfsUtils';
@@ -103,14 +103,12 @@ export const GaugeRegistrarRegisterGaugeActionDetails: React.FC<
                 >
                     <div className="flex flex-col gap-3">
                         {links.map((link) => (
-                            <Link
-                                href={link.url}
+                            <ResourceLink
                                 isExternal={true}
                                 key={link.url}
-                                showUrl={true}
-                            >
-                                {link.name}
-                            </Link>
+                                name={link.name}
+                                url={link.url}
+                            />
                         ))}
                     </div>
                 </DefinitionList.Item>

--- a/src/actions/gaugeVoter/components/gaugeVoterCreateGaugeActionDetails/gaugeVoterCreateGaugeActionDetails.tsx
+++ b/src/actions/gaugeVoter/components/gaugeVoterCreateGaugeActionDetails/gaugeVoterCreateGaugeActionDetails.tsx
@@ -7,10 +7,10 @@ import {
     DefinitionList,
     type IProposalAction,
     type IProposalActionComponentProps,
-    Link,
 } from '@aragon/gov-ui-kit';
 import type { IProposalActionData } from '@/modules/governance/components/createProposalForm';
 import { useDao } from '@/shared/api/daoService';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { ipfsUtils } from '@/shared/utils/ipfsUtils';
@@ -86,14 +86,12 @@ export const GaugeVoterCreateGaugeActionDetails: React.FC<
                 >
                     <div className="flex flex-col gap-3">
                         {links.map((link) => (
-                            <Link
-                                href={link.url}
+                            <ResourceLink
                                 isExternal={true}
                                 key={link.url}
-                                showUrl={true}
-                            >
-                                {link.name}
-                            </Link>
+                                name={link.name}
+                                url={link.url}
+                            />
                         ))}
                     </div>
                 </DefinitionList.Item>

--- a/src/actions/gaugeVoter/components/gaugeVoterUpdateGaugeMetadataActionDetails/gaugeVoterUpdateGaugeMetadataActionDetails.tsx
+++ b/src/actions/gaugeVoter/components/gaugeVoterUpdateGaugeMetadataActionDetails/gaugeVoterUpdateGaugeMetadataActionDetails.tsx
@@ -7,10 +7,10 @@ import {
     DefinitionList,
     type IProposalAction,
     type IProposalActionComponentProps,
-    Link,
 } from '@aragon/gov-ui-kit';
 import type { IProposalActionData } from '@/modules/governance/components/createProposalForm';
 import { useDao } from '@/shared/api/daoService';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { ipfsUtils } from '@/shared/utils/ipfsUtils';
@@ -86,14 +86,12 @@ export const GaugeVoterUpdateGaugeMetadataActionDetails: React.FC<
                 >
                     <div className="flex flex-col gap-3">
                         {links.map((link) => (
-                            <Link
-                                href={link.url}
+                            <ResourceLink
                                 isExternal={true}
                                 key={link.url}
-                                showUrl={true}
-                            >
-                                {link.name}
-                            </Link>
+                                name={link.name}
+                                url={link.url}
+                            />
                         ))}
                     </div>
                 </DefinitionList.Item>

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -580,7 +580,7 @@
         },
         "dangerZone": {
           "title": "Delete Aragon profile",
-          "description": "Once you delete your Aragon profile it's released and can be claimed by someone else. This can't be undone."
+          "description": "Once you delete your Aragon profile, the name is released and can be claimed by anyone else. This action cannot be undone."
         }
       },
       "aragonProfileReleaseAlertDialog": {

--- a/src/modules/application/dialogs/aragonProfileDialog/aragonProfileDialog.tsx
+++ b/src/modules/application/dialogs/aragonProfileDialog/aragonProfileDialog.tsx
@@ -287,7 +287,7 @@ export const AragonProfileDialog: React.FC<IAragonProfileDialogProps> = (
                             className="w-fit"
                             iconLeft={IconType.PEN}
                             onClick={handleRenameAragonName}
-                            size="md"
+                            size="sm"
                             variant="tertiary"
                         >
                             {t(
@@ -384,7 +384,7 @@ export const AragonProfileDialog: React.FC<IAragonProfileDialogProps> = (
                         <Button
                             className="w-fit"
                             onClick={handleRemoveAragonName}
-                            size="md"
+                            size="sm"
                             variant="critical"
                         >
                             {t(

--- a/src/modules/dashboard/pages/daoDashboardPage/daoDashboardPageClient.tsx
+++ b/src/modules/dashboard/pages/daoDashboardPage/daoDashboardPageClient.tsx
@@ -6,7 +6,6 @@ import {
     DateFormat,
     DefinitionList,
     formatterUtils,
-    Link,
 } from '@aragon/gov-ui-kit';
 import type { IFeaturedDelegates } from '@/shared/api/cmsService';
 import {
@@ -16,6 +15,7 @@ import {
 } from '@/shared/api/daoService';
 import { Page } from '@/shared/components/page';
 import { PluginSingleComponent } from '@/shared/components/pluginSingleComponent';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useAdminStatus } from '@/shared/hooks/useAdminStatus';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
@@ -165,14 +165,12 @@ export const DaoDashboardPageClient: React.FC<IDaoDashboardPageClientProps> = (
                             )}
                         >
                             {dao.links.map(({ url, name }) => (
-                                <Link
-                                    href={url}
+                                <ResourceLink
                                     isExternal={true}
                                     key={url}
-                                    showUrl={true}
-                                >
-                                    {name}
-                                </Link>
+                                    name={name}
+                                    url={url}
+                                />
                             ))}
                         </Page.AsideCard>
                     )}

--- a/src/modules/finance/components/daoInfoAside/daoInfoAside.tsx
+++ b/src/modules/finance/components/daoInfoAside/daoInfoAside.tsx
@@ -7,9 +7,9 @@ import {
     Collapsible,
     DefinitionList,
     IconType,
-    Link,
 } from '@aragon/gov-ui-kit';
 import { useFeatureFlags } from '@/shared/components/featureFlagsProvider';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { StatCard } from '@/shared/components/statCard';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { networkDefinitions } from '@/shared/constants/networkDefinitions';
@@ -86,14 +86,12 @@ export const DaoInfoAside: React.FC<IDaoInfoAsideProps> = (props) => {
 
                 <div className="flex flex-col gap-3">
                     {links.map((link) => (
-                        <Link
-                            href={link.url}
+                        <ResourceLink
                             isExternal={true}
                             key={link.url}
-                            showUrl={true}
-                        >
-                            {link.name}
-                        </Link>
+                            name={link.name}
+                            url={link.url}
+                        />
                     ))}
                 </div>
                 {resolvedOctavLink && (

--- a/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.test.tsx
+++ b/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.test.tsx
@@ -315,6 +315,20 @@ describe('<DaoProposalDetailsPageClient /> component', () => {
         });
     });
 
+    it('renders an empty-name proposal resource with the URL as link text', () => {
+        const resource = { name: '', url: 'https://empty-name.com' };
+        const proposal = generateProposal({ resources: [resource] });
+        useProposalSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: proposal }),
+        );
+        render(createTestComponent());
+
+        const link = screen.getByRole('link', { name: resource.url });
+        expect(link).toBeInTheDocument();
+        expect(link.getAttribute('href')).toEqual(resource.url);
+        expect(screen.getAllByText(resource.url)).toHaveLength(1);
+    });
+
     it('does not render the links section when proposal has no resources', () => {
         const proposal = generateProposal({ resources: [] });
         useProposalSpy.mockReturnValue(

--- a/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.tsx
+++ b/src/modules/governance/pages/daoProposalDetailsPage/daoProposalDetailsPageClient.tsx
@@ -9,7 +9,6 @@ import {
     DefinitionList,
     formatterUtils,
     type IProposalActionsFooterDropdownItem,
-    Link,
     ProposalActions,
     ProposalActionTypeNoBasicView,
     ProposalStatus,
@@ -25,6 +24,7 @@ import { AragonBackendServiceError } from '@/shared/api/aragonBackendService';
 import { useDao } from '@/shared/api/daoService';
 import { Page } from '@/shared/components/page';
 import { PluginSingleComponent } from '@/shared/components/pluginSingleComponent';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { SafeDocumentParser } from '@/shared/components/SafeDocumentParser';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
@@ -419,14 +419,12 @@ export const DaoProposalDetailsPageClient: React.FC<
                         >
                             <div className="flex flex-col gap-4">
                                 {resources.map((resource) => (
-                                    <Link
-                                        href={resource.url}
+                                    <ResourceLink
                                         isExternal={true}
-                                        key={resource.name}
-                                        showUrl={true}
-                                    >
-                                        {resource.name}
-                                    </Link>
+                                        key={resource.url}
+                                        name={resource.name}
+                                        url={resource.url}
+                                    />
                                 ))}
                             </div>
                         </Page.AsideCard>

--- a/src/modules/settings/components/daoHierarchy/daoHierarchy.tsx
+++ b/src/modules/settings/components/daoHierarchy/daoHierarchy.tsx
@@ -13,6 +13,7 @@ import {
 import type { IDao, ILinkedAccountSummary } from '@/shared/api/daoService';
 import { DaoTypeTag } from '@/shared/components/daoTypeTag';
 import { useFeatureFlags } from '@/shared/components/featureFlagsProvider';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { daoUtils } from '@/shared/utils/daoUtils';
@@ -128,14 +129,12 @@ const DaoInfo: React.FC<IDaoInfoProps> = ({ dao, permissionsHref }) => {
                 >
                     <div className="flex flex-col gap-3">
                         {dao.links.map((link) => (
-                            <Link
-                                href={link.url}
+                            <ResourceLink
                                 isExternal={true}
                                 key={link.url}
-                                showUrl={true}
-                            >
-                                {link.name}
-                            </Link>
+                                name={link.name}
+                                url={link.url}
+                            />
                         ))}
                     </div>
                 </DefinitionList.Item>

--- a/src/modules/settings/components/daoPluginInfo/daoPluginInfoMetadata.tsx
+++ b/src/modules/settings/components/daoPluginInfo/daoPluginInfoMetadata.tsx
@@ -1,5 +1,5 @@
-import { Link } from '@aragon/gov-ui-kit';
 import type { IResource } from '@/shared/api/daoService';
+import { ResourceLink } from '@/shared/components/resourceLink';
 
 export interface IDaoPluginInfoMetadataProps {
     /**
@@ -20,11 +20,13 @@ export const DaoPluginInfoMetadata: React.FC<IDaoPluginInfoMetadataProps> = (
     return (
         <div className="flex flex-col gap-y-6">
             {description && <p className="text-neutral-500">{description}</p>}
-            {links?.map((resource: IResource, index: number) => (
-                <div className="flex flex-col gap-y-3" key={index}>
-                    <Link href={resource.url} isExternal={true} showUrl={true}>
-                        {resource.name}
-                    </Link>
+            {links?.map((resource: IResource) => (
+                <div className="flex flex-col gap-y-3" key={resource.url}>
+                    <ResourceLink
+                        isExternal={true}
+                        name={resource.name}
+                        url={resource.url}
+                    />
                 </div>
             ))}
         </div>

--- a/src/modules/settings/components/daoSettingsInfo/daoSettingsInfo.tsx
+++ b/src/modules/settings/components/daoSettingsInfo/daoSettingsInfo.tsx
@@ -9,6 +9,7 @@ import {
 } from '@aragon/gov-ui-kit';
 import type { IDao } from '@/shared/api/daoService';
 import { useFeatureFlags } from '@/shared/components/featureFlagsProvider';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import { useDaoChain } from '@/shared/hooks/useDaoChain';
@@ -101,14 +102,12 @@ export const DaoSettingsInfo: React.FC<IDaoSettingsInfoProps> = (props) => {
                     >
                         <div className="flex flex-col gap-3">
                             {dao.links.map((link) => (
-                                <Link
-                                    href={link.url}
+                                <ResourceLink
                                     isExternal={true}
                                     key={link.url}
-                                    showUrl={true}
-                                >
-                                    {link.name}
-                                </Link>
+                                    name={link.name}
+                                    url={link.url}
+                                />
                             ))}
                         </div>
                     </DefinitionList.Item>

--- a/src/plugins/capitalDistributorPlugin/dialogs/capitalDistributorClaimDialog/capitalDistributorClaimDialogDetails/capitalDistributorClaimDialogDetails.tsx
+++ b/src/plugins/capitalDistributorPlugin/dialogs/capitalDistributorClaimDialog/capitalDistributorClaimDialogDetails/capitalDistributorClaimDialogDetails.tsx
@@ -16,6 +16,7 @@ import {
     type ICampaign,
 } from '@/plugins/capitalDistributorPlugin/api/capitalDistributorService';
 import type { ICapitalDistributorPlugin } from '@/plugins/capitalDistributorPlugin/types';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useFormField } from '@/shared/hooks/useFormField';
 import type { ICapitalDistributorClaimDialogForm } from '../capitalDistributorClaimDialogDefinitions';
@@ -137,14 +138,12 @@ export const CapitalDistributorClaimDialogDetails: React.FC<
                     </Heading>
                     <div className="flex flex-col gap-4">
                         {resources.map((resource) => (
-                            <Link
-                                href={resource.url}
+                            <ResourceLink
                                 isExternal={true}
                                 key={resource.url}
-                                showUrl={true}
-                            >
-                                {resource.name}
-                            </Link>
+                                name={resource.name}
+                                url={resource.url}
+                            />
                         ))}
                     </div>
                 </Card>

--- a/src/plugins/capitalDistributorPlugin/pages/capitalDistributorRewardsPage/capitalDistributorRewardsPageClient.tsx
+++ b/src/plugins/capitalDistributorPlugin/pages/capitalDistributorRewardsPage/capitalDistributorRewardsPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CardEmptyState, IconType, Link } from '@aragon/gov-ui-kit';
+import { CardEmptyState, IconType } from '@aragon/gov-ui-kit';
 import { ApplicationDialogId } from '@/modules/application/constants/applicationDialogId';
 import { useWalletAccount } from '@/modules/application/hooks/useWalletAccount';
 import { useDaoOverrides } from '@/shared/api/cmsService';
@@ -8,6 +8,7 @@ import type { IDao } from '@/shared/api/daoService';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { Page } from '@/shared/components/page';
 import { RedirectToUrl } from '@/shared/components/redirectToUrl';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
 import { daoUtils } from '@/shared/utils/daoUtils';
@@ -100,14 +101,12 @@ export const CapitalDistributorRewardsPageClient: React.FC<
                         />
                     )}
                     {links?.map(({ url, name }) => (
-                        <Link
-                            href={url}
+                        <ResourceLink
                             isExternal={true}
                             key={url}
-                            showUrl={true}
-                        >
-                            {name}
-                        </Link>
+                            name={name}
+                            url={url}
+                        />
                     ))}
                 </Page.AsideCard>
             </Page.Aside>

--- a/src/plugins/gaugeVoterPlugin/pages/gaugeVoterGaugesPage/gaugeVoterGaugesPageClient.tsx
+++ b/src/plugins/gaugeVoterPlugin/pages/gaugeVoterGaugesPage/gaugeVoterGaugesPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Link, Tabs } from '@aragon/gov-ui-kit';
+import { Tabs } from '@aragon/gov-ui-kit';
 import { useCallback, useEffect, useState } from 'react';
 import type { Address } from 'viem';
 import { useConnectedWalletGuard } from '@/modules/application/hooks/useConnectedWalletGuard';
@@ -12,6 +12,7 @@ import { useDialogContext } from '@/shared/components/dialogProvider';
 import { Page } from '@/shared/components/page';
 import type { IFilterComponentPlugin } from '@/shared/components/pluginFilterComponent';
 import { RedirectToUrl } from '@/shared/components/redirectToUrl';
+import { ResourceLink } from '@/shared/components/resourceLink';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
 import { useFilterUrlParam } from '@/shared/hooks/useFilterUrlParam';
@@ -361,14 +362,12 @@ export const GaugeVoterGaugesPageClient: React.FC<
                         usagePercentage={usagePercentage}
                     />
                     {links?.map(({ url, name }) => (
-                        <Link
-                            href={url}
+                        <ResourceLink
                             isExternal={true}
                             key={url}
-                            showUrl={true}
-                        >
-                            {name}
-                        </Link>
+                            name={name}
+                            url={url}
+                        />
                     ))}
                 </Page.AsideCard>
                 <Page.AsideCard title={cardTitle}>

--- a/src/shared/components/forms/resourcesInput/resourcesInputItem.test.tsx
+++ b/src/shared/components/forms/resourcesInput/resourcesInputItem.test.tsx
@@ -1,7 +1,7 @@
 import { IconType } from '@aragon/gov-ui-kit';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import * as useFormField from '@/shared/hooks/useFormField';
+import { FormProvider, useForm } from 'react-hook-form';
 import { FormWrapper } from '@/shared/testUtils';
 import {
     type IResourcesInputItemProps,
@@ -9,25 +9,6 @@ import {
 } from './resourcesInputItem';
 
 describe('<ResourcesInputItem /> component', () => {
-    const useFormFieldSpy = jest.spyOn(useFormField, 'useFormField');
-
-    beforeEach(() => {
-        useFormFieldSpy.mockImplementation(() => ({
-            name: 'name',
-            onChange: jest.fn(),
-            onBlur: jest.fn(),
-            value: '',
-            ref: jest.fn(),
-            variant: 'default',
-            alert: undefined,
-            label: 'Label',
-        }));
-    });
-
-    afterEach(() => {
-        useFormFieldSpy.mockReset();
-    });
-
     const createTestComponent = (props?: Partial<IResourcesInputItemProps>) => {
         const completeProps: IResourcesInputItemProps = {
             name: 'resources',
@@ -43,13 +24,54 @@ describe('<ResourcesInputItem /> component', () => {
         );
     };
 
-    it('renders the label and link input fields', () => {
+    const SubmitTestComponent: React.FC<
+        Partial<IResourcesInputItemProps> & { onSubmit: jest.Mock }
+    > = (props) => {
+        const { onSubmit, ...componentProps } = props;
+        const formMethods = useForm({
+            defaultValues: { resources: [{ name: '', url: '' }] },
+            mode: 'onBlur',
+        });
+
+        return (
+            <FormProvider {...formMethods}>
+                <form onSubmit={formMethods.handleSubmit(onSubmit)}>
+                    <ResourcesInputItem
+                        index={0}
+                        name="resources"
+                        remove={jest.fn()}
+                        {...componentProps}
+                    />
+                    <button type="submit">Submit</button>
+                </form>
+            </FormProvider>
+        );
+    };
+
+    it('renders the URL field before the link text field', () => {
         render(createTestComponent());
+
+        const urlInput = screen.getByLabelText(
+            /resourcesInput.item.linkInput.title/,
+        );
+        const labelInput = screen.getByLabelText(
+            /resourcesInput.item.labelInput.title/,
+        );
+
         expect(
-            screen.getByPlaceholderText(
-                /resourcesInput.item.linkInput.placeholder/,
-            ),
-        ).toBeInTheDocument();
+            urlInput.compareDocumentPosition(labelInput) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+    });
+
+    it('uses the URL placeholder without prefilling a value', () => {
+        render(createTestComponent());
+
+        const urlInput = screen.getByPlaceholderText(
+            /resourcesInput.item.linkInput.placeholder/,
+        );
+
+        expect(urlInput).toHaveValue('');
     });
 
     it('calls remove function when remove button is clicked', async () => {
@@ -68,11 +90,11 @@ describe('<ResourcesInputItem /> component', () => {
 
     it('accepts valid URL format in link input', async () => {
         render(createTestComponent());
-        const linkInput = screen.getByPlaceholderText(
+        const urlInput = screen.getByPlaceholderText(
             /resourcesInput.item.linkInput.placeholder/,
         );
 
-        await userEvent.type(linkInput, 'https://example.com');
+        await userEvent.type(urlInput, 'https://example.com');
         await userEvent.tab();
 
         expect(
@@ -81,29 +103,55 @@ describe('<ResourcesInputItem /> component', () => {
     });
 
     it('validates URL format in link input', async () => {
-        useFormFieldSpy.mockImplementationOnce((name, options) => ({
-            name,
-            onChange: jest.fn(),
-            onBlur: jest.fn(),
-            value: '',
-            ref: jest.fn(),
-            variant: 'critical',
-            alert: { message: 'Invalid URL format', variant: 'critical' },
-            label: options?.label,
-        }));
+        render(<SubmitTestComponent onSubmit={jest.fn()} />);
 
-        render(createTestComponent());
-
-        const linkInput = screen.getByPlaceholderText(
+        const urlInput = screen.getByPlaceholderText(
             /resourcesInput.item.linkInput.placeholder/,
         );
 
-        await userEvent.type(linkInput, 'broken link');
+        await userEvent.type(urlInput, 'broken link');
         await userEvent.tab();
 
         expect(
-            await screen.findByText('Invalid URL format'),
+            await screen.findByText(/formField.error.pattern/),
         ).toBeInTheDocument();
+    });
+
+    it('submits with an empty link text when the URL is valid', async () => {
+        const onSubmit = jest.fn();
+        render(<SubmitTestComponent onSubmit={onSubmit} />);
+
+        const urlInput = screen.getByPlaceholderText(
+            /resourcesInput.item.linkInput.placeholder/,
+        );
+
+        await userEvent.type(urlInput, 'https://example.com');
+        await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+        await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+        expect(onSubmit.mock.calls[0][0]).toEqual({
+            resources: [{ name: '', url: 'https://example.com' }],
+        });
+    });
+
+    it('mirrors the URL value as the link text placeholder', async () => {
+        render(createTestComponent());
+
+        const urlInput = screen.getByPlaceholderText(
+            /resourcesInput.item.linkInput.placeholder/,
+        );
+        const labelInput = screen.getByLabelText(
+            /resourcesInput.item.labelInput.title/,
+        );
+
+        await userEvent.type(urlInput, 'https://example.com');
+
+        await waitFor(() =>
+            expect(labelInput).toHaveAttribute(
+                'placeholder',
+                'https://example.com',
+            ),
+        );
     });
 
     it('sets a max length requirement for the resource label', () => {

--- a/src/shared/components/forms/resourcesInput/resourcesInputItem.tsx
+++ b/src/shared/components/forms/resourcesInput/resourcesInputItem.tsx
@@ -5,6 +5,7 @@ import {
     IconType,
     InputText,
 } from '@aragon/gov-ui-kit';
+import { useWatch } from 'react-hook-form';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useFormField } from '@/shared/hooks/useFormField';
 
@@ -32,17 +33,6 @@ export const ResourcesInputItem: React.FC<IResourcesInputItemProps> = (
 
     const { t } = useTranslations();
 
-    const nameFieldName = `${name}.${index.toString()}.name`;
-    const nameField = useFormField<
-        ResourcesInputItemBaseForm,
-        typeof nameFieldName
-    >(nameFieldName, {
-        label: t('app.shared.resourcesInput.item.labelInput.title'),
-        rules: { required: true },
-        defaultValue: '',
-        trimOnBlur: true,
-    });
-
     /**
      * URL Regex:
      * - Optional protocol (http:// or https://)
@@ -55,6 +45,9 @@ export const ResourcesInputItem: React.FC<IResourcesInputItemProps> = (
         /^(https?:\/\/)?(([\da-zA-Z-]+\.)+[a-zA-Z]{2,})(\/[^\s?#]*)?(\?[^\s#]*)?(#[^\s]*)?$/;
 
     const urlFieldName = `${name}.${index.toString()}.url`;
+    const urlValue = useWatch<ResourcesInputItemBaseForm>({
+        name: urlFieldName,
+    });
     const urlField = useFormField<
         ResourcesInputItemBaseForm,
         typeof urlFieldName
@@ -65,15 +58,35 @@ export const ResourcesInputItem: React.FC<IResourcesInputItemProps> = (
         trimOnBlur: true,
     });
 
+    const nameFieldName = `${name}.${index.toString()}.name`;
+    const nameField = useFormField<
+        ResourcesInputItemBaseForm,
+        typeof nameFieldName
+    >(nameFieldName, {
+        label: t('app.shared.resourcesInput.item.labelInput.title'),
+        defaultValue: '',
+        trimOnBlur: true,
+    });
+
+    const namePlaceholder =
+        typeof urlValue === 'string' && urlValue.length > 0
+            ? urlValue
+            : undefined;
+
     return (
         <Card className="flex flex-col gap-3 border border-neutral-100 p-6 shadow-neutral-sm md:flex-row md:gap-2">
-            <InputText maxLength={40} {...nameField} />
-
             <InputText
                 placeholder={t(
                     'app.shared.resourcesInput.item.linkInput.placeholder',
                 )}
                 {...urlField}
+            />
+
+            <InputText
+                isOptional={true}
+                maxLength={40}
+                placeholder={namePlaceholder}
+                {...nameField}
             />
             <div className="mt-0 md:mt-9">
                 <Dropdown.Container

--- a/src/shared/components/resourceLink/index.ts
+++ b/src/shared/components/resourceLink/index.ts
@@ -1,0 +1,1 @@
+export { type IResourceLinkProps, ResourceLink } from './resourceLink';

--- a/src/shared/components/resourceLink/resourceLink.test.tsx
+++ b/src/shared/components/resourceLink/resourceLink.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { type IResourceLinkProps, ResourceLink } from './resourceLink';
+
+describe('<ResourceLink /> component', () => {
+    const createTestComponent = (props?: Partial<IResourceLinkProps>) => {
+        const completeProps: IResourceLinkProps = {
+            url: 'https://example.com',
+            isExternal: true,
+            ...props,
+        };
+
+        return <ResourceLink {...completeProps} />;
+    };
+
+    it('uses the URL once as link text when the name is empty', () => {
+        const url = 'https://example.com';
+        render(createTestComponent({ name: '', url }));
+
+        const link = screen.getByRole('link', { name: url });
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveAttribute('href', url);
+        expect(screen.getAllByText(url)).toHaveLength(1);
+    });
+
+    it('uses the name as link text and shows the URL when the name is present', () => {
+        const url = 'https://example.com';
+        render(createTestComponent({ name: 'Example', url }));
+
+        const link = screen.getByRole('link', { name: /Example/ });
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveAttribute('href', url);
+        expect(screen.getByText(url)).toBeInTheDocument();
+    });
+});

--- a/src/shared/components/resourceLink/resourceLink.tsx
+++ b/src/shared/components/resourceLink/resourceLink.tsx
@@ -1,0 +1,29 @@
+import { type ILinkProps, Link } from '@aragon/gov-ui-kit';
+
+export interface IResourceLinkProps
+    extends Omit<ILinkProps, 'children' | 'href' | 'showUrl'> {
+    /**
+     * Optional custom text for the resource link.
+     */
+    name?: string;
+    /**
+     * Resource URL.
+     */
+    url: string;
+}
+
+/**
+ * Renders an external resource link (gov-ui-kit Link) for user-authored resources: the name is used as link text with
+ * the URL shown below it, falling back to the URL alone when no name is set. Not to be confused with the shared Link
+ * component, which wraps the Next.js Link for internal navigation.
+ */
+export const ResourceLink: React.FC<IResourceLinkProps> = (props) => {
+    const { name, url, ...otherProps } = props;
+    const hasName = Boolean(name);
+
+    return (
+        <Link href={url} showUrl={hasName} {...otherProps}>
+            {name || url}
+        </Link>
+    );
+};


### PR DESCRIPTION
# Description

Make link text optional rather than forcing everyone to enter redundant link text. Was bad UX.

Because this adds some logic, added it to a wrapper around the Link component.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [x] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
