### PR TITLE
feat(APP-266): add the assistant-chat widget package (p3)

### DIFF
--- a/.changeset/assistant-chat-widget.md
+++ b/.changeset/assistant-chat-widget.md
@@ -1,0 +1,5 @@
+---
+"@aragon/assistant-chat": minor
+---
+
+Add the assistant-chat widget package: side-drawer support chat backed by the assistant service, with live collected-fields summary, file attachments (picker, drag-and-drop, paste) with upload progress, explicit ticket creation with retry, session rotation after a created issue and a monitoring DI seam for the host app.

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -27,6 +27,7 @@ app:
 assistant:
   - "apps/assistant/**"
   - "packages/assistant-contracts/**"
+  - "packages/assistant-chat/**"
   - ".github/workflows/assistant-*.yml"
   - ".github/workflows/shared-deploy.yml"
   - ".github/filters.yml"

--- a/.github/workflows/assistant-release-version.yml
+++ b/.github/workflows/assistant-release-version.yml
@@ -58,15 +58,14 @@ jobs:
       - name: Recreate version branch from main
         run: git checkout -B changeset-release/assistant main
 
-      # This flow owns the assistant domain: @aragon/assistant plus its version-only contracts
-      # package. App-scoped packages are versioned by the app release flow (app-release-start.yml),
-      # which symmetrically scopes to @aragon/app.
-      # NOTE: @aragon/assistant-chat ownership will be decided when the widget package lands
-      # (Feature/Wire-up PR).
+      # This flow owns the assistant domain: @aragon/assistant plus its version-only packages
+      # (contracts and the assistant-chat widget, which ships inside the app but is released by
+      # its domain owner). App-scoped packages are versioned by the app release flow
+      # (app-release-start.yml), which symmetrically scopes to @aragon/app.
       - name: Update version and changelog
         uses: ./.github/actions/changeset-version
         with:
-          scope: "@aragon/assistant @aragon/assistant-contracts"
+          scope: "@aragon/assistant @aragon/assistant-contracts @aragon/assistant-chat"
           prettier_changelog: "true"
           github_token: ${{ steps.load-secrets.outputs.ARABOT_PAT }}
 

--- a/packages/assistant-chat/jest.config.js
+++ b/packages/assistant-chat/jest.config.js
@@ -1,0 +1,22 @@
+const { baseConfig, createTsJestTransform } = require('../../jest.config.base');
+
+/** @type {import('@jest/types').Config.InitialOptions} */
+const config = {
+    ...baseConfig,
+    testEnvironment: 'jsdom',
+    collectCoverageFrom: ['./src/**/*.{ts,tsx}'],
+    coveragePathIgnorePatterns: ['.d.ts', '.api.ts', 'index.ts', '/src/test'],
+    setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
+    transform: createTsJestTransform({
+        target: 'ES2020',
+        allowJs: true,
+        jsx: 'react-jsx',
+    }),
+    // Allow transforming specific ESM deps even under pnpm's nested layout
+    // e.g. node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>/...
+    transformIgnorePatterns: [
+        'node_modules/(?!(?:\\.pnpm/[^/]+/node_modules/)?(@aragon/gov-ui-kit|wagmi|@wagmi|use-sync-external-store|react-merge-refs|ai|@ai-sdk|@workflow|swr|throttleit|react-dropzone|file-selector|@vercel/blob|@vercel/oidc|jose)(/|$))',
+    ],
+};
+
+module.exports = config;

--- a/packages/assistant-chat/package.json
+++ b/packages/assistant-chat/package.json
@@ -1,0 +1,68 @@
+{
+    "name": "@aragon/assistant-chat",
+    "version": "0.1.0",
+    "description": "Support-chat widget for the Aragon App, backed by the Aragon assistant service",
+    "author": "Aragon Association",
+    "homepage": "https://github.com/aragon/app#readme",
+    "private": true,
+    "license": "GPL-3.0",
+    "main": "src/index.ts",
+    "types": "src/index.ts",
+    "sideEffects": false,
+    "scripts": {
+        "test": "jest",
+        "test:changed": "jest --ci --passWithNoTests --changedSince=\"$(git merge-base HEAD origin/main 2>/dev/null || echo main)\"",
+        "test:watch": "jest --watch",
+        "test:coverage": "jest --coverage",
+        "lint": "biome check --write --no-errors-on-unmatched --files-ignore-unknown=true",
+        "lint:check": "biome check --no-errors-on-unmatched --files-ignore-unknown=true",
+        "type-check": "tsc --noEmit"
+    },
+    "peerDependencies": {
+        "@aragon/gov-ui-kit": "^2.8.1",
+        "@tanstack/react-query": "^5.101.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+    },
+    "dependencies": {
+        "@ai-sdk/react": "catalog:",
+        "@aragon/assistant-contracts": "workspace:*",
+        "@radix-ui/react-dialog": "catalog:",
+        "@vercel/blob": "catalog:",
+        "ai": "catalog:",
+        "classnames": "catalog:",
+        "react-dropzone": "catalog:",
+        "zod": "catalog:"
+    },
+    "devDependencies": {
+        "@aragon/gov-ui-kit": "catalog:",
+        "@biomejs/biome": "catalog:",
+        "@tailwindcss/typography": "catalog:",
+        "@tanstack/react-query": "catalog:",
+        "@testing-library/dom": "catalog:",
+        "@testing-library/jest-dom": "catalog:",
+        "@testing-library/react": "catalog:",
+        "@testing-library/user-event": "catalog:",
+        "@types/jest": "catalog:",
+        "@types/node": "catalog:",
+        "@types/react": "catalog:",
+        "@types/react-dom": "catalog:",
+        "jest": "catalog:",
+        "jest-environment-jsdom": "catalog:",
+        "react": "catalog:",
+        "react-dom": "catalog:",
+        "react-hook-form": "catalog:",
+        "tailwindcss": "catalog:",
+        "ts-jest": "catalog:",
+        "typescript": "catalog:",
+        "viem": "catalog:",
+        "wagmi": "catalog:"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/aragon/app.git"
+    },
+    "engines": {
+        "node": ">=24.16.0"
+    }
+}

--- a/packages/assistant-chat/src/components/assistantChat/assistantChat.api.ts
+++ b/packages/assistant-chat/src/components/assistantChat/assistantChat.api.ts
@@ -1,0 +1,31 @@
+import type { IAppContext } from '@aragon/assistant-contracts';
+import type { IChatMonitoring } from '../../monitoring';
+
+export interface IAssistantChatProps {
+    /**
+     * Whether the chat drawer is open.
+     */
+    isOpen: boolean;
+    /**
+     * Called when the drawer requests to close.
+     */
+    onClose: () => void;
+    /**
+     * Base URL of the assistant service (no trailing slash).
+     */
+    assistantUrl: string;
+    /**
+     * Context of the app captured at open time, sent alongside every request.
+     */
+    appContext: IAppContext;
+    /**
+     * Fallback support-portal URL offered as an escape hatch when the chat hard-fails (e.g. rate
+     * limited or the service is unreachable), so the user can always file a request the old way.
+     */
+    supportPortalUrl?: string;
+    /**
+     * Monitoring implementation injected by the host app.
+     * @default noopMonitoring
+     */
+    monitoring?: IChatMonitoring;
+}

--- a/packages/assistant-chat/src/components/assistantChat/assistantChat.test.tsx
+++ b/packages/assistant-chat/src/components/assistantChat/assistantChat.test.tsx
@@ -1,0 +1,270 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { IChatMonitoring } from '../../monitoring';
+import { AssistantChat } from './assistantChat';
+
+// Integration tests of the whole widget: real controller, hooks and AI SDK transport — only the
+// network is faked. A failure here means a broken user flow, not a changed implementation detail.
+
+const assistantUrl = 'https://assistant.test';
+
+// AI SDK UI message stream: SSE with one JSON chunk per event, terminated by [DONE]. The stream
+// carries the conversation only — ticket state goes through the explicit preview flow.
+const chatStreamChunks = [
+    { type: 'start' },
+    { type: 'text-start', id: 'text-1' },
+    {
+        type: 'text-delta',
+        id: 'text-1',
+        delta: 'Thanks, that is everything we need!',
+    },
+    { type: 'text-end', id: 'text-1' },
+    { type: 'finish' },
+];
+
+const createHeaders = (entries: Record<string, string>) => ({
+    get: (name: string) => entries[name.toLowerCase()] ?? null,
+});
+
+const createChatResponse = (): Response => {
+    const events = chatStreamChunks
+        .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
+        .join('');
+    const body = new ReadableStream<Uint8Array>({
+        start: (controller) => {
+            controller.enqueue(
+                new TextEncoder().encode(`${events}data: [DONE]\n\n`),
+            );
+            controller.close();
+        },
+    });
+
+    return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: createHeaders({
+            'content-type': 'text/event-stream',
+            'x-vercel-ai-ui-message-stream': 'v1',
+        }),
+        body,
+    } as unknown as Response;
+};
+
+const createJsonResponse = (status: number, body: unknown): Response =>
+    ({
+        ok: status < 400,
+        status,
+        statusText: '',
+        headers: createHeaders({ 'content-type': 'application/json' }),
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(JSON.stringify(body)),
+        body: null,
+    }) as unknown as Response;
+
+const readyPreview = {
+    status: 'ready',
+    summary: 'Proposal page crashes',
+    intent: 'bug',
+};
+
+const createdIssue = {
+    issueId: 'issue-1',
+    identifier: 'SUP-123',
+    url: 'https://linear.app/aragon/issue/SUP-123',
+    alreadyExisted: false,
+};
+
+describe('<AssistantChat /> integration', () => {
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn<Promise<Response>, [RequestInfo | URL]>();
+
+    let previewResponses: Response[] = [];
+    let issueResponses: Response[] = [];
+
+    const issueCalls = () =>
+        fetchMock.mock.calls.filter(([input]) =>
+            input.toString().endsWith('/issues'),
+        );
+
+    beforeEach(() => {
+        localStorage.clear();
+        previewResponses = [];
+        issueResponses = [];
+        fetchMock.mockReset();
+        fetchMock.mockImplementation((input) => {
+            const url = input.toString();
+
+            if (url === `${assistantUrl}/chat`) {
+                return Promise.resolve(createChatResponse());
+            }
+
+            if (url === `${assistantUrl}/issues/preview`) {
+                const next = previewResponses.shift();
+
+                if (next == null) {
+                    throw new Error('Unexpected /issues/preview call');
+                }
+
+                return Promise.resolve(next);
+            }
+
+            if (url === `${assistantUrl}/issues`) {
+                const next = issueResponses.shift();
+
+                if (next == null) {
+                    throw new Error('Unexpected /issues call');
+                }
+
+                return Promise.resolve(next);
+            }
+
+            throw new Error(`Unexpected fetch to ${url}`);
+        });
+        global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterAll(() => {
+        global.fetch = originalFetch;
+    });
+
+    const renderWidget = (monitoring?: IChatMonitoring) =>
+        render(
+            <QueryClientProvider client={new QueryClient()}>
+                <AssistantChat
+                    appContext={{ route: '/dashboard', appVersion: '1.0.0' }}
+                    assistantUrl={assistantUrl}
+                    isOpen={true}
+                    monitoring={monitoring}
+                    onClose={jest.fn()}
+                />
+            </QueryClientProvider>,
+        );
+
+    const chatOneTurn = async () => {
+        const composer = await screen.findByRole('textbox', {
+            name: 'Message',
+        });
+        await userEvent.type(
+            composer,
+            'The proposal page crashes on load.{Enter}',
+        );
+
+        expect(
+            await screen.findByText('Thanks, that is everything we need!'),
+        ).toBeInTheDocument();
+    };
+
+    const prepareUntilReady = async () => {
+        await chatOneTurn();
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Prepare ticket' }),
+        );
+
+        // The reviewed preview: the ticket title the server distilled, offered for sending.
+        expect(
+            await screen.findByText('Proposal page crashes'),
+        ).toBeInTheDocument();
+
+        return screen.getByRole('button', { name: 'Send ticket' });
+    };
+
+    it('previews the ticket from the conversation and creates it exactly once', async () => {
+        // The creation response is deferred so the second click below lands while the request
+        // is still in flight — the window in which a double POST would duplicate the ticket.
+        let resolveIssue!: (response: Response) => void;
+        const deferredIssue = new Promise<Response>((resolve) => {
+            resolveIssue = resolve;
+        });
+        fetchMock.mockImplementation((input) => {
+            const url = input.toString();
+
+            if (url === `${assistantUrl}/chat`) {
+                return Promise.resolve(createChatResponse());
+            }
+
+            if (url === `${assistantUrl}/issues/preview`) {
+                return Promise.resolve(createJsonResponse(200, readyPreview));
+            }
+
+            if (url === `${assistantUrl}/issues`) {
+                return deferredIssue;
+            }
+
+            throw new Error(`Unexpected fetch to ${url}`);
+        });
+        renderWidget();
+
+        const sendButton = await prepareUntilReady();
+        expect(screen.getByText('Ready to send')).toBeInTheDocument();
+
+        // A double click must not create a second ticket.
+        await userEvent.click(sendButton);
+        await userEvent.click(sendButton);
+        resolveIssue(createJsonResponse(201, createdIssue));
+
+        expect(await screen.findByText('Request created')).toBeInTheDocument();
+        expect(screen.getByText('SUP-123')).toBeInTheDocument();
+        expect(issueCalls()).toHaveLength(1);
+
+        // One ticket = one chat: the composer is replaced by the new-chat bar.
+        expect(
+            screen.getByRole('button', { name: 'Start new chat' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('textbox', { name: 'Message' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('keeps collecting when the preview finds no actionable request', async () => {
+        previewResponses = [createJsonResponse(200, { status: 'unclear' })];
+        renderWidget();
+
+        await chatOneTurn();
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Prepare ticket' }),
+        );
+
+        // The honest outcome: no ticket offered, the user is nudged to keep talking.
+        expect(
+            await screen.findByText(/tell us a bit more/),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Send ticket' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows the error panel on a failed creation and recovers through retry', async () => {
+        previewResponses = [createJsonResponse(200, readyPreview)];
+        issueResponses = [
+            createJsonResponse(502, {
+                error: { code: 'internal', message: 'Linear is unreachable.' },
+            }),
+            createJsonResponse(201, createdIssue),
+        ];
+        const monitoring: IChatMonitoring = {
+            logError: jest.fn(),
+            logMessage: jest.fn(),
+        };
+        renderWidget(monitoring);
+
+        const sendButton = await prepareUntilReady();
+        await userEvent.click(sendButton);
+
+        expect(
+            await screen.findByText("We couldn't create your request"),
+        ).toBeInTheDocument();
+
+        // The refusal is reported with the error code only — never with user content.
+        expect(monitoring.logMessage).toHaveBeenCalledWith(
+            'assistantChat: createIssue failed',
+            { level: 'warning', context: { code: 'internal' } },
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+        expect(await screen.findByText('Request created')).toBeInTheDocument();
+        expect(issueCalls()).toHaveLength(2);
+    });
+});

--- a/packages/assistant-chat/src/components/assistantChat/assistantChat.tsx
+++ b/packages/assistant-chat/src/components/assistantChat/assistantChat.tsx
@@ -1,0 +1,67 @@
+import { useDropzone } from 'react-dropzone';
+import {
+    AssistantChatProvider,
+    useAssistantChatController,
+} from '../../controller';
+import { noopMonitoring } from '../../monitoring';
+import { ChatComposer } from '../chatComposer';
+import { ChatDrawer } from '../chatDrawer';
+import { ChatDropOverlay } from '../chatDropOverlay';
+import { ChatHeader } from '../chatHeader';
+import { ChatMessageList } from '../chatMessageList';
+import { ChatNewChatBar } from '../chatNewChatBar';
+import { ChatStatusStrip } from '../chatStatusStrip';
+import type { IAssistantChatProps } from './assistantChat.api';
+
+export const AssistantChat: React.FC<IAssistantChatProps> = (props) => {
+    const {
+        isOpen,
+        onClose,
+        assistantUrl,
+        appContext,
+        supportPortalUrl,
+        monitoring = noopMonitoring,
+    } = props;
+
+    const controller = useAssistantChatController({
+        assistantUrl,
+        appContext,
+        supportPortalUrl,
+        monitoring,
+    });
+
+    const isLocked = controller.flowState === 'issueCreated';
+
+    // One addFiles entry point for all three attach paths: the dropzone covers picker (open) and
+    // drag-and-drop, the composer forwards clipboard pastes. Type and size filtering happens
+    // inside addFiles so all paths share it.
+    const { getRootProps, getInputProps, open, isDragActive } = useDropzone({
+        noClick: true,
+        noKeyboard: true,
+        disabled: isLocked,
+        onDrop: controller.addFiles,
+    });
+
+    return (
+        <AssistantChatProvider value={controller}>
+            <ChatDrawer isOpen={isOpen} onClose={onClose}>
+                <div
+                    {...getRootProps({
+                        className: 'relative flex h-full min-h-0 flex-col',
+                    })}
+                >
+                    <input {...getInputProps()} />
+                    <ChatHeader onClose={onClose} />
+                    <ChatMessageList />
+                    <ChatStatusStrip />
+                    {isLocked ? (
+                        <ChatNewChatBar />
+                    ) : (
+                        <ChatComposer onAttach={open} />
+                    )}
+                    <ChatDropOverlay isVisible={isDragActive} />
+                </div>
+            </ChatDrawer>
+        </AssistantChatProvider>
+    );
+};

--- a/packages/assistant-chat/src/components/assistantChat/index.ts
+++ b/packages/assistant-chat/src/components/assistantChat/index.ts
@@ -1,0 +1,2 @@
+export { AssistantChat } from './assistantChat';
+export type { IAssistantChatProps } from './assistantChat.api';

--- a/packages/assistant-chat/src/components/chatAttachmentList/chatAttachmentList.tsx
+++ b/packages/assistant-chat/src/components/chatAttachmentList/chatAttachmentList.tsx
@@ -1,0 +1,68 @@
+import {
+    AvatarIcon,
+    Button,
+    IconType,
+    Progress,
+    Spinner,
+} from '@aragon/gov-ui-kit';
+import classNames from 'classnames';
+import { useAssistantChatContext } from '../../controller';
+import { formatFileSize } from './formatFileSize';
+
+export const ChatAttachmentList: React.FC = () => {
+    const { attachments, removeFile } = useAssistantChatContext();
+
+    if (attachments.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            {attachments.map((attachment) => (
+                <div
+                    className={classNames(
+                        'flex items-center gap-2 rounded-xl border border-neutral-100 bg-neutral-0 px-2.5 py-1.5',
+                        { 'opacity-50': attachment.status === 'removing' },
+                    )}
+                    key={attachment.id}
+                >
+                    <AvatarIcon icon={IconType.COPY} size="sm" />
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
+                        <div className="flex items-baseline gap-1.5">
+                            <p className="truncate text-neutral-800 text-xs">
+                                {attachment.filename}
+                            </p>
+                            <p className="flex-none text-neutral-500 text-xs">
+                                {formatFileSize(attachment.size)}
+                            </p>
+                        </div>
+                        {attachment.status === 'uploading' && (
+                            <Progress
+                                size="sm"
+                                value={Math.round(attachment.progress * 100)}
+                            />
+                        )}
+                        {attachment.status === 'error' && (
+                            <p className="text-critical-800 text-xs">
+                                Upload failed
+                            </p>
+                        )}
+                    </div>
+                    {attachment.status === 'removing' ? (
+                        <div aria-label="Removing file" role="status">
+                            <Spinner size="sm" variant="neutral" />
+                        </div>
+                    ) : (
+                        <Button
+                            aria-label="Remove file"
+                            iconLeft={IconType.CLOSE}
+                            onClick={() => removeFile(attachment.id)}
+                            size="sm"
+                            variant="tertiary"
+                        />
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/packages/assistant-chat/src/components/chatAttachmentList/formatFileSize.ts
+++ b/packages/assistant-chat/src/components/chatAttachmentList/formatFileSize.ts
@@ -1,0 +1,14 @@
+const kiloByte = 1024;
+const megaByte = 1024 * 1024;
+
+export const formatFileSize = (bytes: number): string => {
+    if (bytes >= megaByte) {
+        return `${(bytes / megaByte).toFixed(1)} MB`;
+    }
+
+    if (bytes >= kiloByte) {
+        return `${Math.round(bytes / kiloByte)} KB`;
+    }
+
+    return `${bytes} B`;
+};

--- a/packages/assistant-chat/src/components/chatAttachmentList/index.ts
+++ b/packages/assistant-chat/src/components/chatAttachmentList/index.ts
@@ -1,0 +1,2 @@
+export { ChatAttachmentList } from './chatAttachmentList';
+export { formatFileSize } from './formatFileSize';

--- a/packages/assistant-chat/src/components/chatComposer/chatComposer.tsx
+++ b/packages/assistant-chat/src/components/chatComposer/chatComposer.tsx
@@ -1,0 +1,123 @@
+import { AlertInline, Button, IconType } from '@aragon/gov-ui-kit';
+import { useAssistantChatContext } from '../../controller';
+import { ChatAttachmentList } from '../chatAttachmentList';
+import { buildFileAlertMessage } from './fileAlertMessage';
+
+export interface IChatComposerProps {
+    /**
+     * Opens the native file picker.
+     */
+    onAttach: () => void;
+}
+
+const maxVisibleRows = 4;
+
+export const ChatComposer: React.FC<IChatComposerProps> = (props) => {
+    const { onAttach } = props;
+
+    const {
+        sendMessage,
+        stop,
+        chatStatus,
+        flowState,
+        isUploading,
+        addFiles,
+        attachments,
+        fileAlert,
+        dismissFileAlert,
+        composerInput: input,
+        setComposerInput: setInput,
+    } = useAssistantChatContext();
+
+    const isStreaming =
+        chatStatus === 'submitted' || chatStatus === 'streaming';
+    const canSend =
+        input.trim().length > 0 &&
+        !(isStreaming || isUploading) &&
+        flowState !== 'creatingIssue';
+
+    const handleSend = () => {
+        if (!canSend) {
+            return;
+        }
+
+        sendMessage(input.trim());
+        setInput('');
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault();
+            handleSend();
+        }
+    };
+
+    const handlePaste = (event: React.ClipboardEvent) => {
+        const files = Array.from(event.clipboardData.files);
+
+        if (files.length > 0) {
+            event.preventDefault();
+            addFiles(files);
+        }
+    };
+
+    const rows = Math.min(
+        maxVisibleRows,
+        Math.max(1, input.split('\n').length),
+    );
+
+    return (
+        <div className="flex flex-none flex-col gap-2 border-neutral-100 border-t px-5 pt-2.5 pb-3.5">
+            {fileAlert != null && (
+                <div className="flex items-center justify-between gap-2">
+                    <AlertInline
+                        message={buildFileAlertMessage(fileAlert)}
+                        variant="critical"
+                    />
+                    <Button
+                        aria-label="Dismiss"
+                        iconLeft={IconType.CLOSE}
+                        onClick={dismissFileAlert}
+                        size="sm"
+                        variant="ghost"
+                    />
+                </div>
+            )}
+            <ChatAttachmentList />
+            {attachments.length > 0 && (
+                <p className="text-neutral-300 text-xs leading-normal">
+                    Attachments are shared with the support team.
+                </p>
+            )}
+            <div className="flex items-end gap-2">
+                <Button
+                    aria-label="Attach file"
+                    iconLeft={IconType.PLUS}
+                    onClick={onAttach}
+                    size="md"
+                    variant="tertiary"
+                />
+                <textarea
+                    aria-label="Message"
+                    className="min-w-0 flex-1 resize-none rounded-xl border border-neutral-100 bg-neutral-0 px-3.5 py-2.5 text-neutral-800 text-sm leading-normal outline-none transition-colors placeholder:text-neutral-300 focus:border-primary-400"
+                    onChange={(event) => setInput(event.target.value)}
+                    onKeyDown={handleKeyDown}
+                    onPaste={handlePaste}
+                    placeholder="Message…"
+                    rows={rows}
+                    value={input}
+                />
+                {/* One persistent button that swaps action: unmounting Stop mid-stream would
+                    drop keyboard focus to the body. */}
+                <Button
+                    disabled={!(isStreaming || canSend)}
+                    onClick={isStreaming ? stop : handleSend}
+                    size="md"
+                    variant={isStreaming ? 'secondary' : 'primary'}
+                >
+                    {isStreaming ? 'Stop' : 'Send'}
+                </Button>
+            </div>
+        </div>
+    );
+};

--- a/packages/assistant-chat/src/components/chatComposer/fileAlertMessage.ts
+++ b/packages/assistant-chat/src/components/chatComposer/fileAlertMessage.ts
@@ -1,0 +1,21 @@
+import { assistantLimits } from '@aragon/assistant-contracts';
+import type { IFileAlert } from '../../files';
+
+const maxFileSizeMb = Math.round(
+    assistantLimits.maxFileSizeBytes / (1024 * 1024),
+);
+
+// Kept deliberately short and filename-free: the filename is what made the alert wrap into a wall
+// of text, and the user can already see which file they just picked.
+export const buildFileAlertMessage = (alert: IFileAlert): string => {
+    switch (alert.reason) {
+        case 'too_large':
+            return `File too large (max ${maxFileSizeMb} MB).`;
+        case 'unsupported':
+            return 'Unsupported file. Use an image, text, log or PDF.';
+        case 'remove_failed':
+            return "Couldn't remove the file. Please try again.";
+        default:
+            return `You can attach up to ${assistantLimits.maxFilesPerSession} files.`;
+    }
+};

--- a/packages/assistant-chat/src/components/chatComposer/index.ts
+++ b/packages/assistant-chat/src/components/chatComposer/index.ts
@@ -1,0 +1,1 @@
+export { ChatComposer, type IChatComposerProps } from './chatComposer';

--- a/packages/assistant-chat/src/components/chatDrawer/chatDrawer.tsx
+++ b/packages/assistant-chat/src/components/chatDrawer/chatDrawer.tsx
@@ -1,0 +1,46 @@
+import * as Dialog from '@radix-ui/react-dialog';
+
+export interface IChatDrawerProps {
+    /**
+     * Whether the drawer is open.
+     */
+    isOpen: boolean;
+    /**
+     * Called when the drawer requests to close (esc, overlay click, close button).
+     */
+    onClose: () => void;
+    /**
+     * Content of the drawer panel.
+     */
+    children: React.ReactNode;
+}
+
+// Built on Radix Dialog directly: the gov-ui-kit DialogRoot is hardcoded to a centered modal and
+// cannot render a side panel. The z-index tokens are the ones the host app already sets for
+// gov-ui-kit dialogs, so no extra wiring is needed.
+export const ChatDrawer: React.FC<IChatDrawerProps> = (props) => {
+    const { isOpen, onClose, children } = props;
+
+    const handleOpenChange = (open: boolean) => {
+        if (!open) {
+            onClose();
+        }
+    };
+
+    return (
+        <Dialog.Root onOpenChange={handleOpenChange} open={isOpen}>
+            <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 z-[var(--guk-dialog-overlay-z-index)] bg-gradient-to-t from-neutral-100/90 to-neutral-100/20 backdrop-blur-md" />
+                <Dialog.Content
+                    aria-describedby={undefined}
+                    className="fixed inset-y-0 right-0 z-[var(--guk-dialog-content-z-index)] flex h-dvh w-full flex-col border-neutral-100 border-l bg-neutral-0 shadow-neutral-md md:w-[clamp(500px,30vw,640px)]"
+                >
+                    <Dialog.Title className="sr-only">
+                        Aragon Support Assistant
+                    </Dialog.Title>
+                    {children}
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+};

--- a/packages/assistant-chat/src/components/chatDrawer/index.ts
+++ b/packages/assistant-chat/src/components/chatDrawer/index.ts
@@ -1,0 +1,1 @@
+export { ChatDrawer, type IChatDrawerProps } from './chatDrawer';

--- a/packages/assistant-chat/src/components/chatDropOverlay/chatDropOverlay.tsx
+++ b/packages/assistant-chat/src/components/chatDropOverlay/chatDropOverlay.tsx
@@ -1,0 +1,22 @@
+export interface IChatDropOverlayProps {
+    /**
+     * Whether files are currently dragged over the panel.
+     */
+    isVisible: boolean;
+}
+
+export const ChatDropOverlay: React.FC<IChatDropOverlayProps> = (props) => {
+    const { isVisible } = props;
+
+    if (!isVisible) {
+        return null;
+    }
+
+    return (
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-none bg-neutral-0/90 p-6">
+            <div className="flex h-full w-full items-center justify-center rounded-xl border-2 border-primary-400 border-dashed">
+                <p className="text-neutral-800 text-sm">Drop files to attach</p>
+            </div>
+        </div>
+    );
+};

--- a/packages/assistant-chat/src/components/chatDropOverlay/index.ts
+++ b/packages/assistant-chat/src/components/chatDropOverlay/index.ts
@@ -1,0 +1,1 @@
+export { ChatDropOverlay, type IChatDropOverlayProps } from './chatDropOverlay';

--- a/packages/assistant-chat/src/components/chatErrorPanel/chatErrorPanel.tsx
+++ b/packages/assistant-chat/src/components/chatErrorPanel/chatErrorPanel.tsx
@@ -1,0 +1,47 @@
+import { AlertCard, Button, IconType } from '@aragon/gov-ui-kit';
+import { useAssistantChatContext } from '../../controller';
+import { getAssistantErrorText } from '../../transport';
+
+export const ChatErrorPanel: React.FC = () => {
+    const { flowState, issueError, createIssue, supportPortalUrl } =
+        useAssistantChatContext();
+
+    if (flowState !== 'issueError') {
+        return null;
+    }
+
+    const description = getAssistantErrorText(
+        issueError?.code,
+        'Nothing was lost. Check your connection and try again.',
+    );
+
+    return (
+        <AlertCard
+            className="self-stretch"
+            message="We couldn't create your request"
+            variant="critical"
+        >
+            <div className="flex flex-col items-start gap-2 pt-1">
+                <p>{description}</p>
+                <Button
+                    iconLeft={IconType.RELOAD}
+                    onClick={createIssue}
+                    size="sm"
+                    variant="secondary"
+                >
+                    Retry
+                </Button>
+                {supportPortalUrl != null && (
+                    <a
+                        className="text-primary-400 text-sm leading-normal underline"
+                        href={supportPortalUrl}
+                        rel="noreferrer"
+                        target="_blank"
+                    >
+                        …or file your request via the support portal →
+                    </a>
+                )}
+            </div>
+        </AlertCard>
+    );
+};

--- a/packages/assistant-chat/src/components/chatErrorPanel/index.ts
+++ b/packages/assistant-chat/src/components/chatErrorPanel/index.ts
@@ -1,0 +1,1 @@
+export { ChatErrorPanel } from './chatErrorPanel';

--- a/packages/assistant-chat/src/components/chatHeader/chatHeader.tsx
+++ b/packages/assistant-chat/src/components/chatHeader/chatHeader.tsx
@@ -1,0 +1,44 @@
+import { AvatarIcon, Button, Heading, IconType } from '@aragon/gov-ui-kit';
+import { useAssistantChatContext } from '../../controller';
+
+export interface IChatHeaderProps {
+    /**
+     * Called when the close button is pressed.
+     */
+    onClose: () => void;
+}
+
+export const ChatHeader: React.FC<IChatHeaderProps> = (props) => {
+    const { onClose } = props;
+
+    const { supportPortalUrl } = useAssistantChatContext();
+
+    return (
+        <div className="relative flex flex-none items-center gap-2.5 bg-gradient-to-b from-neutral-50 to-transparent py-3 pr-13 pl-5">
+            <AvatarIcon icon={IconType.FEEDBACK} size="md" variant="primary" />
+            <Heading as="h2" size="h4">
+                Aragon Support Assistant
+            </Heading>
+            {/* Always-visible escape hatch: the classic support form stays one click away in
+                every flow state, not only on failures. */}
+            {supportPortalUrl != null && (
+                <a
+                    className="ml-auto truncate font-normal text-neutral-500 text-sm leading-normal underline"
+                    href={supportPortalUrl}
+                    rel="noreferrer"
+                    target="_blank"
+                >
+                    Support portal
+                </a>
+            )}
+            <Button
+                aria-label="Close"
+                className="!absolute top-3 right-3"
+                iconLeft={IconType.CLOSE}
+                onClick={onClose}
+                size="sm"
+                variant="tertiary"
+            />
+        </div>
+    );
+};

--- a/packages/assistant-chat/src/components/chatHeader/index.ts
+++ b/packages/assistant-chat/src/components/chatHeader/index.ts
@@ -1,0 +1,1 @@
+export { ChatHeader, type IChatHeaderProps } from './chatHeader';

--- a/packages/assistant-chat/src/components/chatMessageList/chatMessageItem.tsx
+++ b/packages/assistant-chat/src/components/chatMessageList/chatMessageItem.tsx
@@ -1,0 +1,38 @@
+import classNames from 'classnames';
+import type { AssistantUIMessage } from '../../transport';
+
+export interface IChatMessageItemProps {
+    /**
+     * Message to render; only its text parts are displayed.
+     */
+    message: AssistantUIMessage;
+}
+
+export const ChatMessageItem: React.FC<IChatMessageItemProps> = (props) => {
+    const { message } = props;
+
+    const isUser = message.role === 'user';
+
+    const text = message.parts
+        .filter((part) => part.type === 'text')
+        .map((part) => part.text)
+        .join('');
+
+    return (
+        <div
+            className={classNames(
+                'max-w-[85%] whitespace-pre-wrap px-3.5 py-2.5 text-sm leading-normal',
+                {
+                    'self-end rounded-tl-xl rounded-tr-xl rounded-br rounded-bl-xl bg-primary-400 text-neutral-0':
+                        isUser,
+                },
+                {
+                    'self-start rounded-tl-xl rounded-tr-xl rounded-br-xl rounded-bl bg-neutral-50 text-neutral-800':
+                        !isUser,
+                },
+            )}
+        >
+            {text}
+        </div>
+    );
+};

--- a/packages/assistant-chat/src/components/chatMessageList/chatMessageList.tsx
+++ b/packages/assistant-chat/src/components/chatMessageList/chatMessageList.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from 'react';
+import { useAssistantChatContext } from '../../controller';
+import {
+    type AssistantUIMessage,
+    getAssistantErrorText,
+    parseAssistantError,
+} from '../../transport';
+import { ChatErrorPanel } from '../chatErrorPanel';
+import { ChatRequestHistory } from '../chatRequestHistory';
+import { ChatSuccessPanel } from '../chatSuccessPanel';
+import { ChatMessageItem } from './chatMessageItem';
+import { ChatTypingIndicator } from './chatTypingIndicator';
+
+const greetingMessage: AssistantUIMessage = {
+    id: 'greeting',
+    role: 'assistant',
+    parts: [
+        {
+            type: 'text',
+            text: "Hi! Tell us what's going on and we'll get it to the right team.",
+        },
+    ],
+};
+
+// A user who scrolled up further than this is reading history; auto-follow pauses until they
+// scroll back near the bottom.
+const followThreshold = 100;
+
+export const ChatMessageList: React.FC = () => {
+    const {
+        sessionId,
+        messages,
+        chatStatus,
+        chatError,
+        flowState,
+        supportPortalUrl,
+    } = useAssistantChatContext();
+
+    const isTyping = chatStatus === 'submitted';
+
+    const chatErrorText = getAssistantErrorText(
+        parseAssistantError(chatError)?.code,
+        'Something went wrong. Please try sending your message again.',
+    );
+
+    const endRef = useRef<HTMLDivElement>(null);
+
+    // Whether the view is pinned to the bottom; recorded on scroll (before new content changes
+    // the geometry) so a user reading history is never yanked down by a streamed chunk.
+    const isFollowingRef = useRef(true);
+
+    // A fresh session starts pinned: clearing the transcript from scrollTop 0 fires no scroll
+    // event, so without the reset the ref could stay false into the new chat.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: sessionId triggers the reset, it is not read.
+    useEffect(() => {
+        isFollowingRef.current = true;
+    }, [sessionId]);
+
+    const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
+        const { scrollHeight, scrollTop, clientHeight } = event.currentTarget;
+        isFollowingRef.current =
+            scrollHeight - scrollTop - clientHeight < followThreshold;
+    };
+
+    // Follow the latest content: new messages, streaming chunks and flow panels.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: dependencies trigger the scroll, they are not read.
+    useEffect(() => {
+        if (isFollowingRef.current) {
+            endRef.current?.scrollIntoView({ block: 'end' });
+        }
+    }, [messages, isTyping, flowState]);
+
+    return (
+        <div
+            aria-live="polite"
+            className="flex flex-1 flex-col gap-3 overflow-y-auto px-5 pt-2 pb-4"
+            onScroll={handleScroll}
+        >
+            <ChatMessageItem message={greetingMessage} />
+            <ChatRequestHistory />
+            {messages.map((message) => (
+                <ChatMessageItem key={message.id} message={message} />
+            ))}
+            {isTyping && <ChatTypingIndicator />}
+            {chatStatus === 'error' && chatError != null && (
+                <div className="flex flex-col gap-1 self-start">
+                    <p className="text-critical-800 text-sm leading-normal">
+                        {chatErrorText}
+                    </p>
+                    {supportPortalUrl != null && (
+                        <a
+                            className="text-primary-400 text-sm leading-normal underline"
+                            href={supportPortalUrl}
+                            rel="noreferrer"
+                            target="_blank"
+                        >
+                            …or file your request via the support portal →
+                        </a>
+                    )}
+                </div>
+            )}
+            <ChatErrorPanel />
+            <ChatSuccessPanel />
+            <div ref={endRef} />
+        </div>
+    );
+};

--- a/packages/assistant-chat/src/components/chatMessageList/chatTypingIndicator.tsx
+++ b/packages/assistant-chat/src/components/chatMessageList/chatTypingIndicator.tsx
@@ -1,0 +1,11 @@
+import { StatePingAnimation } from '@aragon/gov-ui-kit';
+
+export const ChatTypingIndicator: React.FC = () => (
+    <div
+        aria-label="Assistant is typing"
+        className="flex items-center gap-1 self-start rounded-tl-xl rounded-tr-xl rounded-br-xl rounded-bl bg-neutral-50 px-3.5 py-3"
+        role="status"
+    >
+        <StatePingAnimation variant="primary" />
+    </div>
+);

--- a/packages/assistant-chat/src/components/chatMessageList/index.ts
+++ b/packages/assistant-chat/src/components/chatMessageList/index.ts
@@ -1,0 +1,3 @@
+export { ChatMessageItem, type IChatMessageItemProps } from './chatMessageItem';
+export { ChatMessageList } from './chatMessageList';
+export { ChatTypingIndicator } from './chatTypingIndicator';

--- a/packages/assistant-chat/src/components/chatNewChatBar/chatNewChatBar.tsx
+++ b/packages/assistant-chat/src/components/chatNewChatBar/chatNewChatBar.tsx
@@ -1,0 +1,20 @@
+import { Button } from '@aragon/gov-ui-kit';
+import { useAssistantChatContext } from '../../controller';
+
+// One ticket = one chat: once the request is created the composer is replaced by this bar and
+// a fresh request starts through an explicit new chat.
+export const ChatNewChatBar: React.FC = () => {
+    const { startNewChat } = useAssistantChatContext();
+
+    return (
+        <div className="flex flex-none flex-col gap-2 border-neutral-100 border-t px-5 pt-3.5 pb-4">
+            <Button onClick={startNewChat} size="md" variant="primary">
+                Start new chat
+            </Button>
+            <p className="text-center text-neutral-500 text-xs leading-normal">
+                This chat is linked to the created request. Need something else?
+                Start a new chat.
+            </p>
+        </div>
+    );
+};

--- a/packages/assistant-chat/src/components/chatNewChatBar/index.ts
+++ b/packages/assistant-chat/src/components/chatNewChatBar/index.ts
@@ -1,0 +1,1 @@
+export { ChatNewChatBar } from './chatNewChatBar';

--- a/packages/assistant-chat/src/components/chatRequestHistory/chatRequestHistory.tsx
+++ b/packages/assistant-chat/src/components/chatRequestHistory/chatRequestHistory.tsx
@@ -1,0 +1,50 @@
+import { Tag } from '@aragon/gov-ui-kit';
+import { useAssistantChatContext } from '../../controller';
+
+const maxVisibleEntries = 5;
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+});
+
+const formatCreatedAt = (createdAt: string): string => {
+    const date = new Date(createdAt);
+
+    return Number.isNaN(date.getTime()) ? '' : dateFormatter.format(date);
+};
+
+// Past requests of this device, shown on the idle screen so users can get back to a created
+// ticket without digging through their email.
+export const ChatRequestHistory: React.FC = () => {
+    const { flowState, requestHistory } = useAssistantChatContext();
+
+    if (flowState !== 'idle' || requestHistory.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="mt-2 flex flex-col gap-1.5 self-stretch">
+            <p className="text-neutral-500 text-xs uppercase tracking-wide">
+                Past requests
+            </p>
+            {requestHistory.slice(0, maxVisibleEntries).map((entry) => (
+                <a
+                    className="flex items-center gap-2 rounded-xl border border-neutral-100 bg-neutral-0 px-2.5 py-2 transition-colors hover:border-neutral-200 hover:bg-neutral-50"
+                    href={entry.url}
+                    key={entry.identifier}
+                    rel="noreferrer"
+                    target="_blank"
+                >
+                    <Tag label={entry.identifier} variant="primary" />
+                    <span className="min-w-0 flex-1 truncate text-neutral-800 text-xs">
+                        {entry.summary}
+                    </span>
+                    <span className="flex-none text-neutral-300 text-xs">
+                        {formatCreatedAt(entry.createdAt)}
+                    </span>
+                </a>
+            ))}
+        </div>
+    );
+};

--- a/packages/assistant-chat/src/components/chatRequestHistory/index.ts
+++ b/packages/assistant-chat/src/components/chatRequestHistory/index.ts
@@ -1,0 +1,1 @@
+export { ChatRequestHistory } from './chatRequestHistory';

--- a/packages/assistant-chat/src/components/chatStatusStrip/chatStatusStrip.tsx
+++ b/packages/assistant-chat/src/components/chatStatusStrip/chatStatusStrip.tsx
@@ -1,0 +1,141 @@
+import { Button, Icon, IconType } from '@aragon/gov-ui-kit';
+import { type ChatFlowState, useAssistantChatContext } from '../../controller';
+import { getAssistantErrorText } from '../../transport';
+
+// One hint line above the composer while no preview is up for review; the button next to it is
+// the single ticket affordance.
+const hintByFlowState: Partial<Record<ChatFlowState, string>> = {
+    chatting: "Done explaining? You'll review the ticket before it's sent.",
+    previewing: 'Putting your ticket together…',
+    previewUnclear:
+        "We couldn't put a ticket together yet — tell us a bit more about what happened.",
+};
+
+// The single ticket affordance: a compact sticky bar between messages and composer. It never
+// lives in the scroll area, so it can't push the conversation off-screen; the reviewed preview
+// expands in place (shrinking the scroll viewport, not scrolling content away).
+export const ChatStatusStrip: React.FC = () => {
+    const {
+        flowState,
+        ticketPreview,
+        previewError,
+        attachments,
+        prepareTicket,
+        createIssue,
+        isUploading,
+        isRemoving,
+    } = useAssistantChatContext();
+
+    if (
+        flowState === 'idle' ||
+        flowState === 'issueCreated' ||
+        // The error panel owns the failed-creation moment (message, retry, portal link).
+        flowState === 'issueError'
+    ) {
+        return null;
+    }
+
+    const isCreating = flowState === 'creatingIssue';
+
+    // Collecting bar: hint + Prepare button. A failed preview shows its human message in place
+    // of the hint; pressing the button again retries.
+    if (flowState !== 'previewReady' && !isCreating) {
+        const hint =
+            previewError != null
+                ? getAssistantErrorText(
+                      previewError.code,
+                      'The preview failed. Please try again.',
+                  )
+                : hintByFlowState[flowState];
+
+        return (
+            <div
+                className="flex flex-none items-center gap-2 border-neutral-100 border-t bg-neutral-50 py-2 pr-3 pl-5"
+                role="status"
+            >
+                <Icon
+                    className="flex-none text-neutral-300"
+                    icon={IconType.INFO}
+                    size="sm"
+                />
+                <p className="flex-1 text-neutral-500 text-xs leading-normal">
+                    {hint}
+                </p>
+                <Button
+                    disabled={flowState === 'previewing'}
+                    isLoading={flowState === 'previewing'}
+                    onClick={prepareTicket}
+                    size="sm"
+                    variant="secondary"
+                >
+                    Prepare ticket
+                </Button>
+            </div>
+        );
+    }
+
+    const activeAttachments = attachments.filter(
+        (attachment) => attachment.status !== 'error',
+    );
+    const attachmentLabel =
+        activeAttachments.length > 0
+            ? `${activeAttachments.length} ${activeAttachments.length === 1 ? 'file' : 'files'}`
+            : 'None';
+
+    // Reviewed preview: the title the ticket gets, plus what travels with it. The description
+    // can be long and is deliberately not shown — the full conversation is attached anyway.
+    return (
+        <div className="flex flex-none flex-col border-neutral-100 border-t bg-success-100">
+            <div
+                className="flex items-center gap-2 py-2 pr-3 pl-5"
+                role="status"
+            >
+                <Icon
+                    className="flex-none text-success-800"
+                    icon={IconType.CHECKMARK}
+                    size="sm"
+                />
+                <p className="flex-1 font-semibold text-success-800 text-xs">
+                    Ready to send
+                </p>
+                <Button
+                    disabled={isUploading || isRemoving || isCreating}
+                    isLoading={isCreating}
+                    onClick={createIssue}
+                    size="sm"
+                    variant="primary"
+                >
+                    {isCreating ? 'Sending…' : 'Send ticket'}
+                </Button>
+            </div>
+            <div className="flex flex-col gap-2 border-success-200 border-t bg-neutral-0 px-5 py-3">
+                <div className="flex flex-col gap-px">
+                    <p className="text-neutral-500 text-xs uppercase tracking-wide">
+                        Title
+                    </p>
+                    <p className="whitespace-pre-wrap text-neutral-800 text-sm leading-normal">
+                        {ticketPreview?.summary}
+                    </p>
+                </div>
+                <div className="flex flex-col gap-px">
+                    <p className="text-neutral-500 text-xs uppercase tracking-wide">
+                        Attachments
+                    </p>
+                    <p className="text-neutral-800 text-sm leading-normal">
+                        {attachmentLabel}
+                    </p>
+                </div>
+                <div className="flex items-center gap-1.5 pt-1 text-neutral-400 text-xs">
+                    <Icon icon={IconType.INFO} size="sm" />
+                    <span>
+                        The full conversation and debug info are attached
+                        automatically for the team.
+                    </span>
+                </div>
+                <p className="text-neutral-400 text-xs">
+                    Not quite right? Keep chatting and prepare it again.
+                </p>
+            </div>
+        </div>
+    );
+};

--- a/packages/assistant-chat/src/components/chatStatusStrip/index.ts
+++ b/packages/assistant-chat/src/components/chatStatusStrip/index.ts
@@ -1,0 +1,1 @@
+export { ChatStatusStrip } from './chatStatusStrip';

--- a/packages/assistant-chat/src/components/chatSuccessPanel/chatSuccessPanel.tsx
+++ b/packages/assistant-chat/src/components/chatSuccessPanel/chatSuccessPanel.tsx
@@ -1,0 +1,23 @@
+import { Card, Heading, IllustrationObject, Tag } from '@aragon/gov-ui-kit';
+import { useAssistantChatContext } from '../../controller';
+
+export const ChatSuccessPanel: React.FC = () => {
+    const { flowState, issue } = useAssistantChatContext();
+
+    if (flowState !== 'issueCreated' || issue == null) {
+        return null;
+    }
+
+    return (
+        <Card className="flex flex-col items-center gap-2 self-stretch border border-neutral-100 p-4 text-center">
+            <IllustrationObject className="size-14" object="SUCCESS" />
+            <Heading as="h3" size="h5">
+                Request created
+            </Heading>
+            <Tag label={issue.identifier} variant="primary" />
+            <p className="text-neutral-500 text-sm leading-normal">
+                If you left an email, we&apos;ll send updates there.
+            </p>
+        </Card>
+    );
+};

--- a/packages/assistant-chat/src/components/chatSuccessPanel/index.ts
+++ b/packages/assistant-chat/src/components/chatSuccessPanel/index.ts
@@ -1,0 +1,1 @@
+export { ChatSuccessPanel } from './chatSuccessPanel';

--- a/packages/assistant-chat/src/controller/assistantChatContext.tsx
+++ b/packages/assistant-chat/src/controller/assistantChatContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext } from 'react';
+import type { IAssistantChatController } from './useAssistantChatController';
+
+const assistantChatContext = createContext<IAssistantChatController | null>(
+    null,
+);
+
+export interface IAssistantChatProviderProps {
+    /**
+     * Controller instance shared with all widget components.
+     */
+    value: IAssistantChatController;
+    /**
+     * Children of the provider.
+     */
+    children: React.ReactNode;
+}
+
+export const AssistantChatProvider: React.FC<IAssistantChatProviderProps> = (
+    props,
+) => {
+    const { value, children } = props;
+
+    return (
+        <assistantChatContext.Provider value={value}>
+            {children}
+        </assistantChatContext.Provider>
+    );
+};
+
+export const useAssistantChatContext = (): IAssistantChatController => {
+    const value = useContext(assistantChatContext);
+
+    if (value == null) {
+        throw new Error(
+            'useAssistantChatContext must be used inside an AssistantChatProvider',
+        );
+    }
+
+    return value;
+};

--- a/packages/assistant-chat/src/controller/chatFlowState.api.ts
+++ b/packages/assistant-chat/src/controller/chatFlowState.api.ts
@@ -1,0 +1,20 @@
+/**
+ * Derived state of the intake flow, driving which panels the widget renders:
+ * - `idle`: fresh session, no user message yet;
+ * - `chatting`: conversation ongoing, no ticket action in flight;
+ * - `previewing`: the ticket preview is being prepared;
+ * - `previewUnclear`: the conversation does not describe an actionable request yet;
+ * - `previewReady`: the preview is up for review, sending is offered;
+ * - `creatingIssue`: issue creation request in flight;
+ * - `issueCreated`: issue created, next message starts a new session;
+ * - `issueError`: issue creation failed, retry keeps the session.
+ */
+export type ChatFlowState =
+    | 'idle'
+    | 'chatting'
+    | 'previewing'
+    | 'previewUnclear'
+    | 'previewReady'
+    | 'creatingIssue'
+    | 'issueCreated'
+    | 'issueError';

--- a/packages/assistant-chat/src/controller/index.ts
+++ b/packages/assistant-chat/src/controller/index.ts
@@ -1,0 +1,11 @@
+export {
+    AssistantChatProvider,
+    type IAssistantChatProviderProps,
+    useAssistantChatContext,
+} from './assistantChatContext';
+export type { ChatFlowState } from './chatFlowState.api';
+export {
+    type IAssistantChatController,
+    type IUseAssistantChatControllerParams,
+    useAssistantChatController,
+} from './useAssistantChatController';

--- a/packages/assistant-chat/src/controller/useAssistantChatController.ts
+++ b/packages/assistant-chat/src/controller/useAssistantChatController.ts
@@ -1,0 +1,327 @@
+import type {
+    IAppContext,
+    ICreateIssueRequest,
+    ICreateIssueResponse,
+} from '@aragon/assistant-contracts';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+    type IChatAttachment,
+    type IFileAlert,
+    useFileAttachments,
+} from '../files';
+import {
+    type ITicketError,
+    type ITicketPreview,
+    type TicketStatus,
+    useTicket,
+} from '../issues';
+import type { IChatMonitoring } from '../monitoring';
+import {
+    appendRequestToHistory,
+    getRequestHistory,
+    type IRequestHistoryEntry,
+} from '../requests';
+import { useChatSession } from '../session';
+import {
+    type AssistantUIMessage,
+    type ChatStatus,
+    useAssistantChat,
+} from '../transport';
+import type { ChatFlowState } from './chatFlowState.api';
+
+export interface IUseAssistantChatControllerParams {
+    /**
+     * Base URL of the assistant service.
+     */
+    assistantUrl: string;
+    /**
+     * App context sent alongside every request.
+     */
+    appContext: IAppContext;
+    /**
+     * Fallback support-portal URL offered when the chat hard-fails.
+     */
+    supportPortalUrl?: string;
+    /**
+     * Monitoring implementation injected by the host app.
+     */
+    monitoring: IChatMonitoring;
+}
+
+export interface IAssistantChatController {
+    /**
+     * Identifier of the current chat session.
+     */
+    sessionId: string;
+    /**
+     * App context sent alongside every request.
+     */
+    appContext: IAppContext;
+    /**
+     * Fallback support-portal URL offered when the chat hard-fails; undefined when not configured.
+     */
+    supportPortalUrl?: string;
+    /**
+     * Messages of the transcript, ready for rendering.
+     */
+    messages: AssistantUIMessage[];
+    /**
+     * Status of the current chat request.
+     */
+    chatStatus: ChatStatus;
+    /**
+     * Error of the last chat request, if any.
+     */
+    chatError?: Error;
+    /**
+     * Sends a user message; a message sent after a preview makes that preview stale and resets
+     * it. Ignored once the session's issue has been created (one ticket = one chat — a new
+     * request starts through startNewChat).
+     */
+    sendMessage: (text: string) => void;
+    /**
+     * Aborts the streaming response of the current chat request.
+     */
+    stop: () => void;
+    /**
+     * Derived state of the intake flow.
+     */
+    flowState: ChatFlowState;
+    /**
+     * Prepares the ticket preview from the current transcript.
+     */
+    prepareTicket: () => void;
+    /**
+     * The reviewed ticket preview, set while flowState is previewReady (and kept through
+     * creation).
+     */
+    ticketPreview?: ITicketPreview;
+    /**
+     * Error of the last preview attempt; preparing again retries.
+     */
+    previewError?: ITicketError;
+    /**
+     * Creates the issue the preview showed; also used to retry after a failure. Ignored while
+     * attachments are still uploading or being removed.
+     */
+    createIssue: () => void;
+    /**
+     * The created issue, set on success.
+     */
+    issue?: ICreateIssueResponse;
+    /**
+     * Error of the last issue creation attempt.
+     */
+    issueError?: ITicketError;
+    /**
+     * Resets the widget for a fresh request: new session, clean transcript and attachments.
+     */
+    startNewChat: () => void;
+    /**
+     * Previously created requests of this device, newest first.
+     */
+    requestHistory: IRequestHistoryEntry[];
+    /**
+     * Attachments of the current session.
+     */
+    attachments: IChatAttachment[];
+    /**
+     * Validates and uploads the given files.
+     */
+    addFiles: (files: File[]) => void;
+    /**
+     * Removes an attachment, aborting its upload when still in flight.
+     */
+    removeFile: (id: string) => void;
+    /**
+     * Client-side file rejection alert.
+     */
+    fileAlert?: IFileAlert;
+    /**
+     * Dismisses the file rejection alert.
+     */
+    dismissFileAlert: () => void;
+    /**
+     * Whether any attachment is still uploading (gates sending and issue creation).
+     */
+    isUploading: boolean;
+    /**
+     * Whether any attachment is being removed (gates issue creation).
+     */
+    isRemoving: boolean;
+    /**
+     * Draft text of the composer. Held on the controller (not in the composer component) so it
+     * survives closing and reopening the drawer, whose content unmounts while closed.
+     */
+    composerInput: string;
+    /**
+     * Updates the composer draft.
+     */
+    setComposerInput: (value: string) => void;
+}
+
+export const useAssistantChatController = (
+    params: IUseAssistantChatControllerParams,
+): IAssistantChatController => {
+    const { assistantUrl, appContext, supportPortalUrl, monitoring } = params;
+
+    const { sessionId, rotate } = useChatSession();
+
+    const chat = useAssistantChat({
+        assistantUrl,
+        sessionId,
+        appContext,
+        monitoring,
+    });
+
+    const ticket = useTicket({ assistantUrl, monitoring });
+
+    const files = useFileAttachments({ assistantUrl, sessionId, monitoring });
+
+    const [requestHistory, setRequestHistory] = useState<
+        IRequestHistoryEntry[]
+    >(() => getRequestHistory());
+
+    const [composerInput, setComposerInput] = useState('');
+
+    const { sendMessage: chatSendMessage } = chat;
+    const { status: ticketStatus, reset: resetTicket } = ticket;
+
+    const sendMessage = useCallback(
+        (text: string) => {
+            // One ticket = one chat: a completed session accepts no further messages.
+            if (ticketStatus === 'created') {
+                return;
+            }
+
+            // A newer message makes any prepared preview stale: the user reviews again.
+            resetTicket();
+            chatSendMessage(text);
+        },
+        [ticketStatus, resetTicket, chatSendMessage],
+    );
+
+    // Both ticket actions take the full transcript: preview distills it, creation submits the
+    // exact conversation the ticket documents.
+    const buildTicketRequest = useCallback(
+        (): ICreateIssueRequest => ({
+            sessionId,
+            messages: chat.messages.map((message) => ({
+                id: message.id,
+                role: message.role === 'user' ? 'user' : 'assistant',
+                parts: message.parts,
+            })),
+            appContext,
+        }),
+        [sessionId, chat.messages, appContext],
+    );
+
+    const prepareTicket = useCallback(
+        () => ticket.prepare(buildTicketRequest()),
+        [ticket.prepare, buildTicketRequest],
+    );
+
+    const { isUploading, isRemoving } = files;
+
+    const createIssue = useCallback(() => {
+        // Attachments must be settled: an upload still in flight would miss the ticket, a
+        // removal still in flight would wrongly end up in it.
+        if (isUploading || isRemoving) {
+            return;
+        }
+
+        ticket.send(buildTicketRequest());
+    }, [isUploading, isRemoving, ticket.send, buildTicketRequest]);
+
+    const startNewChat = useCallback(() => {
+        resetTicket();
+        setComposerInput('');
+        // Attachments reset through their session effect once the new identifier lands.
+        rotate();
+    }, [resetTicket, rotate]);
+
+    // The created issue is appended to the device-local history exactly once.
+    const appendedIssueIdRef = useRef<string | undefined>(undefined);
+
+    useEffect(() => {
+        const createdIssue = ticket.issue;
+
+        if (
+            createdIssue == null ||
+            appendedIssueIdRef.current === createdIssue.issueId
+        ) {
+            return;
+        }
+
+        appendedIssueIdRef.current = createdIssue.issueId;
+        setRequestHistory(
+            appendRequestToHistory({
+                identifier: createdIssue.identifier,
+                url: createdIssue.url,
+                summary: ticket.preview?.summary ?? '',
+                createdAt: new Date().toISOString(),
+            }),
+        );
+    }, [ticket.issue, ticket.preview]);
+
+    const flowState = deriveFlowState({
+        ticketStatus,
+        hasMessages: chat.messages.length > 0,
+    });
+
+    return {
+        sessionId,
+        appContext,
+        supportPortalUrl,
+        messages: chat.visibleMessages,
+        chatStatus: chat.status,
+        chatError: chat.error,
+        sendMessage,
+        stop: chat.stop,
+        flowState,
+        prepareTicket,
+        ticketPreview: ticket.preview,
+        previewError: ticket.previewError,
+        createIssue,
+        issue: ticket.issue,
+        issueError: ticket.createError,
+        startNewChat,
+        requestHistory,
+        attachments: files.attachments,
+        addFiles: files.addFiles,
+        removeFile: files.removeFile,
+        fileAlert: files.alert,
+        dismissFileAlert: files.dismissAlert,
+        isUploading,
+        isRemoving,
+        composerInput,
+        setComposerInput,
+    };
+};
+
+// The flow state is the ticket lifecycle verbatim; only the resting state splits into idle
+// (fresh session) and chatting (conversation ongoing).
+const flowStateByTicketStatus: Record<
+    Exclude<TicketStatus, 'idle'>,
+    ChatFlowState
+> = {
+    previewing: 'previewing',
+    previewed: 'previewReady',
+    unclear: 'previewUnclear',
+    creating: 'creatingIssue',
+    created: 'issueCreated',
+    error: 'issueError',
+};
+
+const deriveFlowState = (params: {
+    ticketStatus: TicketStatus;
+    hasMessages: boolean;
+}): ChatFlowState => {
+    const { ticketStatus, hasMessages } = params;
+
+    if (ticketStatus !== 'idle') {
+        return flowStateByTicketStatus[ticketStatus];
+    }
+
+    return hasMessages ? 'chatting' : 'idle';
+};

--- a/packages/assistant-chat/src/files/fileValidation.ts
+++ b/packages/assistant-chat/src/files/fileValidation.ts
@@ -1,0 +1,86 @@
+import { assistantLimits } from '@aragon/assistant-contracts';
+
+// Client-side mirror of the server allowlist (magic-byte validation stays server-side): binary
+// types identified by MIME, text files by extension since browsers often report them as empty
+// or text/plain.
+const allowedMimeTypes = [
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+    'application/pdf',
+];
+
+const allowedTextExtensions = ['.txt', '.log', '.md', '.json'];
+
+/**
+ * Accept map for react-dropzone, mirroring the client-side allowlist.
+ */
+export const dropzoneAccept: Record<string, string[]> = {
+    'image/png': ['.png'],
+    'image/jpeg': ['.jpg', '.jpeg'],
+    'image/gif': ['.gif'],
+    'image/webp': ['.webp'],
+    'application/pdf': ['.pdf'],
+    'text/plain': allowedTextExtensions,
+};
+
+export type FileRejectReason = 'too_large' | 'unsupported' | 'file_limit';
+
+export interface IRejectedFile {
+    /**
+     * The rejected file.
+     */
+    file: File;
+    /**
+     * Why the file was rejected.
+     */
+    reason: FileRejectReason;
+}
+
+export interface IFileValidationResult {
+    /**
+     * Files passing the client-side filter, capped to the remaining session slots.
+     */
+    accepted: File[];
+    /**
+     * Files rejected client-side with the reason of the first failed check.
+     */
+    rejected: IRejectedFile[];
+}
+
+const isSupportedFile = (file: File): boolean => {
+    if (allowedMimeTypes.includes(file.type)) {
+        return true;
+    }
+
+    const extension = file.name.slice(file.name.lastIndexOf('.')).toLowerCase();
+
+    return allowedTextExtensions.includes(extension);
+};
+
+/**
+ * Filters the given files against the shared limits: type allowlist, max size and the remaining
+ * attachment slots of the session.
+ */
+export const validateFiles = (
+    files: File[],
+    remainingSlots: number,
+): IFileValidationResult => {
+    const accepted: File[] = [];
+    const rejected: IRejectedFile[] = [];
+
+    for (const file of files) {
+        if (!isSupportedFile(file)) {
+            rejected.push({ file, reason: 'unsupported' });
+        } else if (file.size > assistantLimits.maxFileSizeBytes) {
+            rejected.push({ file, reason: 'too_large' });
+        } else if (accepted.length >= remainingSlots) {
+            rejected.push({ file, reason: 'file_limit' });
+        } else {
+            accepted.push(file);
+        }
+    }
+
+    return { accepted, rejected };
+};

--- a/packages/assistant-chat/src/files/index.ts
+++ b/packages/assistant-chat/src/files/index.ts
@@ -1,0 +1,25 @@
+export {
+    dropzoneAccept,
+    type FileRejectReason,
+    type IFileValidationResult,
+    type IRejectedFile,
+    validateFiles,
+} from './fileValidation';
+export {
+    deleteFile,
+    type IDeleteFileParams,
+    type IUploadFileHandle,
+    type IUploadFileParams,
+    UploadFileError,
+    type UploadFileErrorCode,
+    uploadFile,
+} from './uploadFile';
+export {
+    type ChatAttachmentStatus,
+    type ChatFileAlertReason,
+    type IChatAttachment,
+    type IFileAlert,
+    type IUseFileAttachmentsParams,
+    type IUseFileAttachmentsResult,
+    useFileAttachments,
+} from './useFileAttachments';

--- a/packages/assistant-chat/src/files/uploadFile.ts
+++ b/packages/assistant-chat/src/files/uploadFile.ts
@@ -1,0 +1,174 @@
+import {
+    assistantErrorSchema,
+    type IAssistantErrorCode,
+    type IUploadFileResponse,
+    uploadFileResponseSchema,
+} from '@aragon/assistant-contracts';
+import { upload } from '@vercel/blob/client';
+
+export type UploadFileErrorCode = IAssistantErrorCode | 'network' | 'aborted';
+
+export class UploadFileError extends Error {
+    readonly code: UploadFileErrorCode;
+
+    constructor(code: UploadFileErrorCode, message: string) {
+        super(message);
+        this.name = 'UploadFileError';
+        this.code = code;
+    }
+}
+
+export interface IUploadFileParams {
+    /**
+     * Base URL of the assistant service.
+     */
+    assistantUrl: string;
+    /**
+     * Identifier of the current chat session.
+     */
+    sessionId: string;
+    /**
+     * File to upload.
+     */
+    file: File;
+    /**
+     * Called with the upload progress in the [0, 1] range.
+     */
+    onProgress?: (progress: number) => void;
+}
+
+export interface IUploadFileHandle {
+    /**
+     * Resolves with the upload response; rejects with an UploadFileError.
+     */
+    promise: Promise<IUploadFileResponse>;
+    /**
+     * Aborts the in-flight upload; the promise rejects with code `aborted`.
+     */
+    abort: () => void;
+}
+
+export interface IDeleteFileParams {
+    /**
+     * Base URL of the assistant service.
+     */
+    assistantUrl: string;
+    /**
+     * Identifier of the current chat session.
+     */
+    sessionId: string;
+    /**
+     * Server identifier of the queued file, as returned by the upload.
+     */
+    fileId: string;
+}
+
+const parseErrorBody = (body: unknown): UploadFileError => {
+    const parsed = assistantErrorSchema.safeParse(body);
+
+    return parsed.success
+        ? new UploadFileError(parsed.data.error.code, parsed.data.error.message)
+        : new UploadFileError('internal', 'The file could not be uploaded.');
+};
+
+const toUploadFileError = (
+    error: unknown,
+    isAborted: boolean,
+): UploadFileError => {
+    if (isAborted) {
+        return new UploadFileError('aborted', 'Upload aborted.');
+    }
+
+    if (error instanceof UploadFileError) {
+        return error;
+    }
+
+    if (error instanceof TypeError) {
+        return new UploadFileError('network', 'Network error during upload.');
+    }
+
+    return new UploadFileError(
+        'internal',
+        error instanceof Error
+            ? error.message
+            : 'The file could not be uploaded.',
+    );
+};
+
+const confirmUpload = async (
+    params: IUploadFileParams,
+    blobUrl: string,
+    signal: AbortSignal,
+): Promise<IUploadFileResponse> => {
+    const { assistantUrl, sessionId } = params;
+
+    const response = await fetch(`${assistantUrl}/files/confirm`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId, blobUrl }),
+        signal,
+    });
+
+    const body: unknown = await response.json().catch(() => null);
+
+    if (!response.ok) {
+        throw parseErrorBody(body);
+    }
+
+    try {
+        return uploadFileResponseSchema.parse(body);
+    } catch {
+        throw new UploadFileError('internal', 'Unexpected upload response.');
+    }
+};
+
+// Two-step client-direct upload (Vercel functions cap request bodies at 4.5 MB, so file bytes
+// never flow through the service): the blob client asks POST /files/token for a client token,
+// uploads the bytes directly to blob storage, then POST /files/confirm lets the service
+// validate the content and queue the file for the ticket.
+export const uploadFile = (params: IUploadFileParams): IUploadFileHandle => {
+    const { assistantUrl, sessionId, file, onProgress } = params;
+
+    const abortController = new AbortController();
+    const { signal } = abortController;
+
+    // The pathname contract of POST /files/token: the raw file name stays last so the server
+    // can derive the display name; the uuid segment becomes the server file id.
+    const pathname = `assistant/${sessionId}/${crypto.randomUUID()}/${file.name}`;
+
+    const promise = upload(pathname, file, {
+        access: 'public',
+        handleUploadUrl: `${assistantUrl}/files/token`,
+        clientPayload: JSON.stringify({ sessionId }),
+        abortSignal: signal,
+        onUploadProgress: ({ percentage }) => onProgress?.(percentage / 100),
+    })
+        .then((blob) => confirmUpload(params, blob.url, signal))
+        .catch((error: unknown) => {
+            throw toUploadFileError(error, signal.aborted);
+        });
+
+    return { promise, abort: () => abortController.abort() };
+};
+
+/**
+ * Removes a queued file from the session; the server frees its slot and deletes the blob.
+ */
+export const deleteFile = async (params: IDeleteFileParams): Promise<void> => {
+    const { assistantUrl, sessionId, fileId } = params;
+
+    let response: Response;
+    try {
+        response = await fetch(`${assistantUrl}/files/${fileId}`, {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sessionId }),
+        });
+    } catch {
+        throw new UploadFileError('network', 'Network error during removal.');
+    }
+
+    if (!response.ok) {
+        throw parseErrorBody(await response.json().catch(() => null));
+    }
+};

--- a/packages/assistant-chat/src/files/useFileAttachments.ts
+++ b/packages/assistant-chat/src/files/useFileAttachments.ts
@@ -1,0 +1,306 @@
+import { assistantLimits } from '@aragon/assistant-contracts';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { IChatMonitoring } from '../monitoring';
+import type { FileRejectReason } from './fileValidation';
+import { validateFiles } from './fileValidation';
+import {
+    deleteFile,
+    type IUploadFileHandle,
+    UploadFileError,
+    uploadFile,
+} from './uploadFile';
+
+export type ChatAttachmentStatus =
+    | 'uploading'
+    | 'uploaded'
+    | 'removing'
+    | 'error';
+
+export type ChatFileAlertReason = FileRejectReason | 'remove_failed';
+
+export interface IChatAttachment {
+    /**
+     * Client-side identifier of the attachment.
+     */
+    id: string;
+    /**
+     * Server identifier of the queued file, set once the upload is confirmed.
+     */
+    serverId?: string;
+    /**
+     * Name of the attached file.
+     */
+    filename: string;
+    /**
+     * Size of the attached file in bytes.
+     */
+    size: number;
+    /**
+     * Upload state of the attachment.
+     */
+    status: ChatAttachmentStatus;
+    /**
+     * Upload progress in the [0, 1] range.
+     */
+    progress: number;
+}
+
+export interface IFileAlert {
+    /**
+     * Why the file was rejected or could not be removed.
+     */
+    reason: ChatFileAlertReason;
+    /**
+     * Name of the affected file, when the alert concerns a single file.
+     */
+    filename?: string;
+}
+
+export interface IUseFileAttachmentsParams {
+    /**
+     * Base URL of the assistant service.
+     */
+    assistantUrl: string;
+    /**
+     * Identifier of the current chat session; changing it resets all attachments.
+     */
+    sessionId: string;
+    /**
+     * Monitoring implementation used to report upload errors.
+     */
+    monitoring: IChatMonitoring;
+}
+
+export interface IUseFileAttachmentsResult {
+    /**
+     * Attachments of the current session.
+     */
+    attachments: IChatAttachment[];
+    /**
+     * Validates and uploads the given files; single entry point for picker, drag-and-drop and
+     * clipboard paste.
+     */
+    addFiles: (files: File[]) => void;
+    /**
+     * Removes an attachment: an in-flight upload is aborted, a confirmed one is deleted from the
+     * session server-side and restored on failure.
+     */
+    removeFile: (id: string) => void;
+    /**
+     * Client-side rejection alert to surface in the composer.
+     */
+    alert?: IFileAlert;
+    /**
+     * Dismisses the rejection alert.
+     */
+    dismissAlert: () => void;
+    /**
+     * Whether any attachment is still uploading (gates sending).
+     */
+    isUploading: boolean;
+    /**
+     * Whether any attachment is being removed (gates issue creation).
+     */
+    isRemoving: boolean;
+}
+
+export const useFileAttachments = (
+    params: IUseFileAttachmentsParams,
+): IUseFileAttachmentsResult => {
+    const { assistantUrl, sessionId, monitoring } = params;
+
+    const [attachments, setAttachments] = useState<IChatAttachment[]>([]);
+    const [alert, setAlert] = useState<IFileAlert | undefined>(undefined);
+
+    const uploadHandlesRef = useRef<Map<string, IUploadFileHandle>>(new Map());
+    const monitoringRef = useRef(monitoring);
+    monitoringRef.current = monitoring;
+    const attachmentsRef = useRef(attachments);
+    attachmentsRef.current = attachments;
+
+    // A new session starts with a clean slate; uploads of the previous session are aborted.
+    const previousSessionIdRef = useRef(sessionId);
+    useEffect(() => {
+        if (previousSessionIdRef.current === sessionId) {
+            return;
+        }
+
+        previousSessionIdRef.current = sessionId;
+        for (const handle of uploadHandlesRef.current.values()) {
+            handle.abort();
+        }
+        uploadHandlesRef.current.clear();
+        setAttachments([]);
+        setAlert(undefined);
+    }, [sessionId]);
+
+    const updateAttachment = useCallback(
+        (id: string, patch: Partial<IChatAttachment>) =>
+            setAttachments((current) =>
+                current.map((attachment) =>
+                    attachment.id === id
+                        ? { ...attachment, ...patch }
+                        : attachment,
+                ),
+            ),
+        [],
+    );
+
+    const startUpload = useCallback(
+        (id: string, file: File) => {
+            const handle = uploadFile({
+                assistantUrl,
+                sessionId,
+                file,
+                onProgress: (progress) => updateAttachment(id, { progress }),
+            });
+            uploadHandlesRef.current.set(id, handle);
+
+            handle.promise
+                .then((response) => {
+                    updateAttachment(id, {
+                        status: 'uploaded',
+                        progress: 1,
+                        serverId: response.id,
+                    });
+                })
+                .catch((error: unknown) => {
+                    if (
+                        error instanceof UploadFileError &&
+                        error.code === 'aborted'
+                    ) {
+                        return;
+                    }
+
+                    updateAttachment(id, { status: 'error' });
+
+                    if (
+                        error instanceof UploadFileError &&
+                        error.code === 'file_limit'
+                    ) {
+                        setAlert({ reason: 'file_limit', filename: file.name });
+                    }
+
+                    monitoringRef.current.logError(error, {
+                        context: { step: 'assistantChat.uploadFile' },
+                    });
+                })
+                .finally(() => uploadHandlesRef.current.delete(id));
+        },
+        [assistantUrl, sessionId, updateAttachment],
+    );
+
+    const addFiles = useCallback(
+        (files: File[]) => {
+            if (files.length === 0) {
+                return;
+            }
+
+            const activeCount = attachmentsRef.current.filter(
+                (attachment) => attachment.status !== 'error',
+            ).length;
+            const remainingSlots = Math.max(
+                0,
+                assistantLimits.maxFilesPerSession - activeCount,
+            );
+
+            const { accepted, rejected } = validateFiles(files, remainingSlots);
+
+            const firstRejection = rejected[0];
+            setAlert(
+                firstRejection
+                    ? {
+                          reason: firstRejection.reason,
+                          filename: firstRejection.file.name,
+                      }
+                    : undefined,
+            );
+
+            const added = accepted.map((file) => {
+                const id = crypto.randomUUID();
+                startUpload(id, file);
+
+                return {
+                    id,
+                    filename: file.name,
+                    size: file.size,
+                    status: 'uploading' as const,
+                    progress: 0,
+                };
+            });
+
+            if (added.length > 0) {
+                setAttachments((current) => [...current, ...added]);
+            }
+        },
+        [startUpload],
+    );
+
+    const removeFile = useCallback(
+        (id: string) => {
+            const attachment = attachmentsRef.current.find(
+                (current) => current.id === id,
+            );
+
+            if (attachment == null || attachment.status === 'removing') {
+                return;
+            }
+
+            // Not confirmed server-side (still uploading or failed): dropping the row is enough,
+            // an in-flight upload is aborted.
+            if (attachment.serverId == null) {
+                uploadHandlesRef.current.get(id)?.abort();
+                uploadHandlesRef.current.delete(id);
+                setAttachments((current) =>
+                    current.filter((entry) => entry.id !== id),
+                );
+
+                return;
+            }
+
+            const { serverId, filename } = attachment;
+            const removalSessionId = sessionId;
+            updateAttachment(id, { status: 'removing' });
+
+            deleteFile({ assistantUrl, sessionId, fileId: serverId })
+                .then(() =>
+                    setAttachments((current) =>
+                        current.filter((entry) => entry.id !== id),
+                    ),
+                )
+                .catch((error: unknown) => {
+                    // The session rotated while the removal was in flight: its attachments are
+                    // already gone, there is nothing to restore.
+                    if (previousSessionIdRef.current !== removalSessionId) {
+                        return;
+                    }
+
+                    updateAttachment(id, { status: 'uploaded' });
+                    setAlert({ reason: 'remove_failed', filename });
+                    monitoringRef.current.logError(error, {
+                        context: { step: 'assistantChat.removeFile' },
+                    });
+                });
+        },
+        [assistantUrl, sessionId, updateAttachment],
+    );
+
+    const dismissAlert = useCallback(() => setAlert(undefined), []);
+
+    const isUploading = attachments.some(
+        (attachment) => attachment.status === 'uploading',
+    );
+    const isRemoving = attachments.some(
+        (attachment) => attachment.status === 'removing',
+    );
+
+    return {
+        attachments,
+        addFiles,
+        removeFile,
+        alert,
+        dismissAlert,
+        isUploading,
+        isRemoving,
+    };
+};

--- a/packages/assistant-chat/src/index.ts
+++ b/packages/assistant-chat/src/index.ts
@@ -1,0 +1,13 @@
+// Lean public barrel (kept small so the host app can load the widget behind next/dynamic): the
+// root component, its props and the monitoring seam. Internal modules are deliberately not
+// re-exported.
+export {
+    AssistantChat,
+    type IAssistantChatProps,
+} from './components/assistantChat';
+export {
+    type IChatMonitoring,
+    type IChatMonitoringErrorParams,
+    type IChatMonitoringMessageParams,
+    noopMonitoring,
+} from './monitoring';

--- a/packages/assistant-chat/src/issues/index.ts
+++ b/packages/assistant-chat/src/issues/index.ts
@@ -1,0 +1,8 @@
+export {
+    type ITicketError,
+    type ITicketPreview,
+    type IUseTicketParams,
+    type IUseTicketResult,
+    type TicketStatus,
+    useTicket,
+} from './useTicket';

--- a/packages/assistant-chat/src/issues/useTicket.ts
+++ b/packages/assistant-chat/src/issues/useTicket.ts
@@ -1,0 +1,286 @@
+import {
+    assistantErrorSchema,
+    createIssueResponseSchema,
+    type IAssistantErrorCode,
+    type ICreateIssueRequest,
+    type ICreateIssueResponse,
+    type IPreviewIssueRequest,
+    type ISupportIntent,
+    previewIssueResponseSchema,
+} from '@aragon/assistant-contracts';
+import { useMutation } from '@tanstack/react-query';
+import { useRef } from 'react';
+import type { z } from 'zod';
+import type { IChatMonitoring } from '../monitoring';
+
+/**
+ * Lifecycle of the session's ticket, driven by two explicit user actions:
+ * - `idle`: nothing prepared yet (or the preview was reset by a newer message);
+ * - `previewing` / `previewed` / `unclear`: preparing the preview and its two outcomes;
+ * - `creating` / `created`: sending the reviewed ticket;
+ * - `error`: the creation failed — retrying reuses the same session.
+ * A failed preview falls back to `idle` with `previewError` set.
+ */
+export type TicketStatus =
+    | 'idle'
+    | 'previewing'
+    | 'previewed'
+    | 'unclear'
+    | 'creating'
+    | 'created'
+    | 'error';
+
+export interface ITicketError {
+    /**
+     * Error code returned by the assistant service, when available.
+     */
+    code?: IAssistantErrorCode;
+    /**
+     * Human-readable error message.
+     */
+    message: string;
+}
+
+export interface ITicketPreview {
+    /**
+     * Summary distilled from the conversation; becomes the ticket title.
+     */
+    summary: string;
+    /**
+     * Classified intent of the request; drives the ticket label.
+     */
+    intent: ISupportIntent;
+}
+
+export interface IUseTicketParams {
+    /**
+     * Base URL of the assistant service.
+     */
+    assistantUrl: string;
+    /**
+     * Monitoring implementation injected by the host app.
+     */
+    monitoring: IChatMonitoring;
+}
+
+export interface IUseTicketResult {
+    /**
+     * Current state of the ticket lifecycle.
+     */
+    status: TicketStatus;
+    /**
+     * The reviewed preview, set while `previewed` (and kept through creation).
+     */
+    preview?: ITicketPreview;
+    /**
+     * Error of the last preview attempt; preparing again retries.
+     */
+    previewError?: ITicketError;
+    /**
+     * The created issue, set on success.
+     */
+    issue?: ICreateIssueResponse;
+    /**
+     * Error of the last creation attempt.
+     */
+    createError?: ITicketError;
+    /**
+     * Prepares the ticket preview from the given transcript.
+     */
+    prepare: (request: IPreviewIssueRequest) => void;
+    /**
+     * Creates the issue the preview showed; also used to retry after a failure.
+     */
+    send: (request: ICreateIssueRequest) => void;
+    /**
+     * Resets the lifecycle: a newer message makes the preview stale, a new session starts over.
+     */
+    reset: () => void;
+}
+
+// Carries the service's error shape through the mutations so the UI can branch on the code.
+class TicketRequestError extends Error {
+    readonly info: ITicketError;
+
+    constructor(info: ITicketError) {
+        super(info.message);
+        this.info = info;
+    }
+}
+
+const fallbackError: ITicketError = {
+    message: 'The request could not be processed.',
+};
+
+// The single wire helper of the ticket flow: POST, validate the happy shape, translate non-2xx
+// bodies into the shared error shape.
+const postJson = async <TResult>(
+    url: string,
+    request: unknown,
+    schema: z.ZodType<TResult>,
+): Promise<TResult> => {
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        const body = await response.json().catch(() => null);
+        const parsed = assistantErrorSchema.safeParse(body);
+        throw new TicketRequestError(
+            parsed.success
+                ? {
+                      code: parsed.data.error.code,
+                      message: parsed.data.error.message,
+                  }
+                : fallbackError,
+        );
+    }
+
+    return schema.parse(await response.json());
+};
+
+const toTicketError = (error: unknown): ITicketError | undefined => {
+    if (error == null) {
+        return undefined;
+    }
+
+    return error instanceof TicketRequestError ? error.info : fallbackError;
+};
+
+export const useTicket = (params: IUseTicketParams): IUseTicketResult => {
+    const { assistantUrl, monitoring } = params;
+
+    // Synchronous double-invoke guard shared by both actions: the isPending render snapshot
+    // updates only on the next render, so two clicks in the same tick would both pass a
+    // state-only gate.
+    const inFlightRef = useRef(false);
+
+    // The refusal is reported with the error code only — never with user content.
+    const buildMutationOptions = (action: string) => ({
+        // The default 'online' mode would silently pause the mutation while the browser is
+        // offline (and auto-fire it on reconnect) instead of surfacing the error.
+        networkMode: 'always' as const,
+        onSettled: () => {
+            inFlightRef.current = false;
+        },
+        onError: (error: Error) => {
+            if (error instanceof TicketRequestError) {
+                monitoring.logMessage(`assistantChat: ${action} failed`, {
+                    level: 'warning',
+                    context: { code: error.info.code },
+                });
+            } else {
+                monitoring.logError(error, {
+                    context: { step: `assistantChat.${action}` },
+                });
+            }
+        },
+    });
+
+    // reset() does not cancel an in-flight react-query mutation — its result still lands. The
+    // generation stamp lets a reset invalidate whatever is still flying: a preview requested
+    // before the reset (e.g. the user sent another message meanwhile) is ignored on arrival.
+    const generationRef = useRef(0);
+
+    const previewMutation = useMutation({
+        mutationFn: (variables: {
+            request: IPreviewIssueRequest;
+            generation: number;
+        }) =>
+            postJson(
+                `${assistantUrl}/issues/preview`,
+                variables.request,
+                previewIssueResponseSchema,
+            ),
+        ...buildMutationOptions('previewIssue'),
+    });
+
+    const isPreviewCurrent =
+        previewMutation.variables?.generation === generationRef.current;
+
+    const createMutation = useMutation({
+        mutationFn: (request: ICreateIssueRequest) =>
+            postJson(
+                `${assistantUrl}/issues`,
+                request,
+                createIssueResponseSchema,
+            ),
+        ...buildMutationOptions('createIssue'),
+    });
+
+    const runExclusive = (action: () => void) => {
+        if (
+            inFlightRef.current ||
+            previewMutation.isPending ||
+            createMutation.isPending ||
+            createMutation.isSuccess
+        ) {
+            return;
+        }
+
+        inFlightRef.current = true;
+        action();
+    };
+
+    const preview =
+        isPreviewCurrent && previewMutation.data?.status === 'ready'
+            ? previewMutation.data
+            : undefined;
+
+    // Creation outranks preview: once the user sent the ticket, the preview sub-state is history.
+    const deriveStatus = (): TicketStatus => {
+        if (createMutation.isPending) {
+            return 'creating';
+        }
+        if (createMutation.isSuccess) {
+            return 'created';
+        }
+        if (createMutation.isError) {
+            return 'error';
+        }
+        if (!isPreviewCurrent) {
+            return 'idle';
+        }
+        if (previewMutation.isPending) {
+            return 'previewing';
+        }
+        if (previewMutation.data?.status === 'ready') {
+            return 'previewed';
+        }
+        if (previewMutation.data?.status === 'unclear') {
+            return 'unclear';
+        }
+
+        return 'idle';
+    };
+
+    return {
+        status: deriveStatus(),
+        preview,
+        previewError: isPreviewCurrent
+            ? toTicketError(previewMutation.error)
+            : undefined,
+        issue: createMutation.data,
+        createError: toTicketError(createMutation.error),
+        prepare: (request) =>
+            runExclusive(() =>
+                previewMutation.mutate({
+                    request,
+                    generation: generationRef.current,
+                }),
+            ),
+        send: (request) => {
+            // Sending requires a reviewed preview; the server enforces the same rule.
+            if (preview != null) {
+                runExclusive(() => createMutation.mutate(request));
+            }
+        },
+        reset: () => {
+            generationRef.current += 1;
+            previewMutation.reset();
+            createMutation.reset();
+        },
+    };
+};

--- a/packages/assistant-chat/src/monitoring/chatMonitoring.api.ts
+++ b/packages/assistant-chat/src/monitoring/chatMonitoring.api.ts
@@ -1,0 +1,33 @@
+export interface IChatMonitoringErrorParams {
+    /**
+     * Additional data to be logged.
+     */
+    context?: Record<string, unknown>;
+}
+
+export interface IChatMonitoringMessageParams {
+    /**
+     * Additional data to be logged.
+     */
+    context?: Record<string, string | number | boolean | undefined>;
+    /**
+     * Severity level of the message.
+     * @default info
+     */
+    level?: 'info' | 'warning' | 'error';
+}
+
+/**
+ * Monitoring seam of the widget. Signature-compatible with the Aragon App monitoringUtils, so the
+ * host app can inject its Sentry-backed implementation by passing the methods through directly.
+ */
+export interface IChatMonitoring {
+    /**
+     * Logs the given error.
+     */
+    logError: (error: unknown, params?: IChatMonitoringErrorParams) => void;
+    /**
+     * Logs the given message.
+     */
+    logMessage: (name: string, params?: IChatMonitoringMessageParams) => void;
+}

--- a/packages/assistant-chat/src/monitoring/index.ts
+++ b/packages/assistant-chat/src/monitoring/index.ts
@@ -1,0 +1,6 @@
+export type {
+    IChatMonitoring,
+    IChatMonitoringErrorParams,
+    IChatMonitoringMessageParams,
+} from './chatMonitoring.api';
+export { noopMonitoring } from './noopMonitoring';

--- a/packages/assistant-chat/src/monitoring/noopMonitoring.ts
+++ b/packages/assistant-chat/src/monitoring/noopMonitoring.ts
@@ -1,0 +1,9 @@
+import type { IChatMonitoring } from './chatMonitoring.api';
+
+/**
+ * Default monitoring used when the host app does not inject an implementation.
+ */
+export const noopMonitoring: IChatMonitoring = {
+    logError: () => undefined,
+    logMessage: () => undefined,
+};

--- a/packages/assistant-chat/src/requests/index.ts
+++ b/packages/assistant-chat/src/requests/index.ts
@@ -1,0 +1,5 @@
+export {
+    appendRequestToHistory,
+    getRequestHistory,
+    type IRequestHistoryEntry,
+} from './requestHistory';

--- a/packages/assistant-chat/src/requests/requestHistory.ts
+++ b/packages/assistant-chat/src/requests/requestHistory.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+const storageKey = 'aragon-assistant:requests';
+
+// The history is a lightweight convenience (deep links to past requests), not a source of
+// truth: it is capped, device-local and dropped silently when localStorage is unavailable.
+const maxEntries = 20;
+
+const requestHistoryEntrySchema = z.object({
+    identifier: z.string(),
+    url: z.string(),
+    summary: z.string(),
+    createdAt: z.string(),
+});
+
+const requestHistorySchema = z.array(requestHistoryEntrySchema);
+
+export type IRequestHistoryEntry = z.infer<typeof requestHistoryEntrySchema>;
+
+/**
+ * Reads the stored request history, newest first. Returns an empty list when storage is
+ * unavailable or holds malformed data.
+ */
+export const getRequestHistory = (): IRequestHistoryEntry[] => {
+    try {
+        const raw = localStorage.getItem(storageKey);
+
+        if (raw == null) {
+            return [];
+        }
+
+        return requestHistorySchema.parse(JSON.parse(raw));
+    } catch {
+        return [];
+    }
+};
+
+/**
+ * Prepends the given entry to the stored request history and returns the updated list.
+ */
+export const appendRequestToHistory = (
+    entry: IRequestHistoryEntry,
+): IRequestHistoryEntry[] => {
+    const history = [entry, ...getRequestHistory()].slice(0, maxEntries);
+
+    try {
+        localStorage.setItem(storageKey, JSON.stringify(history));
+    } catch {
+        // Ignore storage failures (e.g. private mode): the entry only lives in memory.
+    }
+
+    return history;
+};

--- a/packages/assistant-chat/src/session/index.ts
+++ b/packages/assistant-chat/src/session/index.ts
@@ -1,0 +1,1 @@
+export { type IUseChatSessionResult, useChatSession } from './useChatSession';

--- a/packages/assistant-chat/src/session/useChatSession.ts
+++ b/packages/assistant-chat/src/session/useChatSession.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from 'react';
+
+export interface IUseChatSessionResult {
+    /**
+     * Identifier of the current chat session, generated client-side.
+     */
+    sessionId: string;
+    /**
+     * Starts a fresh session (e.g. after an issue has been created).
+     */
+    rotate: () => void;
+}
+
+export const useChatSession = (): IUseChatSessionResult => {
+    const [sessionId, setSessionId] = useState(() => crypto.randomUUID());
+
+    const rotate = useCallback(() => setSessionId(crypto.randomUUID()), []);
+
+    return { sessionId, rotate };
+};

--- a/packages/assistant-chat/src/test/setup.ts
+++ b/packages/assistant-chat/src/test/setup.ts
@@ -1,0 +1,56 @@
+// Setup testing-library DOM element matchers (e.g. toBeInTheDocument)
+import '@testing-library/jest-dom';
+import {
+    ReadableStream,
+    TextDecoderStream,
+    TransformStream,
+    WritableStream,
+} from 'node:stream/web';
+import { TextDecoder, TextEncoder } from 'node:util';
+import { deserialize, serialize } from 'node:v8';
+
+// Globally setup TextEncoder/TextDecoder needed by viem (pulled in through gov-ui-kit)
+Object.assign(global, { TextDecoder, TextEncoder });
+
+// jsdom does not implement web streams, required by the AI SDK's SSE parsing
+Object.assign(global, {
+    ReadableStream,
+    TextDecoderStream,
+    TransformStream,
+    WritableStream,
+});
+
+// jsdom does not implement structuredClone, used by the AI SDK to snapshot message state
+Object.assign(global, {
+    structuredClone: (value: unknown) => deserialize(serialize(value)),
+});
+
+// Mock ResizeObserver functionality
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+}));
+
+// jsdom does not implement scrollIntoView, used to follow the latest chat message
+Element.prototype.scrollIntoView = jest.fn();
+
+// jsdom does not implement the pointer-capture APIs Radix dialogs rely on
+Element.prototype.hasPointerCapture = jest.fn();
+Element.prototype.setPointerCapture = jest.fn();
+Element.prototype.releasePointerCapture = jest.fn();
+
+// jsdom does not implement matchMedia
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+    })),
+});

