### PR TITLE
fix(APP-1012): Exclude unknown plugins from PROCESS type filter to fix SelectPluginDialog regression

### DIFF
--- a/.changeset/fix-select-process-unknown-handling.md
+++ b/.changeset/fix-select-process-unknown-handling.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Exclude unknown plugins as part of PROCESS type plugin filter to fix SelectPluginDialog regression

--- a/apps/app/src/shared/utils/daoUtils/daoUtils.test.ts
+++ b/apps/app/src/shared/utils/daoUtils/daoUtils.test.ts
@@ -408,6 +408,7 @@ describe('dao utils', () => {
                 }),
                 generateDaoPlugin({
                     subdomain: 'sub-process',
+                    interfaceType: PluginInterfaceType.MULTISIG,
                     isProcess: true,
                     isSubPlugin: true,
                 }),

--- a/apps/app/src/shared/utils/daoUtils/daoUtils.ts
+++ b/apps/app/src/shared/utils/daoUtils/daoUtils.ts
@@ -5,7 +5,7 @@ import {
     type IDaoPlugin,
     type ILinkedAccountSummary,
     type Network,
-    type PluginInterfaceType,
+    PluginInterfaceType,
 } from '@/shared/api/daoService';
 import { networkDefinitions } from '@/shared/constants/networkDefinitions';
 import {
@@ -267,7 +267,10 @@ class DaoUtils {
     private filterPluginByType = (plugin: IDaoPlugin, type?: PluginType) =>
         type == null ||
         (type === PluginType.BODY && plugin.isBody) ||
-        (type === PluginType.PROCESS && plugin.isProcess);
+        (type === PluginType.PROCESS &&
+            plugin.isProcess &&
+            // TODO (APP-1012): just a temp solution to fix regression in SelectPluginDialog. Implement a consistent way to handle unknowns across the app!
+            plugin.interfaceType !== PluginInterfaceType.UNKNOWN);
 
     private filterBySubPlugin = (
         plugin: IDaoPlugin,


### PR DESCRIPTION
## Summary

Fixes a regression in `SelectPluginDialog` where plugins with an `UNKNOWN` interface type were incorrectly included in `PROCESS` type filter results.

`DaoUtils.filterPluginByType` now excludes plugins whose `interfaceType` is `PluginInterfaceType.UNKNOWN` from the `PROCESS` branch, so only genuine process plugins are surfaced.

> [!NOTE]
> This is a temporary fix tracked by APP-1012. A consistent, app-wide approach to handling unknown plugins is still needed (see the TODO in `daoUtils.ts`).

## Changes

- `daoUtils.ts` — add `interfaceType !== UNKNOWN` guard to the `PROCESS` filter branch
- `daoUtils.test.ts` — give the sub-process fixture an explicit `SPP` interface type so it reflects a real process plugin

## Testing

- `pnpm test:changed` — all suites pass