### PR TITLE
feat(APP-1007): Show proposal creation eligibility for external Safe bodies

### DIFF
--- a/.changeset/app-1007-show-safe-body-proposal-creation-eligibility.md
+++ b/.changeset/app-1007-show-safe-body-proposal-creation-eligibility.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Show proposal creation eligibility for external Safe bodies in advanced processes

--- a/apps/app/src/assets/locales/en.json
+++ b/apps/app/src/assets/locales/en.json
@@ -3058,6 +3058,11 @@
           "description": "You are not connected to the correct address. If you are one of its owners, you can connect it with WalletConnect.",
           "title": "Not eligible to vote"
         },
+        "sppPermissionCheckProposalCreation": {
+          "function": "Proposal creation",
+          "pluginLabelName": "Name",
+          "requirement": "Safe multisig member"
+        },
         "sppProposalListItem": {
           "stage": "Stage {{stageIndex}}"
         },

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/index.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/index.ts
@@ -1,0 +1,4 @@
+export {
+    type IUseSppExternalPermissionCheckProposalCreationParams,
+    useSppExternalPermissionCheckProposalCreation,
+} from './useSppExternalPermissionCheckProposalCreation';

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.test.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.test.ts
@@ -1,0 +1,77 @@
+import { addressUtils } from '@aragon/gov-ui-kit';
+import { renderHook } from '@testing-library/react';
+import type { IPermissionCheckGuardParams } from '@/modules/governance/types';
+import type { IDaoPlugin } from '@/shared/api/daoService';
+import { generateSppStagePlugin } from '../../testUtils';
+import { VotingBodyBrandIdentity } from '../../types';
+import { useSppExternalPermissionCheckProposalCreation } from './useSppExternalPermissionCheckProposalCreation';
+
+describe('useSppExternalPermissionCheckProposalCreation', () => {
+    const createParams = (
+        plugin: Partial<Parameters<typeof generateSppStagePlugin>[0]>,
+    ): IPermissionCheckGuardParams => ({
+        plugin: generateSppStagePlugin({
+            interfaceType: undefined,
+            ...plugin,
+        }) as unknown as IDaoPlugin,
+        daoId: 'dao-test',
+    });
+
+    it('returns a Safe settings group when the body can create proposals', () => {
+        const safeAddress = `0x${'b'.repeat(40)}`;
+        const params = createParams({
+            address: safeAddress,
+            brandId: VotingBodyBrandIdentity.SAFE,
+            proposalCreationConditionAddress: `0x${'c'.repeat(40)}`,
+        });
+
+        const { result } = renderHook(() =>
+            useSppExternalPermissionCheckProposalCreation(params),
+        );
+
+        expect(result.current).toEqual({
+            hasPermission: true,
+            isLoading: false,
+            isRestricted: true,
+            settings: [
+                [
+                    {
+                        term: 'app.plugins.spp.sppPermissionCheckProposalCreation.pluginLabelName',
+                        definition: addressUtils.truncateAddress(safeAddress),
+                    },
+                    {
+                        term: 'app.plugins.spp.sppPermissionCheckProposalCreation.function',
+                        definition:
+                            'app.plugins.spp.sppPermissionCheckProposalCreation.requirement',
+                    },
+                ],
+            ],
+        });
+    });
+
+    it('returns undefined for a Safe body without proposal-creation rights', () => {
+        const params = createParams({
+            brandId: VotingBodyBrandIdentity.SAFE,
+            proposalCreationConditionAddress: undefined,
+        });
+
+        const { result } = renderHook(() =>
+            useSppExternalPermissionCheckProposalCreation(params),
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined for non-Safe external bodies', () => {
+        const params = createParams({
+            brandId: VotingBodyBrandIdentity.EOA,
+            proposalCreationConditionAddress: `0x${'c'.repeat(40)}`,
+        });
+
+        const { result } = renderHook(() =>
+            useSppExternalPermissionCheckProposalCreation(params),
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+});

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.ts
@@ -1,0 +1,63 @@
+import { addressUtils } from '@aragon/gov-ui-kit';
+import type {
+    IPermissionCheckGuardParams,
+    IPermissionCheckGuardResult,
+} from '@/modules/governance/types';
+import { useTranslations } from '@/shared/components/translationsProvider';
+import type { ISppStagePluginExternal } from '../../types';
+import { VotingBodyBrandIdentity } from '../../types';
+
+export interface IUseSppExternalPermissionCheckProposalCreationParams
+    extends IPermissionCheckGuardParams {}
+
+/**
+ * Fallback for the GOVERNANCE_PERMISSION_CHECK_PROPOSAL_CREATION slot used for external SPP bodies,
+ * which are not DAO plugins and therefore have no registered slot function.
+ *
+ * A Safe body can create proposals only when a SafeOwnerCondition was wired at process creation,
+ * surfaced as `proposalCreationConditionAddress` on the stage body. When set, the body contributes a
+ * Safe-multisig eligibility group; otherwise it contributes nothing.
+ */
+export const useSppExternalPermissionCheckProposalCreation = (
+    params: IUseSppExternalPermissionCheckProposalCreationParams,
+): IPermissionCheckGuardResult | undefined => {
+    const { plugin } = params;
+
+    const { t } = useTranslations();
+
+    const externalBody = plugin as unknown as ISppStagePluginExternal;
+
+    const isSafeProposalCreator =
+        externalBody.brandId === VotingBodyBrandIdentity.SAFE &&
+        externalBody.proposalCreationConditionAddress != null;
+
+    if (!isSafeProposalCreator) {
+        return undefined;
+    }
+
+    return {
+        hasPermission: true,
+        isLoading: false,
+        isRestricted: true,
+        settings: [
+            [
+                {
+                    term: t(
+                        'app.plugins.spp.sppPermissionCheckProposalCreation.pluginLabelName',
+                    ),
+                    definition: addressUtils.truncateAddress(
+                        externalBody.address,
+                    ),
+                },
+                {
+                    term: t(
+                        'app.plugins.spp.sppPermissionCheckProposalCreation.function',
+                    ),
+                    definition: t(
+                        'app.plugins.spp.sppPermissionCheckProposalCreation.requirement',
+                    ),
+                },
+            ],
+        ],
+    };
+};

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.test.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.test.ts
@@ -1,3 +1,4 @@
+import { addressUtils } from '@aragon/gov-ui-kit';
 import { renderHook } from '@testing-library/react';
 import * as useSimulateProposalModule from '@/modules/governance/hooks/useSimulateProposal';
 import type { IPermissionCheckGuardResult } from '@/modules/governance/types';
@@ -15,6 +16,7 @@ import {
     generateSppStage,
     generateSppStagePlugin,
 } from '../../testUtils';
+import { VotingBodyBrandIdentity } from '../../types';
 import { useSppPermissionCheckProposalCreation } from './useSppPermissionCheckProposalCreation';
 
 describe('useSppPermissionCheckProposalCreation', () => {
@@ -197,5 +199,108 @@ describe('useSppPermissionCheckProposalCreation', () => {
         );
 
         expect(result.current.isLoading).toBeTruthy();
+    });
+
+    const createSafeTestParams = (
+        safeBody?: Partial<
+            Parameters<typeof generateSppStagePlugin>[0] & {
+                brandId: VotingBodyBrandIdentity;
+                proposalCreationConditionAddress?: string;
+            }
+        >,
+    ) => {
+        const sppPlugin = generateDaoPlugin({
+            address: `0x${'a'.repeat(40)}`,
+            settings: generateSppPluginSettings({
+                stages: [
+                    generateSppStage({
+                        plugins: [
+                            generateSppStagePlugin({
+                                address: `0x${'b'.repeat(40)}`,
+                                interfaceType: undefined,
+                                brandId: VotingBodyBrandIdentity.SAFE,
+                                ...safeBody,
+                            }),
+                        ],
+                    }),
+                ],
+            }),
+        });
+
+        // External bodies are not DAO plugins, so no meta matches by address.
+        useDaoPluginsSpy.mockReturnValue([]);
+        useDaoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: generateDao() }),
+        );
+
+        return { daoId: 'dao-test', plugin: sppPlugin };
+    };
+
+    it('surfaces a Safe body settings group when it can create proposals', () => {
+        const safeAddress = `0x${'b'.repeat(40)}`;
+        const params = createSafeTestParams({
+            proposalCreationConditionAddress: `0x${'c'.repeat(40)}`,
+        });
+        mockSimulation({ isLoading: false, isSuccess: true });
+
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.isRestricted).toBeTruthy();
+        expect(result.current.settings).toEqual([
+            [
+                {
+                    term: 'app.plugins.spp.sppPermissionCheckProposalCreation.pluginLabelName',
+                    definition: addressUtils.truncateAddress(safeAddress),
+                },
+                {
+                    term: 'app.plugins.spp.sppPermissionCheckProposalCreation.function',
+                    definition:
+                        'app.plugins.spp.sppPermissionCheckProposalCreation.requirement',
+                },
+            ],
+        ]);
+    });
+
+    it('ignores a Safe body without proposal-creation rights', () => {
+        const params = createSafeTestParams({
+            proposalCreationConditionAddress: undefined,
+        });
+        mockSimulation({ isLoading: false, isSuccess: true });
+
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.isRestricted).toBeFalsy();
+        expect(result.current.settings).toEqual([]);
+    });
+
+    it('ignores non-Safe external bodies', () => {
+        const params = createSafeTestParams({
+            brandId: VotingBodyBrandIdentity.EOA,
+            proposalCreationConditionAddress: `0x${'c'.repeat(40)}`,
+        });
+        mockSimulation({ isLoading: false, isSuccess: true });
+
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.isRestricted).toBeFalsy();
+        expect(result.current.settings).toEqual([]);
     });
 });

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.test.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.test.ts
@@ -303,4 +303,81 @@ describe('useSppPermissionCheckProposalCreation', () => {
         expect(result.current.isRestricted).toBeFalsy();
         expect(result.current.settings).toEqual([]);
     });