--- a/packages/assistant-chat/src/transport/assistantErrorText.ts
+++ b/packages/assistant-chat/src/transport/assistantErrorText.ts
@@ -1,0 +1,22 @@
+import type { IAssistantErrorCode } from '@aragon/assistant-contracts';
+
+// Single source of the human wording for error codes the service is known to send. Unknown
+// codes and foreign errors (network failures, aborts) fall back to the caller's
+// context-specific hint.
+const errorTextByCode: Partial<Record<IAssistantErrorCode, string>> = {
+    rate_limited:
+        "You're going a little too fast. Wait a moment and try again.",
+    session_limit:
+        "You've reached today's limit for new support chats. Use the support portal to open a new ticket.",
+    upstream_rate_limited:
+        'The assistant is handling a lot of requests right now. Please try again in a minute.',
+};
+
+/**
+ * Resolves the user-facing message for an assistant service error code. Falls back to the given
+ * context-specific text for unknown codes and non-service failures.
+ */
+export const getAssistantErrorText = (
+    code: IAssistantErrorCode | undefined,
+    fallbackText: string,
+): string => (code != null ? errorTextByCode[code] : undefined) ?? fallbackText;

--- a/packages/assistant-chat/src/transport/chatTransport.api.ts
+++ b/packages/assistant-chat/src/transport/chatTransport.api.ts
@@ -1,0 +1,9 @@
+import type { UIMessage } from 'ai';
+
+/**
+ * UI message shape used by the widget: plain text messages, no metadata and no custom data parts —
+ * the stream carries the conversation only, ticket state lives behind the explicit preview flow.
+ */
+export type AssistantUIMessage = UIMessage;
+
+export type ChatStatus = 'submitted' | 'streaming' | 'ready' | 'error';

