### PR TITLE
Release @aragon/app@1.33.2

### DIFF
--- a/.changeset/fix-spp-executed-stage-expired.md
+++ b/.changeset/fix-spp-executed-stage-expired.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Fix an executed SPP proposal showing its final stage as "expired" / "Proposal not executed in time". The per-stage status was derived from the clock alone (`now > maxAdvanceDate`) without checking whether the proposal had already been executed, so a proposal executed on time would flip to expired once viewed after its max-advance date. Executed proposals are now treated as accepted regardless of the max-advance date.

--- a/.changeset/live-statuses-lie.md
+++ b/.changeset/live-statuses-lie.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Refresh proposal cards in transaction dialogs after transaction indexing so proposal transaction flows show live proposal data.

--- a/.changeset/monorepo-skeleton.md
+++ b/.changeset/monorepo-skeleton.md
@@ -1,5 +1,0 @@
----
-'@aragon/app': patch
----
-
-Restructure the repository into a pnpm monorepo: the app now lives in `apps/app`, shared tooling (turbo, biome, husky, changesets) stays at the workspace root. No runtime changes.

--- a/apps/app/CHANGELOG.md
+++ b/apps/app/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aragon/app
 
+## 1.33.2
+
+### Patch Changes
+
+- [#1212](https://github.com/aragon/app/pull/1212) [`d3ba5f7`](https://github.com/aragon/app/commit/d3ba5f7736c2c9a7a0515488c7d5a6c52c7e77f2) Thanks [@harryburger](https://github.com/harryburger)! - Fix an executed SPP proposal showing its final stage as "expired" / "Proposal not executed in time". The per-stage status was derived from the clock alone (`now > maxAdvanceDate`) without checking whether the proposal had already been executed, so a proposal executed on time would flip to expired once viewed after its max-advance date. Executed proposals are now treated as accepted regardless of the max-advance date.
+
+- [#1206](https://github.com/aragon/app/pull/1206) [`ca7b26e`](https://github.com/aragon/app/commit/ca7b26eb1c20288e972dd997342806326c46ac9a) Thanks [@evanaronson](https://github.com/evanaronson)! - Refresh proposal cards in transaction dialogs after transaction indexing so proposal transaction flows show live proposal data.
+
+- [#1211](https://github.com/aragon/app/pull/1211) [`e827f05`](https://github.com/aragon/app/commit/e827f05f30e5889eedce1d468849a91031947cbe) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Restructure the repository into a pnpm monorepo: the app now lives in `apps/app`, shared tooling (turbo, biome, husky, changesets) stays at the workspace root. No runtime changes.
+
 ## 1.33.1
 
 ### Patch Changes

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/app",
-    "version": "1.33.1",
+    "version": "1.33.2",
     "description": "Human-centered DAO infrastructure",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",


### PR DESCRIPTION
## Features
- Refresh proposal card status in tx dialog after indexing ([#1206](https://github.com/aragon/app/pull/1206)) — [APP-922: As a user, I want proposal status in transaction dialogs to reflect real data](https://linear.app/aragon/issue/APP-922/as-a-user-i-want-proposal-status-in-transaction-dialogs-to-reflect)

## Fixes
- add changeset for executed SPP stage expired fix
- update stage status logic to return accepted for executed proposals past max advance date

## Other Changes
- Release @aragon/app@1.33.2
- restructure into a pnpm monorepo (apps/app)
- monorepo tooling: pnpm workspace, turbo scripts, CI regroup, docs
- move app into apps/app (pure rename, no content changes)
- Merge pull request #1210 from aragon/release/2026-07-06_17-14
- Merge pull request #1212 from aragon/fix/APP-965-spp-executed-stage-shows-expired — [APP-965: Proposal eligibility shows unrestricted for eligible wallets](https://linear.app/aragon/issue/APP-965/proposal-eligibility-shows-unrestricted-for-eligible-wallets)
- Merge branch 'main' into fix/APP-965-spp-executed-stage-shows-expired



<!-- slack_ts: 1783594296.642629 -->