+
+    it('combines an installed internal body with an external Safe body in the same process', () => {
+        const internalAddress = `0x${'1'.repeat(40)}`;
+        const safeAddress = `0x${'2'.repeat(40)}`;
+
+        const internalMeta = generateDaoPlugin({ address: internalAddress });
+        const internalSettings = [
+            [{ term: 'Members', definition: 'Listed only' }],
+        ];
+        const internalGuardResult = generateGuardResult({
+            isRestricted: true,
+            settings: internalSettings,
+        });
+
+        const sppPlugin = generateDaoPlugin({
+            address: `0x${'a'.repeat(40)}`,
+            settings: generateSppPluginSettings({
+                stages: [
+                    generateSppStage({
+                        plugins: [
+                            generateSppStagePlugin({
+                                address: internalAddress,
+                            }),
+                            generateSppStagePlugin({
+                                address: safeAddress,
+                                interfaceType: undefined,
+                                brandId: VotingBodyBrandIdentity.SAFE,
+                                proposalCreationConditionAddress: `0x${'c'.repeat(40)}`,
+                            }),
+                        ],
+                    }),
+                ],
+            }),
+        });
+
+        useDaoPluginsSpy.mockReturnValue([
+            generateFilterComponentPlugin({ meta: internalMeta }),
+        ]);
+        useDaoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: generateDao() }),
+        );
+
+        // Only the internal body resolves to a slot function; the external Safe body
+        // (pluginId 'external') falls through to the fallback hook.
+        getSlotFunctionSpy.mockImplementation(((slotParams: {
+            pluginId: string;
+        }) =>
+            slotParams.pluginId === internalMeta.interfaceType
+                ? () => internalGuardResult
+                : undefined) as never);
+        mockSimulation({ isLoading: false, isSuccess: true });
+
+        const params = { daoId: 'dao-test', plugin: sppPlugin };
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.isRestricted).toBeTruthy();
+        expect(result.current.settings).toEqual([
+            ...internalSettings,
+            [
+                {
+                    term: 'app.plugins.spp.sppPermissionCheckProposalCreation.pluginLabelName',
+                    definition: addressUtils.truncateAddress(safeAddress),
+                },
+                {
+                    term: 'app.plugins.spp.sppPermissionCheckProposalCreation.function',
+                    definition:
+                        'app.plugins.spp.sppPermissionCheckProposalCreation.requirement',
+                },
+            ],
+        ]);
+    });
 });

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.ts
@@ -9,6 +9,7 @@ import { type IDaoPlugin, useDao } from '@/shared/api/daoService';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
 import { pluginRegistryUtils } from '@/shared/utils/pluginRegistryUtils';
 import type { ISppPluginSettings } from '../../types';