--- a/packages/assistant-chat/src/transport/createChatTransport.ts
+++ b/packages/assistant-chat/src/transport/createChatTransport.ts
@@ -1,0 +1,41 @@
+import type { IAppContext, IChatRequest } from '@aragon/assistant-contracts';
+import { DefaultChatTransport } from 'ai';
+import type { AssistantUIMessage } from './chatTransport.api';
+
+export interface ICreateChatTransportParams {
+    /**
+     * Base URL of the assistant service.
+     */
+    assistantUrl: string;
+    /**
+     * Returns the identifier of the current chat session.
+     */
+    getSessionId: () => string;
+    /**
+     * Returns the app context sent alongside every request.
+     */
+    getAppContext: () => IAppContext;
+}
+
+// The server re-validates against chatRequestSchema; only the fields of the contract are sent
+// (the default AI SDK body would leak chat id / trigger metadata).
+const buildRequestBody = (
+    params: ICreateChatTransportParams,
+    messages: AssistantUIMessage[],
+): IChatRequest => ({
+    sessionId: params.getSessionId(),
+    messages: messages.map((message) => ({
+        id: message.id,
+        role: message.role === 'user' ? 'user' : 'assistant',
+        parts: message.parts,
+    })),
+    appContext: params.getAppContext(),
+});
+
+export const createChatTransport = (params: ICreateChatTransportParams) =>
+    new DefaultChatTransport<AssistantUIMessage>({
+        api: `${params.assistantUrl}/chat`,
+        prepareSendMessagesRequest: ({ messages }) => ({
+            body: buildRequestBody(params, messages),
+        }),
+    });

