### PR TITLE
fix(APP-965): Derive SPP proposal creation restriction from sub-plugin rules

### DIFF
--- a/.changeset/fix-spp-proposal-eligibility-unrestricted.md
+++ b/.changeset/fix-spp-proposal-eligibility-unrestricted.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix proposal creation eligibility showing "Unrestricted" for eligible wallets on restricted SPP processes.

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ next-env.d.ts
 !.agents/shared/**
 .playwright-mcp
 .patches
+.omp

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.test.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.test.ts
@@ -1,0 +1,200 @@
+import { renderHook } from '@testing-library/react';
+import * as useSimulateProposalModule from '@/modules/governance/hooks/useSimulateProposal';
+import type { IPermissionCheckGuardResult } from '@/modules/governance/types';
+import * as daoService from '@/shared/api/daoService';
+import * as useDaoPluginsModule from '@/shared/hooks/useDaoPlugins';
+import {
+    generateDao,
+    generateDaoPlugin,
+    generateFilterComponentPlugin,
+    generateReactQueryResultSuccess,
+} from '@/shared/testUtils';
+import { pluginRegistryUtils } from '@/shared/utils/pluginRegistryUtils';
+import {
+    generateSppPluginSettings,
+    generateSppStage,
+    generateSppStagePlugin,
+} from '../../testUtils';
+import { useSppPermissionCheckProposalCreation } from './useSppPermissionCheckProposalCreation';
+
+describe('useSppPermissionCheckProposalCreation', () => {
+    const useDaoPluginsSpy = jest.spyOn(useDaoPluginsModule, 'useDaoPlugins');
+    const useDaoSpy = jest.spyOn(daoService, 'useDao');
+    const useSimulateProposalCreationSpy = jest.spyOn(
+        useSimulateProposalModule,
+        'useSimulateProposalCreation',
+    );
+    const getSlotFunctionSpy = jest.spyOn(
+        pluginRegistryUtils,
+        'getSlotFunction',
+    );
+
+    afterEach(() => {
+        useDaoPluginsSpy.mockReset();
+        useDaoSpy.mockReset();
+        useSimulateProposalCreationSpy.mockReset();
+        getSlotFunctionSpy.mockReset();
+    });
+
+    const createTestParams = (guardResults: IPermissionCheckGuardResult[]) => {
+        const subPluginMetas = guardResults.map((_result, index) =>
+            generateDaoPlugin({
+                address: `0x${String(index + 1).padStart(40, '0')}`,
+            }),
+        );
+
+        const sppPlugin = generateDaoPlugin({
+            address: `0x${'a'.repeat(40)}`,
+            settings: generateSppPluginSettings({
+                stages: [
+                    generateSppStage({
+                        plugins: subPluginMetas.map((meta) =>
+                            generateSppStagePlugin({ address: meta.address }),
+                        ),
+                    }),
+                ],
+            }),
+        });
+
+        useDaoPluginsSpy.mockReturnValue(
+            subPluginMetas.map((meta) =>
+                generateFilterComponentPlugin({ meta }),
+            ),
+        );
+        useDaoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: generateDao() }),
+        );
+
+        const slotFunctions = new Map(
+            subPluginMetas.map((meta, index) => [
+                meta.address,
+                () => guardResults[index],
+            ]),
+        );
+        getSlotFunctionSpy.mockImplementation(
+            () =>
+                ((params: { plugin: { address: string } }) =>
+                    slotFunctions.get(params.plugin.address)?.()) as never,
+        );
+
+        return { daoId: 'dao-test', plugin: sppPlugin };
+    };
+
+    const generateGuardResult = (
+        result?: Partial<IPermissionCheckGuardResult>,
+    ): IPermissionCheckGuardResult => ({
+        hasPermission: false,
+        settings: [],
+        isLoading: false,
+        isRestricted: false,
+        ...result,
+    });
+
+    const mockSimulation = (result: {
+        isLoading: boolean;
+        isSuccess: boolean;
+    }) =>
+        useSimulateProposalCreationSpy.mockReturnValue(
+            result as ReturnType<
+                typeof useSimulateProposalModule.useSimulateProposalCreation
+            >,
+        );
+
+    it('returns isRestricted true for a restricted process even when the connected wallet can create a proposal', () => {
+        const settings = [[{ term: 'Members', definition: 'Listed only' }]];
+        const guardResult = generateGuardResult({
+            isRestricted: true,
+            settings,
+            hasPermission: true,
+        });
+        const params = createTestParams([guardResult]);
+        mockSimulation({ isLoading: false, isSuccess: true });
+
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.isRestricted).toBeTruthy();
+        expect(result.current.settings).toEqual(settings);
+    });
+
+    it('returns isRestricted false when no sub-plugin restricts proposal creation', () => {
+        const params = createTestParams([
+            generateGuardResult({ isRestricted: false }),
+            generateGuardResult({ isRestricted: false }),
+        ]);
+        mockSimulation({ isLoading: false, isSuccess: true });
+
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.isRestricted).toBeFalsy();
+    });
+
+    it('returns isRestricted true when any sub-plugin restricts proposal creation', () => {
+        const restrictedSettings = [
+            [{ term: 'Voting power', definition: '≥10' }],
+        ];
+        const params = createTestParams([
+            generateGuardResult({ isRestricted: false }),
+            generateGuardResult({
+                isRestricted: true,
+                settings: restrictedSettings,
+            }),
+        ]);
+        mockSimulation({ isLoading: false, isSuccess: true });
+
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.isRestricted).toBeTruthy();
+        expect(result.current.settings).toEqual(restrictedSettings);
+    });
+
+    it('derives hasPermission from the proposal creation simulation', () => {
+        const params = createTestParams([
+            generateGuardResult({ isRestricted: true }),
+        ]);
+        mockSimulation({ isLoading: false, isSuccess: false });
+
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.hasPermission).toBeFalsy();
+        expect(result.current.isRestricted).toBeTruthy();
+    });
+
+    it('returns isLoading true while the simulation is loading', () => {
+        const params = createTestParams([generateGuardResult()]);
+        mockSimulation({ isLoading: true, isSuccess: false });
+
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.isLoading).toBeTruthy();
+    });
+});

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.ts
@@ -71,10 +71,16 @@ export const useSppPermissionCheckProposalCreation = (
         result?.isRestricted ? result.settings : [],
     );
 
+    // The simulation only checks the connected wallet's permission; whether the process itself is restricted comes
+    // from the sub-plugin creation rules.
+    const isRestricted = pluginProposalCreationGuardResults.some(
+        (result) => result?.isRestricted === true,
+    );
+
     return {
         hasPermission: permissionGranted,
         settings,
         isLoading,
-        isRestricted: !permissionGranted,
+        isRestricted,
     };
 };


### PR DESCRIPTION
## Summary

Fixes APP-965: the process details page showed **"Unrestricted: anyone can create a proposal"** for any connected wallet that was *eligible* to create one, even when the SPP process has real creation rules.

## Root cause

APP-4547 (#766) moved the SPP proposal-creation guard to an RPC simulation (`useSimulateProposalCreation`, a `useCall` for the connected account) but left the guard's `isRestricted` derived from that wallet-scoped result:

```ts
isRestricted: !permissionGranted // permissionGranted = hasSimulationSucceeded
```

`isRestricted` is a **process-level** fact ("are there restrictions on the action" — see `IPermissionCheckGuardResult`; token derives it from `minProposerVotingPower > 0`, multisig from `onlyListed`), so an eligible wallet (simulation succeeds) flipped the whole process to "Unrestricted" in `PermissionsDefinitionList`. The negative path (ineligible wallet) rendered correctly, which is why this only showed for wallets that could create.

## Fix

`useSppPermissionCheckProposalCreation` now aggregates `isRestricted` from the sub-plugin creation rules (restricted when any stage body restricts creation — the same source the displayed `settings` already came from), while `hasPermission` keeps using the RPC simulation for the wallet-level gate.

## Testing

- New `useSppPermissionCheckProposalCreation.test.ts` (5 cases): reproduces the bug against the pre-fix hook (restricted process + eligible wallet → was rendering unrestricted) and covers restricted/unrestricted aggregation, `hasPermission` from the simulation, and loading composition.
- `type-check`, `lint:check`, and the jest suite pass; additionally verified red→green from a clean checkout in an isolated linux/arm64 sandbox (deny-by-default network, node 24) as part of the sealbox clean-room dogfood.
- Changeset included (`@aragon/app` patch).

Linear: [APP-965](https://linear.app/aragon/issue/APP-965/proposal-eligibility-shows-unrestricted-for-eligible-wallets)