+import { useSppExternalPermissionCheckProposalCreation } from '../useSppExternalPermissionCheckProposalCreation';
 
 export interface IUseSppPermissionCheckProposalCreationParams
     extends IPermissionCheckGuardParams<IDaoPlugin<ISppPluginSettings>> {}
@@ -37,27 +38,38 @@ export const useSppPermissionCheckProposalCreation = (
         });
     const sppPlugins = plugin.settings.stages.flatMap((stage) => stage.plugins);
 
-    // Find the sub plugins that are part of the DAO and filter out any potential undefined values
-    const subPlugins = sppPlugins
-        .map((sppPlugin) =>
-            daoPlugins.find(({ meta }) =>
-                addressUtils.isAddressEqual(meta.address, sppPlugin.address),
-            ),
-        )
-        .filter((plugin) => plugin !== undefined);
+    const pluginProposalCreationGuardResults = sppPlugins.map((sppPlugin) => {
+        const subPlugin = daoPlugins.find(({ meta }) =>
+            addressUtils.isAddressEqual(meta.address, sppPlugin.address),
+        );
 
-    const pluginProposalCreationGuardResults = subPlugins.map(
-        ({ meta: plugin }) =>
+        // Internal bodies not installed on the DAO can't be resolved, so skip them.
+        if (subPlugin == null && sppPlugin.interfaceType != null) {
+            return undefined;
+        }
+
+        // Sub plugins delegate to their own permission-check slot function. External bodies (e.g. Safe)
+        // are not DAO plugins, so no slot function is registered for them — fall back to the external
+        // permission-check hook, mirroring the SETTINGS_GOVERNANCE_SETTINGS_HOOK fallback in the voting terminal.
+        const bodyPlugin = (subPlugin?.meta ?? sppPlugin) as IDaoPlugin;
+        const pluginId = subPlugin?.meta.interfaceType ?? 'external';
+
+        const permissionCheck =
             pluginRegistryUtils.getSlotFunction<
                 IPermissionCheckGuardParams,
                 IPermissionCheckGuardResult
             >({
                 slotId: GovernanceSlotId.GOVERNANCE_PERMISSION_CHECK_PROPOSAL_CREATION,
-                pluginId: plugin.interfaceType,
-            })?.({ plugin, daoId, useConnectedUserInfo }),
-    );
+                pluginId,
+            }) ?? useSppExternalPermissionCheckProposalCreation;
 