--- a/packages/assistant-chat/src/transport/index.ts
+++ b/packages/assistant-chat/src/transport/index.ts
@@ -1,0 +1,12 @@
+export { getAssistantErrorText } from './assistantErrorText';
+export type { AssistantUIMessage, ChatStatus } from './chatTransport.api';
+export {
+    createChatTransport,
+    type ICreateChatTransportParams,
+} from './createChatTransport';
+export { parseAssistantError } from './parseAssistantError';
+export {
+    type IUseAssistantChatParams,
+    type IUseAssistantChatResult,
+    useAssistantChat,
+} from './useAssistantChat';

--- a/packages/assistant-chat/src/transport/parseAssistantError.ts
+++ b/packages/assistant-chat/src/transport/parseAssistantError.ts
@@ -1,0 +1,28 @@
+import {
+    assistantErrorSchema,
+    type IAssistantError,
+} from '@aragon/assistant-contracts';
+
+/**
+ * Extracts the assistant service error shape from a chat transport error, when present. Covers
+ * both failure paths: non-2xx responses (the AI SDK throws with the response body as the Error
+ * message) and mid-stream failures (the service encodes the same shape into the stream error
+ * part). Returns null for anything else — network failures, aborts, foreign errors.
+ */
+export const parseAssistantError = (
+    error: unknown,
+): IAssistantError['error'] | null => {
+    if (!(error instanceof Error)) {
+        return null;
+    }
+
+    try {
+        const parsed = assistantErrorSchema.safeParse(
+            JSON.parse(error.message),
+        );
+
+        return parsed.success ? parsed.data.error : null;
+    } catch {
+        return null;
+    }
+};

