### PR TITLE
fix(APP-988): Show support-threshold status instead of winning option in proposal voting summary

### DIFF
--- a/.changeset/app-988-fix-support-reached-calculation.md
+++ b/.changeset/app-988-fix-support-reached-calculation.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix token and lock-to-vote proposal voting summaries incorrectly implementing support reached calculation.

--- a/apps/app/src/plugins/lockToVotePlugin/components/lockToVoteProposalVotingSummary/lockToVoteProposalVotingSummary.test.tsx
+++ b/apps/app/src/plugins/lockToVotePlugin/components/lockToVoteProposalVotingSummary/lockToVoteProposalVotingSummary.test.tsx
@@ -1,0 +1,250 @@
+import { ProposalStatus } from '@aragon/gov-ui-kit';
+import { render, screen } from '@testing-library/react';
+import { VoteOption } from '../../../tokenPlugin/types';
+import { generateLockToVotePluginSettings } from '../../testUtils/generators/lockToVotePluginSettings';
+import { generateLockToVotePluginSettingsToken } from '../../testUtils/generators/lockToVotePluginSettingsToken';
+import { generateLockToVoteProposal } from '../../testUtils/generators/lockToVoteProposal';
+import { lockToVoteProposalUtils } from '../../utils/lockToVoteProposalUtils';
+import {
+    type ILockToVoteProposalVotingSummaryProps,
+    LockToVoteProposalVotingSummary,
+} from './lockToVoteProposalVotingSummary';
+
+describe('<LockToVoteProposalVotingSummary /> component', () => {
+    const getProposalStatusSpy = jest.spyOn(
+        lockToVoteProposalUtils,
+        'getProposalStatus',
+    );
+
+    afterEach(() => {
+        getProposalStatusSpy.mockReset();
+    });
+
+    const tokenAddress = '0xToken';
+    const translationPrefix =
+        'app.plugins.lockToVote.lockToVoteProposalVotingSummary';
+
+    const generateTestProposal = (params: {
+        yes?: string;
+        no?: string;
+        abstain?: string;
+        minParticipation?: number;
+        totalSupply?: string;
+    }) => {
+        const {
+            yes = '0',
+            no = '0',
+            abstain,
+            minParticipation = 0,
+            totalSupply = '1000000',
+        } = params;
+
+        const votesByOption = [
+            { type: VoteOption.YES, totalVotingPower: yes },
+            { type: VoteOption.NO, totalVotingPower: no },
+        ];
+
+        if (abstain != null) {
+            votesByOption.push({
+                type: VoteOption.ABSTAIN,
+                totalVotingPower: abstain,
+            });
+        }
+
+        return generateLockToVoteProposal({
+            settings: generateLockToVotePluginSettings({
+                minParticipation,
+                supportThreshold: 500_000,
+                token: generateLockToVotePluginSettingsToken({
+                    address: tokenAddress,
+                    decimals: 1,
+                    symbol: 'TTT',
+                }),
+            }),
+            metrics: { votesByOption },
+            tokensTotalSupply: { [tokenAddress.toLowerCase()]: totalSupply },
+        });
+    };
+
+    const createTestComponent = (
+        props?: Partial<ILockToVoteProposalVotingSummaryProps>,
+    ) => {
+        const completeProps: ILockToVoteProposalVotingSummaryProps = {
+            name: 'Lock to vote',
+            isVeto: false,
+            ...props,
+        };
+
+        return <LockToVoteProposalVotingSummary {...completeProps} />;
+    };
+
+    it('renders only the plugin name when no proposal is set', () => {
+        render(createTestComponent({ name: 'My plugin', proposal: undefined }));
+        expect(screen.getByText('My plugin')).toBeInTheDocument();
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    it('displays the yes votes over yes+no votes as support, excluding abstain votes', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal({
+            yes: '7500',
+            no: '2500',
+            abstain: '5000',
+        });
+        render(createTestComponent({ proposal }));
+
+        // Support is yes / (yes + no) = 75%, not winning-option / (yes + no + abstain) = 50%
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar.dataset.value).toEqual('75');
+
+        // Votes description uses the yes + no total (10000 raw -> 1K), not yes + no + abstain (1.5K)
+        expect(screen.getByText('750')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                `${translationPrefix}.votesDescription (details=1K TTT)`,
+            ),
+        ).toBeInTheDocument();
+
+        expect(
+            screen.getByText(`${translationPrefix}.supportLabel`),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId('progress-indicator').dataset.value).toEqual(
+            '50',
+        );
+
+        // 75% > 50% support threshold => reached (primary) variant
+        expect(progressbar.querySelector('.bg-primary-400')).not.toBeNull();
+        expect(progressbar.querySelector('.bg-neutral-400')).toBeNull();
+    });
+
+    it('displays yes-vote support as not reached for veto proposals with majority no votes', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal({ yes: '1000', no: '9000' });
+        render(createTestComponent({ proposal, isVeto: true }));
+
+        expect(
+            screen.getByText(`${translationPrefix}.optimisticSupportLabel`),
+        ).toBeInTheDocument();
+
+        // Veto support is yes / (yes + no) = 10%, not the winning no option (90%)
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar.dataset.value).toEqual('10');
+
+        // 10% < 50% support threshold => not-reached (neutral) variant
+        expect(progressbar.querySelector('.bg-neutral-400')).not.toBeNull();
+        expect(progressbar.querySelector('.bg-primary-400')).toBeNull();
+    });
+
+    it('displays support at exactly the threshold as not reached', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal({ yes: '5000', no: '5000' });
+        render(createTestComponent({ proposal }));
+
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar.dataset.value).toEqual('50');
+        expect(screen.getByTestId('progress-indicator').dataset.value).toEqual(
+            '50',
+        );
+
+        // On-chain semantics are strictly greater-than: 50% support does not reach a 50% threshold
+        expect(progressbar.querySelector('.bg-neutral-400')).not.toBeNull();
+        expect(progressbar.querySelector('.bg-primary-400')).toBeNull();
+    });
+
+    it('displays zero support without the reached variant when only abstain votes are cast', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal({ abstain: '5000' });
+        render(createTestComponent({ proposal }));
+
+        // No countable votes => 0% support, not abstain-as-winning-option (100%).
+        // Progress clamps the rendered value to a minimum of 1.
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar.dataset.value).toEqual('1');
+        expect(progressbar.querySelector('.bg-neutral-400')).not.toBeNull();
+        expect(progressbar.querySelector('.bg-primary-400')).toBeNull();
+        expect(
+            screen.getByText(
+                `${translationPrefix}.votesDescription (details=0 TTT)`,
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('displays veto support as reached for veto proposals when yes votes exceed the threshold', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal({
+            yes: '7500',
+            no: '2500',
+            abstain: '5000',
+        });
+        render(createTestComponent({ proposal, isVeto: true }));
+
+        // Veto support is yes / (yes + no) = 75% > 50% => reached (primary) variant
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar.dataset.value).toEqual('75');
+        expect(progressbar.querySelector('.bg-primary-400')).not.toBeNull();
+        expect(progressbar.querySelector('.bg-neutral-400')).toBeNull();
+        expect(
+            screen.getByText(`${translationPrefix}.optimisticSupportLabel`),
+        ).toBeInTheDocument();
+    });
+
+    it('displays the approved status when proposal is executed and approval is reached', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal({
+            yes: '7500',
+            no: '2500',
+            minParticipation: 200_000,
+            totalSupply: '10000',
+        });
+        render(createTestComponent({ proposal, isExecuted: true }));
+
+        const statusText = screen.getByText(`${translationPrefix}.approved`);
+        expect(statusText).toHaveClass('text-success-800');
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    it('displays the vetoed status when veto proposal is executed and approval is reached', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal({
+            yes: '7500',
+            no: '2500',
+            minParticipation: 200_000,
+            totalSupply: '10000',
+        });
+        render(
+            createTestComponent({ proposal, isExecuted: true, isVeto: true }),
+        );
+
+        const statusText = screen.getByText(`${translationPrefix}.vetoed`);
+        expect(statusText).toHaveClass('text-critical-800');
+    });
+
+    it('displays the not-approved status when proposal has failed and support is not reached', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.FAILED);
+        const proposal = generateTestProposal({
+            yes: '0',
+            no: '2500',
+            minParticipation: 200_000,
+            totalSupply: '10000',
+        });
+        render(createTestComponent({ proposal }));
+
+        const statusText = screen.getByText(`${translationPrefix}.notApproved`);
+        expect(statusText).toHaveClass('text-neutral-500');
+    });
+
+    it('displays the not-vetoed status when veto proposal is executed and support is not reached', () => {
+        const proposal = generateTestProposal({
+            yes: '0',
+            no: '2500',
+            minParticipation: 200_000,
+            totalSupply: '10000',
+        });
+        render(
+            createTestComponent({ proposal, isVeto: true, isExecuted: true }),
+        );
+
+        const statusText = screen.getByText(`${translationPrefix}.notVetoed`);
+        expect(statusText).toHaveClass('text-neutral-500');
+    });
+});

