### PR TITLE
fix: update stage status logic to return accepted for executed proposals past max advance date

### DIFF
--- a/.changeset/fix-spp-executed-stage-expired.md
+++ b/.changeset/fix-spp-executed-stage-expired.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix an executed SPP proposal showing its final stage as "expired" / "Proposal not executed in time". The per-stage status was derived from the clock alone (`now > maxAdvanceDate`) without checking whether the proposal had already been executed, so a proposal executed on time would flip to expired once viewed after its max-advance date. Executed proposals are now treated as accepted regardless of the max-advance date.

--- a/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.test.ts
+++ b/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.test.ts
@@ -547,6 +547,24 @@ describe('SppStageUtils', () => {
             );
         });
 
+        it('returns accepted instead of expired when the max advance date has passed but the proposal has already been executed', () => {
+            const now = '2023-01-01T12:00:00.000Z';
+            const endDate = DateTime.fromISO(now).minus({ days: 3 });
+            const maxAdvance = DateTime.fromISO(now).minus({ days: 2 });
+            const stage = generateSppStage();
+            const proposal = generateSppProposal({
+                hasActions: true,
+                executed: { status: true },
+            });
+            getStageEndDateSpy.mockReturnValue(endDate);
+            getStageMaxAdvanceSpy.mockReturnValue(maxAdvance);
+            isApprovalReachedSpy.mockReturnValue(true);
+            timeUtils.setTime(now);
+            expect(sppStageUtils.getStageStatus(proposal, stage)).toBe(
+                ProposalStatus.ACCEPTED,
+            );
+        });
+
         it('returns accepted when stage has ended, approval is reached, max advance date has passed and stage has already been advanced', () => {
             const now = '2023-01-01T12:00:00.000Z';
             const endDate = DateTime.fromISO(now).minus({ days: 3 });

--- a/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.ts
+++ b/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.ts
@@ -9,7 +9,7 @@ class SppStageUtils {
         proposal: ISppProposal,
         stage: ISppStage,
     ): ProposalStatus => {
-        const { stageIndex: currentStage } = proposal;
+        const { stageIndex: currentStage, executed } = proposal;
         const { stageIndex } = stage;
 
         const isOptimisticStage = this.isVeto(stage);
@@ -43,6 +43,7 @@ class SppStageUtils {
             !isLastStage;
 
         const isExpired =
+            !executed.status &&
             !isSignalling &&
             stageIndex === currentStage &&
             maxAdvanceDate != null &&


### PR DESCRIPTION
# Description

Noticed that an SPP proposal that was already executed can still show its last stage as "expired" / "Proposal not executed in time". We can see it in [here](https://app.aragon.org/dao/ethereum-mainnet/0xf204245b0B05E9A0780761E326552A569c1D6ceb/proposals/CIPX-3): the proposal executed fine back in May, but opening it in July shows the veto stage as expired.

Turns out this is purely a frontend thing. `getStageStatus` decides a stage is expired just by checking `now > maxAdvanceDate`:

```ts
const isExpired =
    !isSignalling &&
    stageIndex === currentStage &&
    maxAdvanceDate != null &&
    now > maxAdvanceDate;
```

It never looks at whether the proposal was actually executed. So once enough real time passes, `now` is always past the max-advance date and the stage flips to expired — even though the proposal was executed well before that deadline. That's why it looks fine one day and "expired" a few weeks later.

The backend data is correct the whole time (`executed.status: true`), and the overall proposal status already shows "Executed" — it's only the per-stage card that gets it wrong.

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Tests

Added a case in `sppStageUtils.test.ts`: same setup as the existing "expired" test, but with `executed.status: true` — now expects `ACCEPTED` instead of `EXPIRED`. Whole suite passes (52/52).
