### PR TITLE
ci(APP-997): auto-start weekly app release every Monday 6PM CET

### DIFF
--- a/.github/workflows/app-release-start.yml
+++ b/.github/workflows/app-release-start.yml
@@ -1,6 +1,10 @@
 name: App Release Start
 
 on:
+  schedule:
+    # Auto release: every Monday at ~6PM CET (17:07 UTC). Off the top of the
+    # hour because GitHub delays or drops schedules queued at :00.
+    - cron: '7 17 * * 1'
   workflow_dispatch:
     inputs:
       base_commit:
@@ -13,7 +17,39 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Gates scheduled runs only (manual dispatch bypasses it): green-skips when
+  # there is nothing to release or a release is already in flight.
+  schedule-gate:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.gate.outputs.proceed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Gate scheduled run
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          skip() { echo "⏭️ Skipping auto release: $1"; echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          OPEN=$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --state open --json headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release/app/"))] | length')
+          [ "${OPEN:-0}" -eq 0 ] || skip "an app release PR is already open."
+
+          grep -qs '"@aragon/app"' .changeset/*.md || skip "no pending changesets for @aragon/app."
+
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
   prepare-release:
+    needs: schedule-gate
+    # !cancelled() lets workflow_dispatch runs proceed past the skipped gate.
+    if: ${{ !cancelled() && (github.event_name != 'schedule' || needs.schedule-gate.outputs.proceed == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Load secrets

--- a/apps/app/docs/projectDocs/release-process.md
+++ b/apps/app/docs/projectDocs/release-process.md
@@ -21,7 +21,7 @@ repo layout — hotfix/rollback workflows only work with `@aragon/app@*` tags (s
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
 │  Start Release  │───▶│  Test & Stage   │───▶│  Approve & Tag  │───▶│  Auto Deploy    │───▶│   Merge PR      │
-│  (manual)       │    │  (automatic)    │    │  (label+review) │    │  (automatic)    │    │  (manual)       │
+│  (auto/manual)  │    │  (automatic)    │    │  (label+review) │    │  (automatic)    │    │  (manual)       │
 └─────────────────┘    └─────────────────┘    └─────────────────┘    └─────────────────┘    └─────────────────┘
 ```
 
@@ -30,7 +30,9 @@ repo layout — hotfix/rollback workflows only work with `@aragon/app@*` tags (s
 ### 1. Start Release
 
 **Who:** Developer or Manager  
-**Action:** Manually trigger **App Release Start** workflow in GitHub Actions.
+**Action:** Starts automatically every Monday at ~6PM CET (auto release), or trigger **App Release Start** manually in GitHub Actions.
+
+The scheduled run green-skips when there are no pending changesets for `@aragon/app` or a release PR is already open. Manual trigger:
 
 1. Go to [Actions → App Release Start](https://github.com/aragon/app/actions/workflows/app-release-start.yml)
 2. Click **Run workflow**


### PR DESCRIPTION
# Description

Adds an auto release: **App Release Start** now also runs on a schedule — every Monday at 6PM CET (`0 17 * * 1` UTC) — so the weekly release no longer needs a manual kick-off. Manual dispatch keeps working exactly as before.

A new `schedule-gate` job (scheduled runs only, manual dispatch bypasses it) green-skips instead of starting a duplicate or empty release when:

- a `release/app/*` PR is already open;
- there are no pending changesets for `@aragon/app`.

Docs: the Start Release step in `release-process.md` now documents the schedule.

Task: [APP-997](https://linear.app/aragon/issue/APP-997/auto-releases)

## Type of Change

- [x] CI/docs only — no version bump, no changeset needed

## Developer Checklist:

- [x] Selected the correct base branch
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing