### PR TITLE
feat: Reorder chains in DAO creation

### DIFF
--- a/.changeset/reorder-dao-creation-chains.md
+++ b/.changeset/reorder-dao-creation-chains.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Reorder the chains shown during DAO creation.

--- a/apps/app/src/shared/constants/networkDefinitions.ts
+++ b/apps/app/src/shared/constants/networkDefinitions.ts
@@ -134,7 +134,7 @@ export const networkDefinitions: Record<Network, INetworkDefinition> = {
             rpcProvider: RpcProvider.ALCHEMY,
             rpcUrl: 'https://polygon-mainnet.g.alchemy.com/v2/',
         },
-        order: 4,
+        order: 5,
         protocolVersion: latestProtocolVersion,
         tenderlySupport: true,
         addresses: {
@@ -172,7 +172,7 @@ export const networkDefinitions: Record<Network, INetworkDefinition> = {
             rpcProvider: RpcProvider.ALCHEMY,
             rpcUrl: 'https://arb-mainnet.g.alchemy.com/v2/',
         },
-        order: 3,
+        order: 4,
         protocolVersion: latestProtocolVersion,
         tenderlySupport: true,
         addresses: {
@@ -191,7 +191,7 @@ export const networkDefinitions: Record<Network, INetworkDefinition> = {
             rpcProvider: RpcProvider.ALCHEMY,
             rpcUrl: 'https://opt-mainnet.g.alchemy.com/v2/',
         },
-        order: 6,
+        order: 7,
         protocolVersion: latestProtocolVersion,
         tenderlySupport: true,
         addresses: {
@@ -210,7 +210,7 @@ export const networkDefinitions: Record<Network, INetworkDefinition> = {
             rpcProvider: RpcProvider.ALCHEMY,
             rpcUrl: 'https://avax-mainnet.g.alchemy.com/v2/',
         },
-        order: 5,
+        order: 6,
         protocolVersion: latestProtocolVersion,
         tenderlySupport: true,
         addresses: {
@@ -341,7 +341,7 @@ export const networkDefinitions: Record<Network, INetworkDefinition> = {
             rpcProvider: RpcProvider.DRPC,
             rpcUrl: 'https://lb.drpc.live/monad/',
         },
-        order: 7,
+        order: 3,
         protocolVersion: latestProtocolVersion,
         tenderlySupport: true,
         addresses: {


### PR DESCRIPTION
## Description

Request from Anthony to reorder the chains shown during DAO creation to prioritize Sepolia, Ethereum, Base, Monad, Arbitrum, and Polygon while preserving the existing relative order of the remaining chains.

Adds a patch changeset for `@aragon/app`.

## Type of Change

- [x] Patch: Enhancement (non-breaking change to an existing feature)

