### PR TITLE
Version Packages: assistant (@aragon/assistant@0.2.0)

### DIFF
--- a/.changeset/assistant-contracts-scaffold.md
+++ b/.changeset/assistant-contracts-scaffold.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant-contracts": minor
----
-
-Scaffold the assistant contracts package: shared zod schemas between the assistant service and the assistant-chat widget, starting with the /health response contract

--- a/.changeset/assistant-scaffold.md
+++ b/.changeset/assistant-scaffold.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant": minor
----
-
-Scaffold the assistant service: Hono app with /health endpoint and CORS allowlist, per-environment config, Vercel project wiring (preview/dev/production deploys) and the Version-PR release flow

--- a/apps/assistant/CHANGELOG.md
+++ b/apps/assistant/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @aragon/assistant
+
+## 0.2.0
+
+### Minor Changes
+
+- [#1222](https://github.com/aragon/app/pull/1222) [`36c1fc4`](https://github.com/aragon/app/commit/36c1fc44d7a3ca3759d8f7d1c4c4fc1046287c0b) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Scaffold the assistant service: Hono app with /health endpoint and CORS allowlist, per-environment config, Vercel project wiring (preview/dev/production deploys) and the Version-PR release flow
+
+### Patch Changes
+
+- Updated dependencies [[`36c1fc4`](https://github.com/aragon/app/commit/36c1fc44d7a3ca3759d8f7d1c4c4fc1046287c0b)]:
+    - @aragon/assistant-contracts@0.2.0

--- a/apps/assistant/package.json
+++ b/apps/assistant/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/assistant",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Aragon assistant service: support-chat intake API",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",

--- a/packages/assistant-contracts/CHANGELOG.md
+++ b/packages/assistant-contracts/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @aragon/assistant-contracts
+
+## 0.2.0
+
+### Minor Changes
+
+- [#1222](https://github.com/aragon/app/pull/1222) [`36c1fc4`](https://github.com/aragon/app/commit/36c1fc44d7a3ca3759d8f7d1c4c4fc1046287c0b) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Scaffold the assistant contracts package: shared zod schemas between the assistant service and the assistant-chat widget, starting with the /health response contract

--- a/packages/assistant-contracts/package.json
+++ b/packages/assistant-contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/assistant-contracts",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Shared zod contracts between the Aragon assistant service and the assistant-chat widget",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",


### PR DESCRIPTION
Accumulated version bump and changelog for the assistant service, maintained automatically
from pending changesets on `main`.

**Merging this PR releases `@aragon/assistant@0.2.0`**:
the merge is tagged and the tag triggers the production deploy to assistant.aragon.org.