--- a/packages/assistant-chat/src/transport/useAssistantChat.ts
+++ b/packages/assistant-chat/src/transport/useAssistantChat.ts
@@ -1,0 +1,123 @@
+import { useChat } from '@ai-sdk/react';
+import type { IAppContext } from '@aragon/assistant-contracts';
+import { useCallback, useMemo, useRef } from 'react';
+import type { IChatMonitoring } from '../monitoring';
+import type { AssistantUIMessage, ChatStatus } from './chatTransport.api';
+import { createChatTransport } from './createChatTransport';
+
+export interface IUseAssistantChatParams {
+    /**
+     * Base URL of the assistant service.
+     */
+    assistantUrl: string;
+    /**
+     * Identifier of the current chat session; a new identifier starts a fresh chat.
+     */
+    sessionId: string;
+    /**
+     * App context sent alongside every request.
+     */
+    appContext: IAppContext;
+    /**
+     * Monitoring implementation used to report transport errors.
+     */
+    monitoring: IChatMonitoring;
+}
+
+export interface IUseAssistantChatResult {
+    /**
+     * Raw transcript, used for stateless issue creation.
+     */
+    messages: AssistantUIMessage[];
+    /**
+     * Messages for rendering: only the ones carrying text content (data-part-only chunks are
+     * dropped).
+     */
+    visibleMessages: AssistantUIMessage[];
+    /**
+     * Status of the current chat request.
+     */
+    status: ChatStatus;
+    /**
+     * Error of the last chat request, if any.
+     */
+    error?: Error;
+    /**
+     * Sends a user text message to the assistant.
+     */
+    sendMessage: (text: string) => void;
+    /**
+     * Aborts the streaming response of the current chat request.
+     */
+    stop: () => void;
+}
+
+/**
+ * The widget's single seam to the AI SDK: transport wiring, error reporting and data-part
+ * extraction all live behind this hook.
+ */
+export const useAssistantChat = (
+    params: IUseAssistantChatParams,
+): IUseAssistantChatResult => {
+    const { assistantUrl, sessionId, appContext, monitoring } = params;
+
+    // The transport reads session and context through refs so that a stale closure can never
+    // send an outdated session identifier after a rotation.
+    const sessionIdRef = useRef(sessionId);
+    sessionIdRef.current = sessionId;
+    const appContextRef = useRef(appContext);
+    appContextRef.current = appContext;
+
+    const transport = useMemo(
+        () =>
+            createChatTransport({
+                assistantUrl,
+                getSessionId: () => sessionIdRef.current,
+                getAppContext: () => appContextRef.current,
+            }),
+        [assistantUrl],
+    );
+
+    const monitoringRef = useRef(monitoring);
+    monitoringRef.current = monitoring;
+
+    const handleError = useCallback(
+        (error: Error) =>
+            monitoringRef.current.logError(error, {
+                context: { step: 'assistantChat.transport' },
+            }),
+        [],
+    );
+
+    const chat = useChat<AssistantUIMessage>({
+        id: sessionId,
+        transport,
+        onError: handleError,
+    });
+
+    const visibleMessages = useMemo(
+        () =>
+            chat.messages.filter((message) =>
+                message.parts.some(
+                    (part) => part.type === 'text' && part.text.length > 0,
+                ),
+            ),
+        [chat.messages],
+    );
+
+    const sendMessage = useCallback(
+        (text: string) => void chat.sendMessage({ text }),
+        [chat.sendMessage],
+    );
+
+    const stop = useCallback(() => void chat.stop(), [chat.stop]);
+
+    return {
+        messages: chat.messages,
+        visibleMessages,
+        status: chat.status,
+        error: chat.error,
+        sendMessage,
+        stop,
+    };
+};

