### PR TITLE
fix(ci): scope app-finalize changeset guard; assistant release on-demand

### DIFF
--- a/.github/workflows/app-release-pr-finalize.yml
+++ b/.github/workflows/app-release-pr-finalize.yml
@@ -48,13 +48,19 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.secrets.outputs.ARABOT_PAT }}
 
-      - name: "Guard: no new changesets at finalize"
+      - name: "Guard: no new @aragon/app changesets at finalize"
         shell: bash
         run: |
           set -euo pipefail
-          if ls .changeset/*.md >/dev/null 2>&1; then
-            echo "Found .changeset/*.md at finalize. Policy: do not add new changesets to an existing release. Cancel and start a new one." >&2
-            ls -1 .changeset/*.md >&2 || true
+          # Scope-aware, mirroring the --ignore scoping in the changeset-version action:
+          # this flow only versions @aragon/app, so only app changesets are consumed here.
+          # Other workspaces' changesets (e.g. "@aragon/assistant") live in .changeset/
+          # continuously and are released by their own flows — they must not trip this guard.
+          # A changeset's frontmatter names the bumped package, e.g. `"@aragon/app": patch`.
+          app_changesets=$(grep -lE '^"@aragon/app":' .changeset/*.md 2>/dev/null || true)
+          if [ -n "$app_changesets" ]; then
+            echo "Found new @aragon/app changesets at finalize. Policy: do not add new changesets to an existing release. Cancel and start a new one." >&2
+            echo "$app_changesets" >&2
             exit 1
           fi
 

--- a/.github/workflows/assistant-release-version.yml
+++ b/.github/workflows/assistant-release-version.yml
@@ -1,20 +1,14 @@
-# The "Assistant Release Version" workflow maintains the "Version Packages: assistant" pull request:
-# on every merge to main with pending assistant changesets it recreates the changeset-release/assistant
-# branch, applies `changeset version` scoped to @aragon/assistant, and keeps a PR open with the
-# accumulated version bump and CHANGELOG. Merging that PR is the release act — the finalize workflow
-# tags it (@aragon/assistant@x.y.z) and the tag triggers the production deploy.
+# The "Assistant Release Version" workflow prepares the "Version Packages: assistant" pull request
+# ON DEMAND (trunk-based: merging to main never starts a release by itself). Dispatching it
+# recreates the changeset-release/assistant branch from main, applies `changeset version` scoped to
+# the assistant domain packages, and opens/updates the PR with the accumulated version bump and
+# CHANGELOG. Merging that PR is the release act — the finalize workflow tags it
+# (@aragon/assistant@x.y.z) and the tag triggers the production deploy.
 
 name: Assistant Release Version
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - ".changeset/**"
-      - "apps/assistant/**"
-      - "packages/assistant-contracts/**"
-      - ".github/workflows/assistant-release-version.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
## Why

The [`@aragon/app@1.33.3` finalize run](https://github.com/aragon/app/actions/runs/29327044080) failed at the **"Guard: no new changesets at finalize"** step, so the release was never tagged and production never deployed. Recovered manually (tag + Release on the tested SHA), but the guard is broken for the monorepo and will block **every** app release until fixed.

Root cause: the guard checked for *any* `.changeset/*.md`. In the monorepo, assistant changesets (`assistant-scaffold.md`, `assistant-contracts-scaffold.md`) live in `.changeset/` permanently — they're consumed by the assistant's own release flow, not the app ceremony. They tripped a guard that's only meant to catch *new app* changesets.

## Changes

- **Scope the finalize guard to `@aragon/app`** — parses each changeset's frontmatter and only fails on ones that bump `"@aragon/app"`, mirroring the `--ignore` scoping already used in [`changeset-version`](.github/actions/changeset-version/action.yml). Other workspaces' changesets no longer trip it. Verified against the current `.changeset/` contents: flags the app changeset, ignores both assistant ones.
- **Assistant Version-PR bot → `workflow_dispatch`** — was firing on every push to `main`, auto-opening a "Version Packages: assistant" PR. Now on-demand (trunk-based), matching the change already staged on the p4 feature branch.


🤖 Generated with [Claude Code](https://claude.com/claude-code)