--- a/apps/app/src/plugins/lockToVotePlugin/components/lockToVoteProposalVotingSummary/lockToVoteProposalVotingSummary.test.tsx
+++ b/apps/app/src/plugins/lockToVotePlugin/components/lockToVoteProposalVotingSummary/lockToVoteProposalVotingSummary.test.tsx
@@ -93,7 +93,8 @@ describe('<LockToVoteProposalVotingSummary /> component', () => {
         });
         render(createTestComponent({ proposal }));
 
-        // Support is yes / (yes + no) = 75%, not winning-option / (yes + no + abstain) = 50%
+        // CORRECT calculation: 750 / (750 + 250) = 75%
+        // WRONG: winning-option / all-votes (750 / 1500 = 50%)
         const progressbar = screen.getByRole('progressbar');
         expect(progressbar.dataset.value).toEqual('75');
 
@@ -189,7 +190,7 @@ describe('<LockToVoteProposalVotingSummary /> component', () => {
     });
 
     it('displays the approved status when proposal is executed and approval is reached', () => {
-        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.EXECUTED);
         const proposal = generateTestProposal({
             yes: '7500',
             no: '2500',
@@ -203,17 +204,15 @@ describe('<LockToVoteProposalVotingSummary /> component', () => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     });
 
-    it('displays the vetoed status when veto proposal is executed and approval is reached', () => {
-        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+    it('displays the vetoed status when veto proposal has failed and approval is reached', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.FAILED);
         const proposal = generateTestProposal({
             yes: '7500',
             no: '2500',
             minParticipation: 200_000,
             totalSupply: '10000',
         });
-        render(
-            createTestComponent({ proposal, isExecuted: true, isVeto: true }),
-        );
+        render(createTestComponent({ proposal, isVeto: true }));
 
         const statusText = screen.getByText(`${translationPrefix}.vetoed`);
         expect(statusText).toHaveClass('text-critical-800');

--- a/apps/app/src/plugins/lockToVotePlugin/components/lockToVoteProposalVotingSummary/lockToVoteProposalVotingSummary.tsx
+++ b/apps/app/src/plugins/lockToVotePlugin/components/lockToVoteProposalVotingSummary/lockToVoteProposalVotingSummary.tsx
@@ -60,12 +60,6 @@ export const LockToVoteProposalVotingSummary: React.FC<
     const noVotes = Number(
         lockToVoteProposalUtils.getOptionVotingPower(proposal, VoteOption.NO),
     );
-    const abstainVotes = Number(
-        lockToVoteProposalUtils.getOptionVotingPower(
-            proposal,
-            VoteOption.ABSTAIN,
-        ),
-    );
 
     const tokenTotalSupply = formatUnits(
         bigIntUtils.safeParse(
@@ -80,23 +74,22 @@ export const LockToVoteProposalVotingSummary: React.FC<
         'LockToVoteProposalVotingSummary: tokenTotalSupply must be a positive number',
     );
 
-    const totalVotes = yesVotes + noVotes + abstainVotes;
-    const formattedTotalVotes = formatterUtils.formatNumber(totalVotes, {
-        format: NumberFormat.GENERIC_SHORT,
-    })!;
+    const countableTotalVotes = yesVotes + noVotes;
+    const formattedCountableTotalVotes = formatterUtils.formatNumber(
+        countableTotalVotes,
+        { format: NumberFormat.GENERIC_SHORT },
+    );
 
-    const winningOption = Math.max(yesVotes, noVotes, abstainVotes);
-    const winningOptionPercentage =
-        totalVotes > 0 ? (winningOption / totalVotes) * 100 : 0;
-    const formattedWinningOption = formatterUtils.formatNumber(winningOption, {
+    const supportPercentage =
+        countableTotalVotes > 0 ? (yesVotes / countableTotalVotes) * 100 : 0;
+    const formattedYesVotes = formatterUtils.formatNumber(yesVotes, {
         format: NumberFormat.GENERIC_SHORT,
     });
 
     const supportThresholdPercentage =
         tokenSettingsUtils.ratioToPercentage(supportThreshold);
-    const supportReached =
-        winningOptionPercentage >= supportThresholdPercentage;
 
+    const isSupportReached = lockToVoteProposalUtils.isSupportReached(proposal);
     const isApprovalReached =
         lockToVoteProposalUtils.isApprovalReached(proposal);
 
@@ -140,16 +133,16 @@ export const LockToVoteProposalVotingSummary: React.FC<
             </p>
             <Progress
                 thresholdIndicator={supportThresholdPercentage}
-                value={winningOptionPercentage}
-                variant={supportReached ? 'primary' : 'neutral'}
+                value={supportPercentage}
+                variant={isSupportReached ? 'primary' : 'neutral'}
             />
             <p className="font-normal text-neutral-800 text-sm leading-tight md:text-base">
-                {formattedWinningOption}{' '}
+                {formattedYesVotes}{' '}
                 <span className="text-neutral-500">
                     {t(
                         'app.plugins.lockToVote.lockToVoteProposalVotingSummary.votesDescription',
                         {
-                            details: `${formattedTotalVotes} ${symbol}`,
+                            details: `${formattedCountableTotalVotes} ${symbol}`,
                         },
                     )}
                 </span>

--- a/apps/app/src/plugins/tokenPlugin/components/tokenProposalVotingSummary/tokenProposalVotingSummary.test.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenProposalVotingSummary/tokenProposalVotingSummary.test.tsx
@@ -1,0 +1,246 @@
+import { ProposalStatus } from '@aragon/gov-ui-kit';
+import { render, screen } from '@testing-library/react';
+import {
+    generateTokenPluginSettings,
+    generateTokenPluginSettingsToken,
+    generateTokenProposal,
+} from '../../testUtils';
+import { type ITokenProposal, VoteOption } from '../../types';
+import { tokenProposalUtils } from '../../utils/tokenProposalUtils';
+import {
+    type ITokenProposalVotingSummaryProps,
+    TokenProposalVotingSummary,
+} from './tokenProposalVotingSummary';
+
+describe('<TokenProposalVotingSummary /> component', () => {
+    const getProposalStatusSpy = jest.spyOn(
+        tokenProposalUtils,
+        'getProposalStatus',
+    );
+
+    afterEach(() => {
+        getProposalStatusSpy.mockReset();
+    });
+
+    // supportThreshold 500_000 = 50% (ratio base 1_000_000), token decimals 1,
+    // raw amounts are formatted with the token decimals by the component.
+    const generateTestProposal = (
+        votesByOption: Array<{ type: VoteOption; totalVotingPower: string }>,
+        settings?: Partial<ITokenProposal['settings']>,
+    ) =>
+        generateTokenProposal({
+            settings: generateTokenPluginSettings({
+                supportThreshold: 500_000,
+                minParticipation: 0,
+                historicalTotalSupply: '1000000',
+                token: generateTokenPluginSettingsToken({
+                    decimals: 1,
+                    symbol: 'TTT',
+                }),
+                ...settings,
+            }),
+            metrics: { votesByOption },
+        });
+
+    const createTestComponent = (
+        props?: Partial<ITokenProposalVotingSummaryProps>,
+    ) => {
+        const completeProps: ITokenProposalVotingSummaryProps = {
+            proposal: generateTestProposal([]),
+            name: 'Token Voting',
+            isVeto: false,
+            ...props,
+        };
+
+        return <TokenProposalVotingSummary {...completeProps} />;
+    };
+
+    it('renders only the plugin name when no proposal is set', () => {
+        render(createTestComponent({ proposal: undefined }));
+        expect(screen.getByText('Token Voting')).toBeInTheDocument();
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    it('displays the yes votes over yes+no votes as support, excluding abstain votes', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal([
+            { type: VoteOption.YES, totalVotingPower: '7500' },
+            { type: VoteOption.NO, totalVotingPower: '2500' },
+            { type: VoteOption.ABSTAIN, totalVotingPower: '5000' },
+        ]);
+        render(createTestComponent({ proposal }));
+
+        // 750 / (750 + 250) = 75%
+        // WRONG: winning-option / all-votes (750 / 1500 = 50%)
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar.dataset.value).toEqual('75');
+        expect(screen.getByTestId('progress-indicator').dataset.value).toEqual(
+            '50',
+        );
+        // Support is above the threshold => reached (primary) variant
+        expect(progressbar.querySelector('.bg-primary-400')).not.toBeNull();
+        expect(progressbar.querySelector('.bg-neutral-400')).toBeNull();
+        expect(
+            screen.getByText(
+                'app.plugins.token.tokenProposalVotingSummary.supportLabel',
+            ),
+        ).toBeInTheDocument();
+        // Votes description total is yes+no (1K), not yes+no+abstain (1.5K)
+        expect(screen.getByText('750')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'app.plugins.token.tokenProposalVotingSummary.votesDescription (details=1K TTT)',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('displays yes-vote support as not reached for veto proposals with majority no votes', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal([
+            { type: VoteOption.YES, totalVotingPower: '1000' },
+            { type: VoteOption.NO, totalVotingPower: '9000' },
+        ]);
+        render(createTestComponent({ proposal, isVeto: true }));
+
+        // Veto support is the yes votes (10%), not the winning no option (90%)
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar.dataset.value).toEqual('10');
+        // Support must not be marked as reached
+        expect(progressbar.querySelector('.bg-neutral-400')).not.toBeNull();
+        expect(progressbar.querySelector('.bg-primary-400')).toBeNull();
+        expect(
+            screen.getByText(
+                'app.plugins.token.tokenProposalVotingSummary.optimisticSupportLabel',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('displays support at exactly the threshold as not reached', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal([
+            { type: VoteOption.YES, totalVotingPower: '5000' },
+            { type: VoteOption.NO, totalVotingPower: '5000' },
+        ]);
+        render(createTestComponent({ proposal }));
+
+        // On-chain support check is strictly greater than the threshold
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar.dataset.value).toEqual('50');
+        expect(screen.getByTestId('progress-indicator').dataset.value).toEqual(
+            '50',
+        );
+        expect(progressbar.querySelector('.bg-neutral-400')).not.toBeNull();
+        expect(progressbar.querySelector('.bg-primary-400')).toBeNull();
+    });
+
+    it('displays zero support without the reached variant when only abstain votes are cast', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal([
+            { type: VoteOption.ABSTAIN, totalVotingPower: '5000' },
+        ]);
+        render(createTestComponent({ proposal }));
+
+        // No countable votes => 0% support, not abstain-as-winning-option (100%).
+        // Progress clamps the rendered value to a minimum of 1.
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar.dataset.value).toEqual('1');
+        expect(progressbar.querySelector('.bg-neutral-400')).not.toBeNull();
+        expect(progressbar.querySelector('.bg-primary-400')).toBeNull();
+        expect(
+            screen.getByText(
+                'app.plugins.token.tokenProposalVotingSummary.votesDescription (details=0 TTT)',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('displays veto support as reached for veto proposals when yes votes exceed the threshold', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal([
+            { type: VoteOption.YES, totalVotingPower: '7500' },
+            { type: VoteOption.NO, totalVotingPower: '2500' },
+            { type: VoteOption.ABSTAIN, totalVotingPower: '5000' },
+        ]);
+        render(createTestComponent({ proposal, isVeto: true }));
+
+        // Veto support is yes / (yes + no) = 75% > 50% => reached (primary) variant
+        const progressbar = screen.getByRole('progressbar');
+        expect(progressbar.dataset.value).toEqual('75');
+        expect(progressbar.querySelector('.bg-primary-400')).not.toBeNull();
+        expect(progressbar.querySelector('.bg-neutral-400')).toBeNull();
+        expect(
+            screen.getByText(
+                'app.plugins.token.tokenProposalVotingSummary.optimisticSupportLabel',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('displays the approved status when proposal is executed and approval is reached', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal(
+            [
+                { type: VoteOption.YES, totalVotingPower: '7500' },
+                { type: VoteOption.NO, totalVotingPower: '2500' },
+            ],
+            { minParticipation: 200_000, historicalTotalSupply: '10000' },
+        );
+        render(createTestComponent({ proposal, isExecuted: true }));
+
+        const status = screen.getByText(
+            'app.plugins.token.tokenProposalVotingSummary.approved',
+        );
+        expect(status).toBeInTheDocument();
+        expect(status).toHaveClass('text-success-800');
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    it('displays the vetoed status when veto proposal is executed and approval is reached', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        const proposal = generateTestProposal(
+            [
+                { type: VoteOption.YES, totalVotingPower: '7500' },
+                { type: VoteOption.NO, totalVotingPower: '2500' },
+            ],
+            { minParticipation: 200_000, historicalTotalSupply: '10000' },
+        );
+        render(
+            createTestComponent({ proposal, isVeto: true, isExecuted: true }),
+        );
+
+        const status = screen.getByText(
+            'app.plugins.token.tokenProposalVotingSummary.vetoed',
+        );
+        expect(status).toBeInTheDocument();
+        expect(status).toHaveClass('text-critical-800');
+    });
+
+    it('displays the not-approved status when proposal has failed and support is not reached', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.FAILED);
+        const proposal = generateTestProposal(
+            [{ type: VoteOption.NO, totalVotingPower: '2500' }],
+            { minParticipation: 200_000, historicalTotalSupply: '10000' },
+        );
+        render(createTestComponent({ proposal }));
+
+        const status = screen.getByText(
+            'app.plugins.token.tokenProposalVotingSummary.notApproved',
+        );
+        expect(status).toBeInTheDocument();
+        expect(status).toHaveClass('text-neutral-500');
+    });
+
+    it('displays the not-vetoed status when veto proposal is executed and support is not reached', () => {
+        const proposal = generateTestProposal(
+            [{ type: VoteOption.NO, totalVotingPower: '2500' }],
+            { minParticipation: 200_000, historicalTotalSupply: '10000' },
+        );
+        render(
+            createTestComponent({ proposal, isVeto: true, isExecuted: true }),
+        );
+
+        expect(
+            screen.getByText(
+                'app.plugins.token.tokenProposalVotingSummary.notVetoed',
+            ),
+        ).toBeInTheDocument();
+    });
+});

--- a/apps/app/src/plugins/tokenPlugin/components/tokenProposalVotingSummary/tokenProposalVotingSummary.test.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenProposalVotingSummary/tokenProposalVotingSummary.test.tsx
@@ -70,7 +70,7 @@ describe('<TokenProposalVotingSummary /> component', () => {
         ]);
         render(createTestComponent({ proposal }));
 
-        // 750 / (750 + 250) = 75%
+        // CORRECT calculation: 750 / (750 + 250) = 75%
         // WRONG: winning-option / all-votes (750 / 1500 = 50%)
         const progressbar = screen.getByRole('progressbar');
         expect(progressbar.dataset.value).toEqual('75');
@@ -175,7 +175,7 @@ describe('<TokenProposalVotingSummary /> component', () => {
     });
 
     it('displays the approved status when proposal is executed and approval is reached', () => {
-        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.EXECUTED);
         const proposal = generateTestProposal(
             [
                 { type: VoteOption.YES, totalVotingPower: '7500' },
@@ -193,8 +193,8 @@ describe('<TokenProposalVotingSummary /> component', () => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     });
 
-    it('displays the vetoed status when veto proposal is executed and approval is reached', () => {
-        getProposalStatusSpy.mockReturnValue(ProposalStatus.ACTIVE);
+    it('displays the vetoed status when veto proposal has failed and approval is reached', () => {
+        getProposalStatusSpy.mockReturnValue(ProposalStatus.FAILED);
         const proposal = generateTestProposal(
             [
                 { type: VoteOption.YES, totalVotingPower: '7500' },
@@ -202,9 +202,7 @@ describe('<TokenProposalVotingSummary /> component', () => {
             ],
             { minParticipation: 200_000, historicalTotalSupply: '10000' },
         );
-        render(
-            createTestComponent({ proposal, isVeto: true, isExecuted: true }),
-        );
+        render(createTestComponent({ proposal, isVeto: true }));
 
         const status = screen.getByText(
             'app.plugins.token.tokenProposalVotingSummary.vetoed',

--- a/apps/app/src/plugins/tokenPlugin/components/tokenProposalVotingSummary/tokenProposalVotingSummary.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenProposalVotingSummary/tokenProposalVotingSummary.tsx
@@ -76,17 +76,17 @@ export const TokenProposalVotingSummary: React.FC<
         countableTotalVotes,
         { format: NumberFormat.GENERIC_SHORT },
     );
+
     const supportPercentage =
         countableTotalVotes > 0 ? (yesVotes / countableTotalVotes) * 100 : 0;
-
     const formattedYesVotes = formatterUtils.formatNumber(yesVotes, {
         format: NumberFormat.GENERIC_SHORT,
     });
 
     const supportThresholdPercentage =
         tokenSettingsUtils.ratioToPercentage(supportThreshold);
-    const supportReached = supportPercentage >= supportThresholdPercentage;
 
+    const isSupportReached = tokenProposalUtils.isSupportReached(proposal);
     const isApprovalReached = tokenProposalUtils.isApprovalReached(proposal);
 
     if (status !== ProposalStatus.ACTIVE || isExecuted) {
@@ -130,7 +130,7 @@ export const TokenProposalVotingSummary: React.FC<
             <Progress
                 thresholdIndicator={supportThresholdPercentage}
                 value={supportPercentage}
-                variant={supportReached ? 'primary' : 'neutral'}
+                variant={isSupportReached ? 'primary' : 'neutral'}
             />
             <p className="font-normal text-neutral-800 text-sm leading-tight md:text-base">
                 {formattedYesVotes}{' '}

--- a/apps/app/src/plugins/tokenPlugin/components/tokenProposalVotingSummary/tokenProposalVotingSummary.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenProposalVotingSummary/tokenProposalVotingSummary.tsx
@@ -59,9 +59,6 @@ export const TokenProposalVotingSummary: React.FC<
     const noVotes = Number(
         tokenProposalUtils.getOptionVotingPower(proposal, VoteOption.NO),
     );
-    const abstainVotes = Number(
-        tokenProposalUtils.getOptionVotingPower(proposal, VoteOption.ABSTAIN),
-    );
 
     const tokenTotalSupply = formatUnits(
         bigIntUtils.safeParse(historicalTotalSupply),
@@ -74,22 +71,21 @@ export const TokenProposalVotingSummary: React.FC<
         'TokenProposalVotingSummary: tokenTotalSupply must be a positive number',
     );
 
-    const totalVotes = yesVotes + noVotes + abstainVotes;
-    const formattedTotalVotes = formatterUtils.formatNumber(totalVotes, {
-        format: NumberFormat.GENERIC_SHORT,
-    })!;
+    const countableTotalVotes = yesVotes + noVotes;
+    const formattedCountableTotalVotes = formatterUtils.formatNumber(
+        countableTotalVotes,
+        { format: NumberFormat.GENERIC_SHORT },
+    );
+    const supportPercentage =
+        countableTotalVotes > 0 ? (yesVotes / countableTotalVotes) * 100 : 0;
 
-    const winningOption = Math.max(yesVotes, noVotes, abstainVotes);
-    const winningOptionPercentage =
-        totalVotes > 0 ? (winningOption / totalVotes) * 100 : 0;
-    const formattedWinningOption = formatterUtils.formatNumber(winningOption, {
+    const formattedYesVotes = formatterUtils.formatNumber(yesVotes, {
         format: NumberFormat.GENERIC_SHORT,
     });
 
     const supportThresholdPercentage =
         tokenSettingsUtils.ratioToPercentage(supportThreshold);
-    const supportReached =
-        winningOptionPercentage >= supportThresholdPercentage;
+    const supportReached = supportPercentage >= supportThresholdPercentage;
 
     const isApprovalReached = tokenProposalUtils.isApprovalReached(proposal);
 
@@ -133,16 +129,16 @@ export const TokenProposalVotingSummary: React.FC<
             </p>
             <Progress
                 thresholdIndicator={supportThresholdPercentage}
-                value={winningOptionPercentage}
+                value={supportPercentage}
                 variant={supportReached ? 'primary' : 'neutral'}
             />
             <p className="font-normal text-neutral-800 text-sm leading-tight md:text-base">
-                {formattedWinningOption}{' '}
+                {formattedYesVotes}{' '}
                 <span className="text-neutral-500">
                     {t(
                         'app.plugins.token.tokenProposalVotingSummary.votesDescription',
                         {
-                            details: `${formattedTotalVotes} ${symbol}`,
+                            details: `${formattedCountableTotalVotes} ${symbol}`,
                         },
                     )}
                 </span>


### PR DESCRIPTION
# Description

The token and lock-to-vote proposal voting summary panels were showing the winning option's vote share (yes/no/abstain, whichever had the most votes) labeled as support-threshold progress. This mixed two different concepts: the underlying numbers came from the winning option, while the label/presentation implied support-threshold status — so a proposal with 100% "no" votes could visually read as support reached.

This PR aligns the overview panel with the same support-threshold calculation used in the vote breakdown component: countable votes are `yes + no` (abstain excluded), support percentage is `yes / countableVotes`, and reached/not-reached now comes from `isSupportReached` on the proposal utils instead of a locally recomputed winning-option comparison.

Fixes [APP-988](https://linear.app/aragon/issue/APP-988/token-panel-body-overview-falsely-shows-veto-support-reached).

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project