--- a/packages/assistant-chat/tsconfig.json
+++ b/packages/assistant-chat/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "allowJs": true,
+        "jsx": "react-jsx",
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "esnext"
+        ],
+        "types": [
+            "node",
+            "jest",
+            "@testing-library/jest-dom"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "coverage"
+    ],
+    "include": [
+        "src",
+        "jest.config.js"
+    ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@ai-sdk/react':
+      specifier: ^4.0.0
+      version: 4.0.19
+    '@aragon/gov-ui-kit':
+      specifier: ^2.8.1
+      version: 2.9.0
     '@biomejs/biome':
       specifier: ^2.5.0
       version: 2.5.0
@@ -21,6 +27,9 @@ catalogs:
     '@linear/sdk':
       specifier: ^88.0.0
       version: 88.0.0
+    '@radix-ui/react-dialog':
+      specifier: ^1.1.17
+      version: 1.1.17
     '@sentry/cli':
       specifier: ^3.6.0
       version: 3.6.0
@@ -33,12 +42,36 @@ catalogs:
     '@sentry/profiling-node':
       specifier: ^10.63.0
       version: 10.63.0
+    '@tailwindcss/typography':
+      specifier: ^0.5.20
+      version: 0.5.20
+    '@tanstack/react-query':
+      specifier: ^5.101.0
+      version: 5.101.0
+    '@testing-library/dom':
+      specifier: ^10.4.1
+      version: 10.4.1
+    '@testing-library/jest-dom':
+      specifier: ^6.9.1
+      version: 6.9.1
+    '@testing-library/react':
+      specifier: ^16.3.2
+      version: 16.3.2
+    '@testing-library/user-event':
+      specifier: ^14.6.1
+      version: 14.6.1
     '@types/jest':
       specifier: ^30.0.0
       version: 30.0.0
     '@types/node':
       specifier: ^24.13.2
       version: 24.13.2
+    '@types/react':
+      specifier: ^19.2.17
+      version: 19.2.17
+    '@types/react-dom':
+      specifier: ^19.2.3
+      version: 19.2.3
     '@upstash/ratelimit':
       specifier: ^2.0.8
       version: 2.0.8
@@ -51,6 +84,9 @@ catalogs:
     ai:
       specifier: ^7.0.0
       version: 7.0.15
+    classnames:
+      specifier: ^2.5.1
+      version: 2.5.1
     cross-env:
       specifier: ^10.1.0
       version: 10.1.0
@@ -66,9 +102,27 @@ catalogs:
     jest:
       specifier: ^30.4.2
       version: 30.4.2
+    jest-environment-jsdom:
+      specifier: ^30.4.1
+      version: 30.4.1
     lint-staged:
       specifier: ^17.0.7
       version: 17.0.7
+    react:
+      specifier: ^19.2.7
+      version: 19.2.7
+    react-dom:
+      specifier: ^19.2.7
+      version: 19.2.7
+    react-dropzone:
+      specifier: ^15.0.0
+      version: 15.0.0
+    react-hook-form:
+      specifier: ^7.79.0
+      version: 7.79.0
+    tailwindcss:
+      specifier: ^4.3.1
+      version: 4.3.1
     ts-jest:
       specifier: ^29.4.11
       version: 29.4.11
@@ -90,6 +144,12 @@ catalogs:
     vercel:
       specifier: ^52.2.1
       version: 52.2.1
+    viem:
+      specifier: ^2.52.2
+      version: 2.53.1
+    wagmi:
+      specifier: ^3.6.17
+      version: 3.6.17
     yaml:
       specifier: ^2.9.0
       version: 2.9.0
@@ -275,7 +335,7 @@ importers:
         version: 1.61.0
       '@synthetixio/synpress':
         specifier: ^4.1.2
-        version: 4.1.2(@depay/solana-web3.js@1.98.3)(@depay/web3-blockchains@9.8.13)(@playwright/test@1.61.0)(ethers@5.8.0)(playwright-core@1.61.0)(postcss@8.5.15)(typescript@5.9.3)(zod@3.25.76)
+        version: 4.1.2(@depay/solana-web3.js@1.98.3)(@depay/web3-blockchains@9.8.13)(@playwright/test@1.61.0)(ethers@5.8.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)(zod@3.25.76)
       '@tailwindcss/postcss':
         specifier: ^4.3.1
         version: 4.3.1
@@ -422,6 +482,100 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/assistant-chat:
+    dependencies:
+      '@ai-sdk/react':
+        specifier: 'catalog:'
+        version: 4.0.19(react@19.2.7)(zod@4.4.3)
+      '@aragon/assistant-contracts':
+        specifier: workspace:*
+        version: link:../assistant-contracts
+      '@radix-ui/react-dialog':
+        specifier: 'catalog:'
+        version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@vercel/blob':
+        specifier: 'catalog:'
+        version: 2.5.0
+      ai:
+        specifier: 'catalog:'
+        version: 7.0.15(zod@4.4.3)
+      classnames:
+        specifier: 'catalog:'
+        version: 2.5.1
+      react-dropzone:
+        specifier: 'catalog:'
+        version: 15.0.0(react@19.2.7)
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@aragon/gov-ui-kit':
+        specifier: 'catalog:'
+        version: 2.9.0(@emotion/is-prop-valid@1.4.0)(@floating-ui/dom@1.7.6)(@tailwindcss/typography@0.5.20(tailwindcss@4.3.1))(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.79.0(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(viem@2.53.1(typescript@5.9.3)(zod@4.4.3))(wagmi@3.6.17(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@4.4.3))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@4.4.3))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@4.4.3))(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(viem@2.53.1(typescript@5.9.3)(zod@4.4.3)))
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 2.5.0
+      '@tailwindcss/typography':
+        specifier: 'catalog:'
+        version: 0.5.20(tailwindcss@4.3.1)
+      '@tanstack/react-query':
+        specifier: 'catalog:'
+        version: 5.101.0(react@19.2.7)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      jest:
+        specifier: 'catalog:'
+        version: 30.4.2(@types/node@24.13.2)(babel-plugin-macros@3.1.0)
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.4.1
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+      react-hook-form:
+        specifier: 'catalog:'
+        version: 7.79.0(react@19.2.7)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.3.1
+      ts-jest:
+        specifier: 'catalog:'
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.13.2)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      viem:
+        specifier: 'catalog:'
+        version: 2.53.1(typescript@5.9.3)(zod@4.4.3)
+      wagmi:
+        specifier: 'catalog:'
+        version: 3.6.17(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@4.4.3))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@4.4.3))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@4.4.3))(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(viem@2.53.1(typescript@5.9.3)(zod@4.4.3))
+
   packages/assistant-contracts:
     dependencies:
       zod:
@@ -467,8 +621,26 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@4.0.14':
+    resolution: {integrity: sha512-wbYqQKpASsuK7bdoa1fp+QA6oy3ddqqBOukN3IkyaR8PAp0pWoc66ch2td+ixeknoCcO4F6VTkSFKVC6MP3bTQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mcp@2.0.9':
+    resolution: {integrity: sha512-Mokfd6Ff5QjpdftICnQ9jC9opJcUqfPE31oG9sTYiXEykj5InIt0FA+9acLtCrnM/hx3Tz2BgkNQCXibjSDhpA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.5':
     resolution: {integrity: sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.6':
+    resolution: {integrity: sha512-i4mVayGtC+HrRmtfPFOxvKKQgFU+1dwTTsh4MY0jY1MaGuppOwDFrNYrJ3dDXWMkO3o6FDVAKY8ZDsy7hLsO9Q==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -476,6 +648,12 @@ packages:
   '@ai-sdk/provider@4.0.2':
     resolution: {integrity: sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==}
     engines: {node: '>=22'}
+
+  '@ai-sdk/react@4.0.19':
+    resolution: {integrity: sha512-3n/UxiZZh727ROIjQMEyphyzsz3N8bKyBIcfFHicLq7fJjuydQ8owcGRmLXoU5jrhGBRTf4O1QhwmgYNU+vkJA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -4490,6 +4668,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  ai@7.0.18:
+    resolution: {integrity: sha512-/DsiRfbLPtoHf9C47Hy+LK+HkjNowX1DQo3id4zWegfU6z1WjVDRAHYJAiX7SXhGp0mWX4tcenUhfIFessDWnw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
 
@@ -6875,6 +7059,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -7551,6 +7739,11 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swr@2.4.2:
+    resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -8337,7 +8530,29 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
+  '@ai-sdk/gateway@4.0.14(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/mcp@2.0.9(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.4.3)
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@5.0.5(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.6(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.2
       '@standard-schema/spec': 1.1.0
@@ -8348,6 +8563,18 @@ snapshots:
   '@ai-sdk/provider@4.0.2':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/react@4.0.19(react@19.2.7)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/mcp': 2.0.9(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.4.3)
+      ai: 7.0.18(zod@4.4.3)
+      react: 19.2.7
+      swr: 2.4.2(react@19.2.7)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -8425,6 +8652,52 @@ snapshots:
       tiptap-markdown: 0.9.0(@tiptap/core@3.27.0(@tiptap/pm@3.27.0))
       viem: 2.53.1(typescript@5.9.3)(zod@3.25.76)
       wagmi: 3.6.17(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@3.25.76))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(viem@2.53.1(typescript@5.9.3)(zod@3.25.76))
+    optionalDependencies:
+      '@tailwindcss/typography': 0.5.20(tailwindcss@4.3.1)
+      tailwindcss: 4.3.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@floating-ui/dom'
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@aragon/gov-ui-kit@2.9.0(@emotion/is-prop-valid@1.4.0)(@floating-ui/dom@1.7.6)(@tailwindcss/typography@0.5.20(tailwindcss@4.3.1))(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.79.0(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(viem@2.53.1(typescript@5.9.3)(zod@4.4.3))(wagmi@3.6.17(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@4.4.3))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@4.4.3))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@4.4.3))(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(viem@2.53.1(typescript@5.9.3)(zod@4.4.3)))':
+    dependencies:
+      '@radix-ui/react-accordion': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-alert-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-avatar': 1.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-checkbox': 1.3.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu': 2.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-progress': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-radio-group': 1.4.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-switch': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tabs': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle-group': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tooltip': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-query': 5.101.0(react@19.2.7)
+      '@tiptap/core': 3.27.0(@tiptap/pm@3.27.0)
+      '@tiptap/extension-image': 3.27.0(@tiptap/core@3.27.0(@tiptap/pm@3.27.0))
+      '@tiptap/extensions': 3.27.0(@tiptap/core@3.27.0(@tiptap/pm@3.27.0))(@tiptap/pm@3.27.0)
+      '@tiptap/pm': 3.27.0
+      '@tiptap/react': 3.27.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.0(@tiptap/pm@3.27.0))(@tiptap/pm@3.27.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/starter-kit': 3.27.0
+      blockies-ts: 1.0.0
+      classnames: 2.5.1
+      framer-motion: 12.40.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      imask: 7.6.1
+      luxon: 3.7.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-dropzone: 15.0.0(react@19.2.7)
+      react-hook-form: 7.79.0(react@19.2.7)
+      react-imask: 7.6.1(react@19.2.7)
+      sanitize-html: 2.17.5
+      tiptap-markdown: 0.9.0(@tiptap/core@3.27.0(@tiptap/pm@3.27.0))
+      viem: 2.53.1(typescript@5.9.3)(zod@4.4.3)
+      wagmi: 3.6.17(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@4.4.3))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@4.4.3))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@4.4.3))(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(viem@2.53.1(typescript@5.9.3)(zod@4.4.3))
     optionalDependencies:
       '@tailwindcss/typography': 0.5.20(tailwindcss@4.3.1)
       tailwindcss: 4.3.1
@@ -8923,6 +9196,27 @@ snapshots:
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
       viem: 2.53.1(typescript@5.9.3)(zod@3.25.76)
+      zustand: 5.0.3(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@4.4.3)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)(zod@4.4.3)
+      preact: 10.24.2
+      viem: 2.53.1(typescript@5.9.3)(zod@4.4.3)
       zustand: 5.0.3(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     transitivePeerDependencies:
       - '@types/react'
@@ -11102,10 +11396,32 @@ snapshots:
       - zod
     optional: true
 
+  '@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@4.4.3)':
+    dependencies:
+      '@safe-global/safe-apps-sdk': 9.1.0(typescript@5.9.3)(zod@4.4.3)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    optional: true
+
   '@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
       viem: 2.53.1(typescript@5.9.3)(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@4.4.3)':
+    dependencies:
+      '@safe-global/safe-gateway-typescript-sdk': 3.23.1
+      viem: 2.53.1(typescript@5.9.3)(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -11904,7 +12220,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@synthetixio/synpress-cache@0.0.14(playwright-core@1.61.0)(postcss@8.5.15)(typescript@5.9.3)':
+  '@synthetixio/synpress-cache@0.0.14(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       axios: 1.18.0
       chalk: 5.3.0
@@ -11913,7 +12229,6 @@ snapshots:
       fs-extra: 11.2.0
       glob: 13.0.6
       gradient-string: 2.0.2
-      playwright-core: 1.61.0
       progress: 2.0.3
       tsup: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       unzip-crx-3: 0.2.0
@@ -11934,10 +12249,10 @@ snapshots:
     dependencies:
       '@playwright/test': 1.61.0
 
-  '@synthetixio/synpress-metamask@0.0.14(@playwright/test@1.61.0)(playwright-core@1.61.0)(postcss@8.5.15)(typescript@5.9.3)':
+  '@synthetixio/synpress-metamask@0.0.14(@playwright/test@1.61.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       '@playwright/test': 1.61.0
-      '@synthetixio/synpress-cache': 0.0.14(playwright-core@1.61.0)(postcss@8.5.15)(typescript@5.9.3)
+      '@synthetixio/synpress-cache': 0.0.14(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
       '@synthetixio/synpress-core': 0.0.14(@playwright/test@1.61.0)
       '@viem/anvil': 0.0.7
       fs-extra: 11.2.0
@@ -11956,10 +12271,10 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@synthetixio/synpress-phantom@0.0.14(@playwright/test@1.61.0)(playwright-core@1.61.0)(postcss@8.5.15)(typescript@5.9.3)':
+  '@synthetixio/synpress-phantom@0.0.14(@playwright/test@1.61.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       '@playwright/test': 1.61.0
-      '@synthetixio/synpress-cache': 0.0.14(playwright-core@1.61.0)(postcss@8.5.15)(typescript@5.9.3)
+      '@synthetixio/synpress-cache': 0.0.14(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
       '@synthetixio/synpress-core': 0.0.14(@playwright/test@1.61.0)
       '@viem/anvil': 0.0.7
       fs-extra: 11.2.0
@@ -11978,14 +12293,14 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@synthetixio/synpress@4.1.2(@depay/solana-web3.js@1.98.3)(@depay/web3-blockchains@9.8.13)(@playwright/test@1.61.0)(ethers@5.8.0)(playwright-core@1.61.0)(postcss@8.5.15)(typescript@5.9.3)(zod@3.25.76)':
+  '@synthetixio/synpress@4.1.2(@depay/solana-web3.js@1.98.3)(@depay/web3-blockchains@9.8.13)(@playwright/test@1.61.0)(ethers@5.8.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)(zod@3.25.76)':
     dependencies:
       '@playwright/test': 1.61.0
       '@synthetixio/ethereum-wallet-mock': 0.0.14(@depay/solana-web3.js@1.98.3)(@depay/web3-blockchains@9.8.13)(@playwright/test@1.61.0)(ethers@5.8.0)(typescript@5.9.3)(zod@3.25.76)
-      '@synthetixio/synpress-cache': 0.0.14(playwright-core@1.61.0)(postcss@8.5.15)(typescript@5.9.3)
+      '@synthetixio/synpress-cache': 0.0.14(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
       '@synthetixio/synpress-core': 0.0.14(@playwright/test@1.61.0)
-      '@synthetixio/synpress-metamask': 0.0.14(@playwright/test@1.61.0)(playwright-core@1.61.0)(postcss@8.5.15)(typescript@5.9.3)
-      '@synthetixio/synpress-phantom': 0.0.14(@playwright/test@1.61.0)(playwright-core@1.61.0)(postcss@8.5.15)(typescript@5.9.3)
+      '@synthetixio/synpress-metamask': 0.0.14(@playwright/test@1.61.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
+      '@synthetixio/synpress-phantom': 0.0.14(@playwright/test@1.61.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@depay/solana-web3.js'
       - '@depay/web3-blockchains'
@@ -12921,11 +13236,36 @@ snapshots:
       '@safe-global/safe-apps-sdk': 9.1.0(typescript@5.9.3)(zod@3.25.76)
       typescript: 5.9.3
 
+  '@wagmi/connectors@8.0.16(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@4.4.3))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@4.4.3))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@4.4.3))(@wagmi/core@3.5.1(@tanstack/query-core@5.101.0)(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.53.1(typescript@5.9.3)(zod@4.4.3)))(typescript@5.9.3)(viem@2.53.1(typescript@5.9.3)(zod@4.4.3))':
+    dependencies:
+      '@wagmi/core': 3.5.1(@tanstack/query-core@5.101.0)(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.53.1(typescript@5.9.3)(zod@4.4.3))
+      viem: 2.53.1(typescript@5.9.3)(zod@4.4.3)
+    optionalDependencies:
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@4.4.3)
+      '@safe-global/safe-apps-provider': 0.18.6(typescript@5.9.3)(zod@4.4.3)
+      '@safe-global/safe-apps-sdk': 9.1.0(typescript@5.9.3)(zod@4.4.3)
+      typescript: 5.9.3
+
   '@wagmi/core@3.5.1(@tanstack/query-core@5.101.0)(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.53.1(typescript@5.9.3)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
       viem: 2.53.1(typescript@5.9.3)(zod@3.25.76)
+      zustand: 5.0.0(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
+    optionalDependencies:
+      '@tanstack/query-core': 5.101.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@3.5.1(@tanstack/query-core@5.101.0)(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.53.1(typescript@5.9.3)(zod@4.4.3))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@5.9.3)
+      viem: 2.53.1(typescript@5.9.3)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
     optionalDependencies:
       '@tanstack/query-core': 5.101.0
@@ -13552,6 +13892,11 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
+  abitype@1.2.3(typescript@5.9.3)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.4.3
+
   abitype@1.2.4(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
       typescript: 5.9.3
@@ -13561,6 +13906,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       zod: 3.25.76
+
+  abitype@1.2.4(typescript@5.9.3)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.4.3
 
   acorn-import-attributes@1.9.5(acorn@8.17.0):
     dependencies:
@@ -13587,6 +13937,13 @@ snapshots:
       '@ai-sdk/gateway': 4.0.12(zod@4.4.3)
       '@ai-sdk/provider': 4.0.2
       '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      zod: 4.4.3
+
+  ai@7.0.18(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.14(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@2.1.1:
@@ -15961,6 +16318,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.14.29(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -15969,6 +16341,21 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.4(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+    optional: true
+
+  ox@0.6.9(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -16155,6 +16542,8 @@ snapshots:
       thread-stream: 3.2.0
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -16902,6 +17291,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.4.2(react@19.2.7):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
   symbol-tree@3.2.4: {}
 
   synckit@0.11.13:
@@ -17400,6 +17795,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.53.1(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
+      isows: 1.0.7(ws@8.21.0)
+      ox: 0.14.29(typescript@5.9.3)(zod@4.4.3)
+      ws: 8.21.0
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   viem@2.9.9(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
@@ -17431,6 +17843,29 @@ snapshots:
       react: 19.2.7
       use-sync-external-store: 1.4.0(react@19.2.7)
       viem: 2.53.1(typescript@5.9.3)(zod@3.25.76)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@base-org/account'
+      - '@coinbase/wallet-sdk'
+      - '@metamask/connect-evm'
+      - '@safe-global/safe-apps-provider'
+      - '@safe-global/safe-apps-sdk'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@walletconnect/ethereum-provider'
+      - accounts
+      - immer
+      - porto
+
+  wagmi@3.6.17(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@4.4.3))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@4.4.3))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@4.4.3))(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(viem@2.53.1(typescript@5.9.3)(zod@4.4.3)):
+    dependencies:
+      '@tanstack/react-query': 5.101.0(react@19.2.7)
+      '@wagmi/connectors': 8.0.16(@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@4.4.3))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@4.4.3))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@4.4.3))(@wagmi/core@3.5.1(@tanstack/query-core@5.101.0)(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.53.1(typescript@5.9.3)(zod@4.4.3)))(typescript@5.9.3)(viem@2.53.1(typescript@5.9.3)(zod@4.4.3))
+      '@wagmi/core': 3.5.1(@tanstack/query-core@5.101.0)(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.53.1(typescript@5.9.3)(zod@4.4.3))
+      react: 19.2.7
+      use-sync-external-store: 1.4.0(react@19.2.7)
+      viem: 2.53.1(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,27 +7,45 @@ packages:
 # (run `pnpm up` from the root afterwards). Remember: a catalog bump changes all workspaces, so run
 # the full test fan-out and expect releases of every affected workspace.
 catalog:
+  "@ai-sdk/react": ^4.0.0
+  "@aragon/gov-ui-kit": ^2.8.1
   "@biomejs/biome": ^2.5.0
   "@changesets/changelog-github": ^0.7.0
   "@changesets/cli": ^2.31.0
   "@hono/node-server": ^1.19.7
   "@linear/sdk": ^88.0.0
+  "@radix-ui/react-dialog": ^1.1.17
   "@sentry/cli": ^3.6.0
   "@sentry/hono": ^10.63.0
   "@sentry/node": ^10.63.0
   "@sentry/profiling-node": ^10.63.0
+  "@tailwindcss/typography": ^0.5.20
+  "@tanstack/react-query": ^5.101.0
+  "@testing-library/dom": ^10.4.1
+  "@testing-library/jest-dom": ^6.9.1
+  "@testing-library/react": ^16.3.2
+  "@testing-library/user-event": ^14.6.1
   "@types/jest": ^30.0.0
   "@types/node": ^24.13.2
+  "@types/react": ^19.2.17
+  "@types/react-dom": ^19.2.3
   "@upstash/ratelimit": ^2.0.8
   "@upstash/redis": ^1.38.0
   "@vercel/blob": ^2.5.0
   ai: ^7.0.0
+  classnames: ^2.5.1
   cross-env: ^10.1.0
   file-type: ^22.0.0
   hono: ^4.11.9
   husky: ^9.1.7
   jest: ^30.4.2
+  jest-environment-jsdom: ^30.4.1
   lint-staged: ^17.0.7
+  react: ^19.2.7
+  react-dom: ^19.2.7
+  react-dropzone: ^15.0.0
+  react-hook-form: ^7.79.0
+  tailwindcss: ^4.3.1
   ts-jest: ^29.4.11
   tsup: ^8.5.1
   tsx: ^4.20.0
@@ -35,6 +53,8 @@ catalog:
   typescript: ^5.9.3
   ultracite: ^7.8.3
   vercel: ^52.2.1
+  viem: ^2.52.2
+  wagmi: ^3.6.17
   yaml: ^2.9.0
   zod: ^4.1.16
 


### PR DESCRIPTION
This adds `packages/assistant-chat` — the support chat widget consuming the intake API from #1224. Previously the intake pipeline existed only as an API; there was no UI to talk to it. Now the full drawer experience from the design mock is implemented as a source-consumed workspace package: chat with live intake summary, blob-backed attachments, explicit ticket creation and per-request lifecycle. The widget stays dark until PR4 — nothing imports it from the app yet.

The widget carries no hand-rolled infrastructure: issue creation is a `@tanstack/react-query` mutation (the host app already provides the `QueryClientProvider`), and components consume AI SDK `UIMessage`s directly — no mapper layer, no parallel view-model types.

## Changes

- **New workspace `@aragon/assistant-chat`** — private, source-consumed (`main/types: src/index.ts`, `sideEffects: false`, no build step; the app adds it to `transpilePackages` in PR4). Peers: `react`/`react-dom` ^19, `@aragon/gov-ui-kit` ^2.8.1, `@tanstack/react-query` ^5; the lean barrel exports only `AssistantChat`, its props, `IChatMonitoring` and `noopMonitoring` — sized for `next/dynamic`.
- **AI SDK isolated in `src/transport/`** — the only import point of `ai`/`@ai-sdk/react`: `createChatTransport` sends a clean `{sessionId, messages, appContext}` body, `useAssistantChat` wraps `useChat` and exposes the raw transcript (for stateless issue creation), a rendering list filtered to messages with text parts, `stop`, and the zod-parsed `data-collectedFields` snapshot (malformed → logged and ignored). No mapper: components render `UIMessage` text parts directly.
- **Issue creation = react-query `useMutation`**: server error codes surface to the UI through a typed error (`missing_required_fields` gets its own copy), retry re-fires with the same session so the server-side idempotency claim holds, `reset` backs "Start new chat". Double-submit safety is layered: a synchronous in-flight ref (render snapshots lag a tick) + `isPending`/`isSuccess` gates + disabled buttons. `networkMode: 'always'` so an offline click errors into the retry panel instead of silently pausing and auto-firing on reconnect.
- **Chat lifecycle: one ticket = one chat.** Derived flow state `idle → chatting → readyToSend → creatingIssue → issueCreated | issueError`. After success the composer is replaced by a "Start new chat" bar (reset + session rotation — no silent auto-rotation); a sticky status strip above the composer always shows what's still missing or "ready + Create ticket", driven by the streamed data part. Request history (identifier, url, summary, date) persists in zod-validated `localStorage` and renders on the idle screen.
- **Streaming UX**: the composer's Send button becomes Stop while a reply streams (`chat.stop`, abort maps to status `ready` — one persistent button so keyboard focus survives the swap); auto-scroll follows new content only while the view is pinned near the bottom, so reading history is never interrupted, and re-pins on session rotation.
- **Attachments over Vercel Blob** — matches the PR2 blob architecture: `upload()` from `@vercel/blob/client` against `/files/token` (progress + abort), then `POST /files/confirm` pins and validates server-side. Single `addFiles()` entry serves picker, drag&drop and clipboard paste; removal is exact — in-flight uploads abort, uploaded files go through `DELETE /files/:fileId` with a `removing` state and restore-on-failure.
- **Monitoring via DI** — `IChatMonitoring` (signature-compatible with the app's `monitoringUtils`, adapter lands in PR4), `noopMonitoring` default, PII-free contexts (step names and error codes only); the widget never imports Sentry.
- **Components per the design mock** — Radix Dialog side drawer styled with gov-ui-kit z-index tokens, context chips, message list with typing indicator, summary card, status strip, success/error panels, composer with attachment list and drop overlay. Deviation: the composer uses a raw styled textarea — gov-ui-kit `TextArea` has a baked-in `min-h-40`; pixel parity check is a PR4 item.
- **Tests = 2 integration RTL tests of the whole widget** (real controller, hooks, AI SDK transport and react-query — only `fetch` is faked with a streamed SSE response): happy path from typed message through streamed reply and live summary to the success panel, with a deferred creation response proving a double click cannot POST twice; server error → error panel with PII-free monitoring assertion → retry → success. A failing test = a broken user flow, not a changed implementation detail. jsdom setup polyfills web streams, `TextDecoderStream` and `structuredClone` for ai@7.
- **Release flow**: the widget joins the assistant domain — Version-PR bot scope becomes `@aragon/assistant @aragon/assistant-contracts @aragon/assistant-chat`, bot trigger paths and `.github/filters.yml` gain `packages/assistant-chat/**`, changeset minor.

## Note

- Full integration (feature flag, footer button, health gate, e2e, pixel parity) is PR4 — this package has no visual integration into the app yet.
- The Stop button is the single sanctioned visual addition vs the design mock; both buttons render at the same 96px floor, only colors swap.
- The design mock also shows an interactive context confirm/edit message; deliberately not implemented — it contradicts the agreed "appContext is confirmed by chips, not asked" and would need a contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