-    // GOVERNANCE_PERMISSION_CHECK_PROPOSAL_CREATION is now used only to get settings in the SPP case (we still miss settings for Safe bodies, though).
+        return permissionCheck({
+            plugin: bodyPlugin,
+            daoId,
+            useConnectedUserInfo,
+        });
+    });
+
     const permissionGranted = simulationResult === 'success';
 
     const isLoading =

--- a/apps/app/src/plugins/sppPlugin/types/sppStagePlugin.ts
+++ b/apps/app/src/plugins/sppPlugin/types/sppStagePlugin.ts
@@ -28,4 +28,9 @@ export interface ISppStagePluginExternal {
      * Branded identity of the plugin.
      */
     brandId: VotingBodyBrandIdentity;
+    /**
+     * Condition address of an external body. Currently, it could be only
+     * SafeOwnerCondition if set.
+     */
+    proposalCreationConditionAddress?: string;
 }


### PR DESCRIPTION
# Description

External bodies of type Safe only exist as sub-plugins inside an advanced (SPP) process, and they are never installed as DAO plugins. The `GOVERNANCE_PERMISSION_CHECK_PROPOSAL_CREATION` slot resolves per body by `interfaceType`, so Safe bodies (which have no `interfaceType` and no registered slot function) were silently dropped — the process details page and permission-check flows showed no proposal-creation eligibility for them.

This surfaces a Safe-multisig eligibility group for external Safe bodies that were actually granted proposal creation. The eligibility signal is `proposalCreationConditionAddress` on the stage body: at process creation only Safe bodies with `canCreateProposal: true` get a `SafeOwnerCondition` deployed and wired into the SPP rules, and the backend reports that address back on the body. When present, the body contributes a `Name → <truncated Safe address>` / `Proposal creation → Safe multisig member` group; when absent, it contributes nothing.

The external-body handling is implemented as a `fallback` to the slot (`getSlotFunction(...) ?? useSppExternalPermissionCheckProposalCreation`), mirroring the existing `fallback: useSppGovernanceSettingsDefault` pattern used in the SPP voting terminal. `hasPermission` continues to come from proposal-creation simulation, which already exercises the `SafeOwnerCondition` on-chain, so no per-wallet Safe membership check is needed.

Linear: APP-1007

## Type of Change

- [x] Minor: Feature (non-breaking change which adds new functionality)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
