### PR TITLE
feat(APP-1001): Filter plugin actions in action composer by DAO permissions

### DIFF
--- a/.agents/shared/metrics/hits.jsonl
+++ b/.agents/shared/metrics/hits.jsonl
@@ -141,3 +141,4 @@
 {"ts":"2026-07-08T16:29:42.858Z","tool":"Edit","file":"apps/app/src/modules/governance/dialogs/selectPluginDialog/selectPluginDialog.tsx","rule":"plugin-visibility","bytes":2379,"elapsed_ms":3,"adapter":"claude"}
 {"ts":"2026-07-08T16:29:55.658Z","tool":"Edit","file":"apps/app/src/modules/governance/dialogs/selectPluginDialog/selectPluginDialog.tsx","rule":"plugin-visibility","bytes":2379,"elapsed_ms":11,"adapter":"claude"}
 {"ts":"2026-07-08T16:30:49.523Z","tool":"Edit","file":"apps/app/src/modules/governance/dialogs/selectPluginDialog/selectPluginDialogProcessListItem.tsx","rule":"plugin-visibility","bytes":2379,"elapsed_ms":2,"adapter":"claude"}
+{"ts":"2026-07-22T08:55:56.658Z","tool":"Edit","file":"apps/app/src/shared/api/daoService/queries/useAllDaoPermissions/useAllDaoPermissions.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":6,"adapter":"claude"}

--- a/.changeset/app-1001-filter-osx-related-actions-from-action-builder.md
+++ b/.changeset/app-1001-filter-osx-related-actions-from-action-builder.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Filter OSx-related actions from the action builder when the DAO lacks the required permission

--- a/apps/app/src/assets/locales/en.json
+++ b/apps/app/src/assets/locales/en.json
@@ -1838,7 +1838,7 @@
           "default": "Action",
           "walletConnect": "Connect"
         },
-        "authorizedSwitchLabel": "Only show authorized actions",
+        "authorizedSwitchLabel": "Only show allowed actions",
         "customItem": {
           "ADD_CONTRACT": "Add contract address",
           "RAW_CALLDATA": "Enter raw calldata"

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerInput/actionComposerInput.api.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerInput/actionComposerInput.api.ts
@@ -13,6 +13,14 @@ export interface IActionComposerInputItem<TMeta = undefined>
      * Default value for the action.
      */
     defaultValue?: IProposalAction;
+    /**
+     * keccak256 permission-id the DAO must hold for this action to be executable.
+     * When absent, the item is never permission-filtered. Matched by id only
+     * (see actionComposerUtils.getDaoActions).
+     *
+     *  who/where are not checked for now.
+     */
+    requiredPermissionId?: string;
 }
 
 export interface IActionComposerInputProps<TMeta = undefined>

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerInput/actionComposerInput.api.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerInput/actionComposerInput.api.ts
@@ -15,9 +15,9 @@ export interface IActionComposerInputItem<TMeta = undefined>
     defaultValue?: IProposalAction;
     /**
      * keccak256 permission-id the DAO must hold for this action to be executable.
-     * When absent, the item is never permission-filtered. Matched by id and by
-     * target contract (the action's `defaultValue.to` as `where`); the grantee
-     * (`who`) is not checked for now (see actionComposerUtils.getDaoActions).
+     * When absent, the item is never permission-filtered. Matched by id, by target
+     * contract (the action's `defaultValue.to` as `where`) and by grantee (the DAO
+     * address as `who`) — see actionComposerUtils.getDaoActions.
      */
     requiredPermissionId?: string;
 }

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerInput/actionComposerInput.api.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerInput/actionComposerInput.api.ts
@@ -15,10 +15,9 @@ export interface IActionComposerInputItem<TMeta = undefined>
     defaultValue?: IProposalAction;
     /**
      * keccak256 permission-id the DAO must hold for this action to be executable.
-     * When absent, the item is never permission-filtered. Matched by id only
-     * (see actionComposerUtils.getDaoActions).
-     *
-     *  who/where are not checked for now.
+     * When absent, the item is never permission-filtered. Matched by id and by
+     * target contract (the action's `defaultValue.to` as `where`); the grantee
+     * (`who`) is not checked for now (see actionComposerUtils.getDaoActions).
      */
     requiredPermissionId?: string;
 }

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.api.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.api.ts
@@ -1,4 +1,4 @@
-import type { IDao } from '@/shared/api/daoService';
+import type { IDao, IDaoPermission } from '@/shared/api/daoService';
 import type { IAutocompleteInputGroup } from '@/shared/components/forms/autocompleteInput';
 import type { TranslationFunction } from '@/shared/components/translationsProvider';
 import type { IAllowedAction } from '../../api/executeSelectorsService';
@@ -66,5 +66,5 @@ export interface IGetDaoActionsParams extends IGetActionBaseParams {
     /**
      * Permissions granted to DAO.
      */
-    permissions?: Array<{ permissionId: string; whereAddress: string }>;
+    permissions?: IDaoPermission[];
 }

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.test.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.test.ts
@@ -1,7 +1,10 @@
 import { addressUtils, IconType } from '@aragon/gov-ui-kit';
 import { generateDao } from '@/shared/testUtils';
 import { mockTranslations } from '@/test/utils';
-import { ProposalActionType } from '../../api/governanceService';
+import {
+    type IProposalAction,
+    ProposalActionType,
+} from '../../api/governanceService';
 import { generateSmartContractAbi } from '../../testUtils';
 import type { IActionComposerInputItem } from './actionComposerInput';
 import { actionComposerUtils } from './actionComposerUtils';
@@ -282,6 +285,233 @@ describe('actionComposerUtils', () => {
                         item.defaultValue?.type === ActionItemId.RAW_CALLDATA,
                 ),
             ).toBeUndefined();
+        });
+    });
+
+    describe('getDaoActions', () => {
+        const pluginAddress = '0x1111111111111111111111111111111111111111';
+        const otherAddress = '0x2222222222222222222222222222222222222222';
+        const permissionId = '0xabc123';
+
+        const getDaoPluginActionsSpy = jest.spyOn(
+            actionComposerUtils,
+            'getDaoPluginActions',
+        );
+        const getDaoPermissionActionsSpy = jest.spyOn(
+            actionComposerUtils,
+            'getDaoPermissionActions',
+        );
+
+        const buildPluginItem = (
+            overrides: Partial<IActionComposerInputItem> = {},
+        ): IActionComposerInputItem => ({
+            id: 'item',
+            name: 'Item',
+            icon: IconType.SETTINGS,
+            groupId: pluginAddress,
+            defaultValue: { to: pluginAddress } as IProposalAction,
+            ...overrides,
+        });
+
+        beforeEach(() => {
+            // Isolate the plugin path: permission-registry actions are covered
+            // by their own suites, so keep System B empty here.
+            getDaoPermissionActionsSpy.mockReturnValue({
+                items: [],
+                groups: [],
+                components: {},
+            });
+        });
+
+        afterEach(() => {
+            getDaoPluginActionsSpy.mockReset();
+            getDaoPermissionActionsSpy.mockReset();
+        });
+
+        it('keeps a plugin item whose required permission is granted on the action target', () => {
+            getDaoPluginActionsSpy.mockReturnValue({
+                pluginItems: [
+                    buildPluginItem({
+                        id: 'i1',
+                        requiredPermissionId: permissionId,
+                    }),
+                ],
+                pluginGroups: [{ id: pluginAddress, name: 'Plugin', info: '' }],
+                pluginComponents: {},
+            });
+
+            const result = actionComposerUtils.getDaoActions({
+                dao: generateDao(),
+                t: mockTranslations.tMock,
+                permissions: [{ permissionId, whereAddress: pluginAddress }],
+            });
+
+            expect(result.items.map((item) => item.id)).toEqual(['i1']);
+            expect(result.groups.map((group) => group.id)).toEqual([
+                pluginAddress,
+            ]);
+        });
+
+        it('filters out a plugin item when the permission is granted on a different contract', () => {
+            getDaoPluginActionsSpy.mockReturnValue({
+                pluginItems: [
+                    buildPluginItem({
+                        id: 'i1',
+                        requiredPermissionId: permissionId,
+                    }),
+                ],
+                pluginGroups: [{ id: pluginAddress, name: 'Plugin', info: '' }],
+                pluginComponents: {},
+            });
+
+            const result = actionComposerUtils.getDaoActions({
+                dao: generateDao(),
+                t: mockTranslations.tMock,
+                permissions: [{ permissionId, whereAddress: otherAddress }],
+            });
+
+            expect(result.items).toEqual([]);
+            expect(result.groups).toEqual([]);
+        });
+
+        it('filters out a plugin item when the required permission id is not granted', () => {
+            getDaoPluginActionsSpy.mockReturnValue({
+                pluginItems: [
+                    buildPluginItem({
+                        id: 'i1',
+                        requiredPermissionId: permissionId,
+                    }),
+                ],
+                pluginGroups: [{ id: pluginAddress, name: 'Plugin', info: '' }],
+                pluginComponents: {},
+            });
+
+            const result = actionComposerUtils.getDaoActions({
+                dao: generateDao(),
+                t: mockTranslations.tMock,
+                permissions: [
+                    { permissionId: '0xother', whereAddress: pluginAddress },
+                ],
+            });
+
+            expect(result.items).toEqual([]);
+        });
+
+        it('keeps items without a requiredPermissionId regardless of permissions', () => {
+            getDaoPluginActionsSpy.mockReturnValue({
+                pluginItems: [buildPluginItem({ id: 'i1' })],
+                pluginGroups: [{ id: pluginAddress, name: 'Plugin', info: '' }],
+                pluginComponents: {},
+            });
+
+            const result = actionComposerUtils.getDaoActions({
+                dao: generateDao(),
+                t: mockTranslations.tMock,
+                permissions: [],
+            });
+
+            expect(result.items.map((item) => item.id)).toEqual(['i1']);
+        });
+
+        it('does not filter plugin items while permissions are not loaded', () => {
+            getDaoPluginActionsSpy.mockReturnValue({
+                pluginItems: [
+                    buildPluginItem({
+                        id: 'i1',
+                        requiredPermissionId: permissionId,
+                    }),
+                ],
+                pluginGroups: [{ id: pluginAddress, name: 'Plugin', info: '' }],
+                pluginComponents: {},
+            });
+
+            const result = actionComposerUtils.getDaoActions({
+                dao: generateDao(),
+                t: mockTranslations.tMock,
+                permissions: undefined,
+            });
+
+            expect(result.items.map((item) => item.id)).toEqual(['i1']);
+        });
+
+        it('prunes plugin groups left without any items after filtering', () => {
+            getDaoPluginActionsSpy.mockReturnValue({
+                pluginItems: [
+                    buildPluginItem({
+                        id: 'kept',
+                        groupId: pluginAddress,
+                        requiredPermissionId: permissionId,
+                        defaultValue: { to: pluginAddress } as IProposalAction,
+                    }),
+                    buildPluginItem({
+                        id: 'filtered',
+                        groupId: otherAddress,
+                        requiredPermissionId: permissionId,
+                        defaultValue: { to: otherAddress } as IProposalAction,
+                    }),
+                ],
+                pluginGroups: [
+                    { id: pluginAddress, name: 'Plugin', info: '' },
+                    { id: otherAddress, name: 'Other', info: '' },
+                ],
+                pluginComponents: {},
+            });
+
+            const result = actionComposerUtils.getDaoActions({
+                dao: generateDao(),
+                t: mockTranslations.tMock,
+                permissions: [{ permissionId, whereAddress: pluginAddress }],
+            });
+
+            expect(result.items.map((item) => item.id)).toEqual(['kept']);
+            expect(result.groups.map((group) => group.id)).toEqual([
+                pluginAddress,
+            ]);
+        });
+
+        it('matches the required permission id case-insensitively', () => {
+            getDaoPluginActionsSpy.mockReturnValue({
+                pluginItems: [
+                    buildPluginItem({
+                        id: 'i1',
+                        requiredPermissionId: '0xABCDEF',
+                    }),
+                ],
+                pluginGroups: [{ id: pluginAddress, name: 'Plugin', info: '' }],
+                pluginComponents: {},
+            });
+
+            const result = actionComposerUtils.getDaoActions({
+                dao: generateDao(),
+                t: mockTranslations.tMock,
+                permissions: [
+                    { permissionId: '0xabcdef', whereAddress: pluginAddress },
+                ],
+            });
+
+            expect(result.items.map((item) => item.id)).toEqual(['i1']);
+        });
+
+        it('throws when a plugin item declares a requiredPermissionId but has no target', () => {
+            getDaoPluginActionsSpy.mockReturnValue({
+                pluginItems: [
+                    buildPluginItem({
+                        id: 'i1',
+                        requiredPermissionId: permissionId,
+                        defaultValue: undefined,
+                    }),
+                ],
+                pluginGroups: [],
+                pluginComponents: {},
+            });
+
+            expect(() =>
+                actionComposerUtils.getDaoActions({
+                    dao: generateDao(),
+                    t: mockTranslations.tMock,
+                    permissions: [],
+                }),
+            ).toThrow();
         });
     });
 });

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.test.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.test.ts
@@ -1,5 +1,5 @@
 import { addressUtils, IconType } from '@aragon/gov-ui-kit';
-import { generateDao } from '@/shared/testUtils';
+import { generateDao, generateDaoPermission } from '@/shared/testUtils';
 import { mockTranslations } from '@/test/utils';
 import {
     type IProposalAction,
@@ -291,7 +291,10 @@ describe('actionComposerUtils', () => {
     describe('getDaoActions', () => {
         const pluginAddress = '0x1111111111111111111111111111111111111111';
         const otherAddress = '0x2222222222222222222222222222222222222222';
+        const daoAddress = '0x3333333333333333333333333333333333333333';
         const permissionId = '0xabc123';
+
+        const dao = generateDao({ address: daoAddress });
 
         const getDaoPluginActionsSpy = jest.spyOn(
             actionComposerUtils,
@@ -341,9 +344,15 @@ describe('actionComposerUtils', () => {
             });
 
             const result = actionComposerUtils.getDaoActions({
-                dao: generateDao(),
+                dao,
                 t: mockTranslations.tMock,
-                permissions: [{ permissionId, whereAddress: pluginAddress }],
+                permissions: [
+                    generateDaoPermission({
+                        permissionId,
+                        whereAddress: pluginAddress,
+                        whoAddress: daoAddress,
+                    }),
+                ],
             });
 
             expect(result.items.map((item) => item.id)).toEqual(['i1']);
@@ -365,9 +374,43 @@ describe('actionComposerUtils', () => {
             });
 
             const result = actionComposerUtils.getDaoActions({
-                dao: generateDao(),
+                dao,
                 t: mockTranslations.tMock,
-                permissions: [{ permissionId, whereAddress: otherAddress }],
+                permissions: [
+                    generateDaoPermission({
+                        permissionId,
+                        whereAddress: otherAddress,
+                        whoAddress: daoAddress,
+                    }),
+                ],
+            });
+
+            expect(result.items).toEqual([]);
+            expect(result.groups).toEqual([]);
+        });
+
+        it('filters out a plugin item when the permission is granted to another address than the DAO', () => {
+            getDaoPluginActionsSpy.mockReturnValue({
+                pluginItems: [
+                    buildPluginItem({
+                        id: 'i1',
+                        requiredPermissionId: permissionId,
+                    }),
+                ],
+                pluginGroups: [{ id: pluginAddress, name: 'Plugin', info: '' }],
+                pluginComponents: {},
+            });
+
+            const result = actionComposerUtils.getDaoActions({
+                dao,
+                t: mockTranslations.tMock,
+                permissions: [
+                    generateDaoPermission({
+                        permissionId,
+                        whereAddress: pluginAddress,
+                        whoAddress: otherAddress,
+                    }),
+                ],
             });
 
             expect(result.items).toEqual([]);
@@ -387,10 +430,14 @@ describe('actionComposerUtils', () => {
             });
 
             const result = actionComposerUtils.getDaoActions({
-                dao: generateDao(),
+                dao,
                 t: mockTranslations.tMock,
                 permissions: [
-                    { permissionId: '0xother', whereAddress: pluginAddress },
+                    generateDaoPermission({
+                        permissionId: '0xother',
+                        whereAddress: pluginAddress,
+                        whoAddress: daoAddress,
+                    }),
                 ],
             });
 
@@ -405,7 +452,7 @@ describe('actionComposerUtils', () => {
             });
 
             const result = actionComposerUtils.getDaoActions({
-                dao: generateDao(),
+                dao,
                 t: mockTranslations.tMock,
                 permissions: [],
             });
@@ -427,7 +474,7 @@ describe('actionComposerUtils', () => {
             });
 
             const result = actionComposerUtils.getDaoActions({
-                dao: generateDao(),
+                dao,
                 t: mockTranslations.tMock,
                 permissions: undefined,
             });
@@ -462,9 +509,15 @@ describe('actionComposerUtils', () => {
             });
 
             const result = actionComposerUtils.getDaoActions({
-                dao: generateDao(),
+                dao,
                 t: mockTranslations.tMock,
-                permissions: [{ permissionId, whereAddress: pluginAddress }],
+                permissions: [
+                    generateDaoPermission({
+                        permissionId,
+                        whereAddress: pluginAddress,
+                        whoAddress: daoAddress,
+                    }),
+                ],
             });
 
             expect(result.items.map((item) => item.id)).toEqual(['kept']);
@@ -486,10 +539,14 @@ describe('actionComposerUtils', () => {
             });
 
             const result = actionComposerUtils.getDaoActions({
-                dao: generateDao(),
+                dao,
                 t: mockTranslations.tMock,
                 permissions: [
-                    { permissionId: '0xabcdef', whereAddress: pluginAddress },
+                    generateDaoPermission({
+                        permissionId: '0xabcdef',
+                        whereAddress: pluginAddress,
+                        whoAddress: daoAddress,
+                    }),
                 ],
             });
 
@@ -511,7 +568,7 @@ describe('actionComposerUtils', () => {
 
             expect(() =>
                 actionComposerUtils.getDaoActions({
-                    dao: generateDao(),
+                    dao,
                     t: mockTranslations.tMock,
                     permissions: [],
                 }),

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.test.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.test.ts
@@ -413,13 +413,14 @@ describe('actionComposerUtils', () => {
             expect(result.items.map((item) => item.id)).toEqual(['i1']);
         });
 
-        it('does not filter plugin items while permissions are not loaded', () => {
+        it('filters out permission-gated items but keeps ungated ones when permissions are undefined', () => {
             getDaoPluginActionsSpy.mockReturnValue({
                 pluginItems: [
                     buildPluginItem({
-                        id: 'i1',
+                        id: 'gated',
                         requiredPermissionId: permissionId,
                     }),
+                    buildPluginItem({ id: 'ungated' }),
                 ],
                 pluginGroups: [{ id: pluginAddress, name: 'Plugin', info: '' }],
                 pluginComponents: {},
@@ -431,7 +432,10 @@ describe('actionComposerUtils', () => {
                 permissions: undefined,
             });
 
-            expect(result.items.map((item) => item.id)).toEqual(['i1']);
+            expect(result.items.map((item) => item.id)).toEqual(['ungated']);
+            expect(result.groups.map((group) => group.id)).toEqual([
+                pluginAddress,
+            ]);
         });
 
         it('prunes plugin groups left without any items after filtering', () => {

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
@@ -77,7 +77,10 @@ class ActionComposerUtils {
      * Filters out plugin action items whose required OSx permission is not granted
      * to the DAO. Items without a `requiredPermissionId` are always kept, and
      * filtering is skipped entirely (fail-open) while `permissions` is undefined
-     * (not yet loaded). Matching is by permission id only, case-insensitively.
+     * (not yet loaded).
+     * A required permission counts as granted when the DAO's permission list
+     * contains a matching `permissionId` on the action's target contract
+     * (`defaultValue.to` as `where`), matched case-insensitively.
      *
      * @param items - Plugin action items to filter.
      * @param permissions - Permissions granted to the DAO, or undefined when not loaded.
@@ -91,17 +94,27 @@ class ActionComposerUtils {
             return items;
         }
 
-        const grantedIds = new Set(
-            permissions.map((permission) =>
-                permission.permissionId.toLowerCase(),
-            ),
-        );
+        return items.filter((item) => {
+            const { requiredPermissionId, defaultValue } = item;
 
-        return items.filter(
-            (item) =>
-                item.requiredPermissionId == null ||
-                grantedIds.has(item.requiredPermissionId.toLowerCase()),
-        );
+            // Items without a required permission are never permission-filtered.
+            if (requiredPermissionId == null) {
+                return true;
+            }
+
+            // Fail-open when the action's target contract cannot be resolved.
+            const where = defaultValue?.to;
+            if (!where) {
+                return true;
+            }
+
+            return permissions.some(
+                (permission) =>
+                    permission.permissionId.toLowerCase() ===
+                        requiredPermissionId.toLowerCase() &&
+                    addressUtils.isAddressEqual(permission.whereAddress, where),
+            );
+        });
     };
 
     /**

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
@@ -8,6 +8,7 @@ import {
     actionViewRegistry,
 } from '@/shared/utils/actionViewRegistry';
 import { ipfsUtils } from '@/shared/utils/ipfsUtils';
+import { permissionNameUtils } from '@/shared/utils/permissionNameUtils';
 import { pluginRegistryUtils } from '@/shared/utils/pluginRegistryUtils';
 import {
     type IProposalAction,
@@ -32,6 +33,10 @@ import {
     type IGetNativeActionGroupsParams,
     type IGetNativeActionItemsParams,
 } from './actionComposerUtils.api';
+
+const setMetadataPermissionId = permissionNameUtils.getPermissionId(
+    'SET_METADATA_PERMISSION',
+);
 
 class ActionComposerUtils {
     // The TransferActionLocked is a UI-only variant of the TransferAction which locks the token field to the one set as
@@ -374,6 +379,7 @@ class ActionComposerUtils {
                 plugin,
                 additionalMetadata,
             ),
+            requiredPermissionId: setMetadataPermissionId,
         };
     };
 

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
@@ -75,9 +75,8 @@ class ActionComposerUtils {
 
     /**
      * Filters out plugin action items whose required OSx permission is not granted
-     * to the DAO. Items without a `requiredPermissionId` are always kept, and
-     * filtering is skipped entirely (fail-open) while `permissions` is undefined
-     * (not yet loaded).
+     * to the DAO. Items without a `requiredPermissionId` are always kept.
+     *
      * A required permission counts as granted when the DAO's permission list
      * contains a matching `permissionId` on the action's target contract
      * (`defaultValue.to` as `where`), matched case-insensitively. A tagged item
@@ -89,12 +88,8 @@ class ActionComposerUtils {
      */
     private filterItemsByPermission = (
         items: IActionComposerInputItem[],
-        permissions?: IGetDaoActionsParams['permissions'],
+        permissions: IGetDaoActionsParams['permissions'] = [],
     ): IActionComposerInputItem[] => {
-        if (permissions == null) {
-            return items;
-        }
-
         return items.filter((item) => {
             const { requiredPermissionId, defaultValue } = item;
 

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
@@ -1,4 +1,4 @@
-import { addressUtils, IconType } from '@aragon/gov-ui-kit';
+import { addressUtils, IconType, invariant } from '@aragon/gov-ui-kit';
 import { zeroAddress } from 'viem';
 import type { IDao, IDaoPlugin } from '@/shared/api/daoService';
 import type { IAutocompleteInputGroup } from '@/shared/components/forms/autocompleteInput';
@@ -80,7 +80,8 @@ class ActionComposerUtils {
      * (not yet loaded).
      * A required permission counts as granted when the DAO's permission list
      * contains a matching `permissionId` on the action's target contract
-     * (`defaultValue.to` as `where`), matched case-insensitively.
+     * (`defaultValue.to` as `where`), matched case-insensitively. A tagged item
+     * with no resolvable target throws, as that indicates a misconfigured action.
      *
      * @param items - Plugin action items to filter.
      * @param permissions - Permissions granted to the DAO, or undefined when not loaded.
@@ -102,11 +103,14 @@ class ActionComposerUtils {
                 return true;
             }
 
-            // Fail-open when the action's target contract cannot be resolved.
+            // An action that declares a required permission must have a target
+            // contract to check it against — a missing `to` means the action
+            // item is misconfigured.
             const where = defaultValue?.to;
-            if (!where) {
-                return true;
-            }
+            invariant(
+                where != null && where !== '',
+                `filterItemsByPermission: action "${item.id}" declares a requiredPermissionId but has no target address.`,
+            );
 
             return permissions.some(
                 (permission) =>

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
@@ -51,13 +51,69 @@ class ActionComposerUtils {
             t,
         });
 
+        // Keep only plugin actions the DAO is authorized to execute, then drop
+        // plugin groups left without any items.
+        const pluginItems = this.filterItemsByPermission(
+            pluginActions.pluginItems,
+            permissions,
+        );
+        const pluginGroups = this.pruneEmptyGroups(
+            pluginActions.pluginGroups,
+            pluginItems,
+        );
+
         return {
-            items: [...pluginActions.pluginItems, ...permissionActions.items],
-            groups: [
-                ...pluginActions.pluginGroups,
-                ...permissionActions.groups,
-            ],
+            items: [...pluginItems, ...permissionActions.items],
+            groups: [...pluginGroups, ...permissionActions.groups],
         };
+    };
+
+    /**
+     * Filters out plugin action items whose required OSx permission is not granted
+     * to the DAO. Items without a `requiredPermissionId` are always kept, and
+     * filtering is skipped entirely (fail-open) while `permissions` is undefined
+     * (not yet loaded). Matching is by permission id only, case-insensitively.
+     *
+     * @param items - Plugin action items to filter.
+     * @param permissions - Permissions granted to the DAO, or undefined when not loaded.
+     * @returns The items the DAO is authorized to execute.
+     */
+    private filterItemsByPermission = (
+        items: IActionComposerInputItem[],
+        permissions?: IGetDaoActionsParams['permissions'],
+    ): IActionComposerInputItem[] => {
+        if (permissions == null) {
+            return items;
+        }
+
+        const grantedIds = new Set(
+            permissions.map((permission) =>
+                permission.permissionId.toLowerCase(),
+            ),
+        );
+
+        return items.filter(
+            (item) =>
+                item.requiredPermissionId == null ||
+                grantedIds.has(item.requiredPermissionId.toLowerCase()),
+        );
+    };
+
+    /**
+     * Removes groups that no longer contain any of the given items, so plugin
+     * groups whose actions were all filtered out are not rendered empty.
+     *
+     * @param groups - Candidate groups.
+     * @param items - Items that survived filtering.
+     * @returns Only the groups still referenced by at least one item's `groupId`.
+     */
+    private pruneEmptyGroups = (
+        groups: IAutocompleteInputGroup[],
+        items: IActionComposerInputItem[],
+    ): IAutocompleteInputGroup[] => {
+        const usedGroupIds = new Set(items.map((item) => item.groupId));
+
+        return groups.filter((group) => usedGroupIds.has(group.id));
     };
 
     getDaoPluginActions = (

--- a/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
+++ b/apps/app/src/modules/governance/components/actionComposer/actionComposerUtils.ts
@@ -61,6 +61,7 @@ class ActionComposerUtils {
         const pluginItems = this.filterItemsByPermission(
             pluginActions.pluginItems,
             permissions,
+            dao?.address,
         );
         const pluginGroups = this.pruneEmptyGroups(
             pluginActions.pluginGroups,
@@ -78,17 +79,20 @@ class ActionComposerUtils {
      * to the DAO. Items without a `requiredPermissionId` are always kept.
      *
      * A required permission counts as granted when the DAO's permission list
-     * contains a matching `permissionId` on the action's target contract
-     * (`defaultValue.to` as `where`), matched case-insensitively. A tagged item
-     * with no resolvable target throws, as that indicates a misconfigured action.
+     * contains a matching `permissionId` (case-insensitive) granted to the DAO
+     * itself (`whoAddress`) on the action's target contract (`defaultValue.to`
+     * as `where`). A tagged item with no resolvable target throws, as that
+     * indicates a misconfigured action.
      *
      * @param items - Plugin action items to filter.
-     * @param permissions - Permissions granted to the DAO, or undefined when not loaded.
+     * @param permissions - Permissions granted on the DAO, or undefined when not loaded.
+     * @param daoAddress - Address of the DAO, which must be the grantee (`who`) of the permission.
      * @returns The items the DAO is authorized to execute.
      */
     private filterItemsByPermission = (
         items: IActionComposerInputItem[],
         permissions: IGetDaoActionsParams['permissions'] = [],
+        daoAddress?: string,
     ): IActionComposerInputItem[] => {
         return items.filter((item) => {
             const { requiredPermissionId, defaultValue } = item;
@@ -111,7 +115,14 @@ class ActionComposerUtils {
                 (permission) =>
                     permission.permissionId.toLowerCase() ===
                         requiredPermissionId.toLowerCase() &&
-                    addressUtils.isAddressEqual(permission.whereAddress, where),
+                    addressUtils.isAddressEqual(
+                        permission.whereAddress,
+                        where,
+                    ) &&
+                    addressUtils.isAddressEqual(
+                        permission.whoAddress,
+                        daoAddress,
+                    ),
             );
         });
     };

--- a/apps/app/src/plugins/lockToVotePlugin/utils/lockToVoteActionUtils/lockToVoteActionUtils.ts
+++ b/apps/app/src/plugins/lockToVotePlugin/utils/lockToVoteActionUtils/lockToVoteActionUtils.ts
@@ -11,6 +11,7 @@ import type { ITokenProposalAction } from '@/plugins/tokenPlugin/types';
 import type { IDaoPlugin } from '@/shared/api/daoService';
 import type { TranslationFunction } from '@/shared/components/translationsProvider';
 import { daoUtils } from '@/shared/utils/daoUtils';
+import { permissionNameUtils } from '@/shared/utils/permissionNameUtils';
 import { LockToVoteUpdateSettingsAction } from '../../components/lockToVoteActions/lockToVoteUpdateSettingsAction';
 import type {
     ILockToVoteActionChangeSettings,
@@ -51,6 +52,10 @@ export type IGetLockToVoteActionsResult = IActionComposerPluginData<
     IDaoPlugin<ILockToVotePluginSettings>
 >;
 
+const updateSettingsPermissionId = permissionNameUtils.getPermissionId(
+    'UPDATE_SETTINGS_PERMISSION',
+);
+
 class LockToVoteActionUtils {
     getLockToVoteActions = ({
         plugin,
@@ -84,6 +89,7 @@ class LockToVoteActionUtils {
                     groupId: address,
                     defaultValue: defaultUpdateSettings(plugin),
                     meta: plugin,
+                    requiredPermissionId: updateSettingsPermissionId,
                 },
                 {
                     ...actionComposerUtils.getDefaultActionPluginMetadataItem(

--- a/apps/app/src/plugins/multisigPlugin/utils/multisigActionUtils/multisigActionUtils.ts
+++ b/apps/app/src/plugins/multisigPlugin/utils/multisigActionUtils/multisigActionUtils.ts
@@ -11,6 +11,7 @@ import type { IActionComposerPluginData } from '@/modules/governance/types';
 import type { IDaoPlugin } from '@/shared/api/daoService';
 import type { TranslationFunction } from '@/shared/components/translationsProvider';
 import { daoUtils } from '@/shared/utils/daoUtils';
+import { permissionNameUtils } from '@/shared/utils/permissionNameUtils';
 import { versionComparatorUtils } from '@/shared/utils/versionComparatorUtils';
 import { MultisigAddMembersAction } from '../../components/multisigActions/multisigAddMembersAction';
 import { MultisigRemoveMembersAction } from '../../components/multisigActions/multisigRemoveMembersAction';
@@ -55,6 +56,12 @@ export type IGetMultisigActionsResult = IActionComposerPluginData<
     IDaoPlugin<IMultisigPluginSettings>
 >;
 
+// Add / remove members and update settings all require the multisig
+// update-settings permission on the plugin.
+const updateSettingsPermissionId = permissionNameUtils.getPermissionId(
+    'UPDATE_MULTISIG_SETTINGS_PERMISSION',
+);
+
 class MultisigActionUtils {
     getMultisigActions = ({
         plugin,
@@ -85,6 +92,7 @@ class MultisigActionUtils {
                     icon: IconType.PLUS,
                     groupId: address,
                     defaultValue: { ...defaultAddMembers, to: address },
+                    requiredPermissionId: updateSettingsPermissionId,
                 },
                 {
                     id: `${address}-${MultisigProposalActionType.MULTISIG_REMOVE_MEMBERS}`,
@@ -94,6 +102,7 @@ class MultisigActionUtils {
                     icon: IconType.MINUS,
                     groupId: address,
                     defaultValue: { ...defaultRemoveMembers, to: address },
+                    requiredPermissionId: updateSettingsPermissionId,
                 },
                 {
                     id: `${address}-${MultisigProposalActionType.UPDATE_MULTISIG_SETTINGS}`,
@@ -104,6 +113,7 @@ class MultisigActionUtils {
                     groupId: address,
                     defaultValue: defaultUpdateSettings(plugin),
                     meta: plugin,
+                    requiredPermissionId: updateSettingsPermissionId,
                 },
                 {
                     ...actionComposerUtils.getDefaultActionPluginMetadataItem(

--- a/apps/app/src/plugins/tokenPlugin/utils/tokenActionUtils/tokenActionUtils.ts
+++ b/apps/app/src/plugins/tokenPlugin/utils/tokenActionUtils/tokenActionUtils.ts
@@ -12,6 +12,7 @@ import type { IActionComposerPluginData } from '@/modules/governance/types';
 import type { IDaoPlugin } from '@/shared/api/daoService';
 import type { TranslationFunction } from '@/shared/components/translationsProvider';
 import { daoUtils } from '@/shared/utils/daoUtils';
+import { permissionNameUtils } from '@/shared/utils/permissionNameUtils';
 import { versionComparatorUtils } from '@/shared/utils/versionComparatorUtils';
 import { TokenMintTokensAction } from '../../components/tokenActions/tokenMintTokensAction';
 import { TokenUpdateSettingsAction } from '../../components/tokenActions/tokenUpdateSettingsAction';
@@ -58,6 +59,11 @@ export type IGetTokenActionsResult = IActionComposerPluginData<
     IDaoPlugin<ITokenPluginSettings>
 >;
 
+const mintPermissionId = permissionNameUtils.getPermissionId('MINT_PERMISSION');
+const updateVotingSettingsPermissionId = permissionNameUtils.getPermissionId(
+    'UPDATE_VOTING_SETTINGS_PERMISSION',
+);
+
 class TokenActionUtils {
     getTokenActions = ({
         plugin,
@@ -96,6 +102,7 @@ class TokenActionUtils {
                     groupId: tokenAddress,
                     meta: plugin,
                     defaultValue: defaultMintAction(settings),
+                    requiredPermissionId: mintPermissionId,
                 },
                 {
                     id: `${address}-${TokenProposalActionType.UPDATE_VOTE_SETTINGS}`,
@@ -106,6 +113,7 @@ class TokenActionUtils {
                     groupId: address,
                     defaultValue: defaultUpdateSettings(plugin),
                     meta: plugin,
+                    requiredPermissionId: updateVotingSettingsPermissionId,
                 },
                 {
                     ...actionComposerUtils.getDefaultActionPluginMetadataItem(

--- a/apps/app/src/shared/api/daoService/queries/useAllDaoPermissions/useAllDaoPermissions.ts
+++ b/apps/app/src/shared/api/daoService/queries/useAllDaoPermissions/useAllDaoPermissions.ts
@@ -40,6 +40,11 @@ export const useAllDaoPermissions = (
         options,
     );
 
+    // While auto-paginating, `isLoading` only tracks the first page and `data`
+    // defaults to an empty array, so neither can express "the full permission
+    // set is not ready yet".
+    const isFetchingAll = isLoading || hasNextPage || isFetchingNextPage;
+
     useEffect(() => {
         if (hasNextPage && !isFetchingNextPage) {
             void fetchNextPage();
@@ -47,13 +52,16 @@ export const useAllDaoPermissions = (
     }, [hasNextPage, fetchNextPage, isFetchingNextPage]);
 
     const allPermissions = useMemo(
-        () => data?.pages.flatMap((page) => page.data) ?? [],
-        [data],
+        () =>
+            isFetchingAll || error
+                ? undefined
+                : (data?.pages.flatMap((page) => page.data) ?? []),
+        [data, isFetchingAll, error],
     );
 
     return {
         data: allPermissions,
-        isLoading,
+        isLoading: isFetchingAll,
         error,
         refetch,
     };


### PR DESCRIPTION
# Description

Filters OSx-related plugin actions out of the action builder when the DAO does not hold the required permission to execute them, so users are no longer offered actions that would fail on execution.

Each plugin action item can now declare a `requiredPermissionId` (keccak256 permission id). When building the DAO action list, `actionComposerUtils` keeps only the plugin items whose required permission is granted to the DAO, then prunes any plugin groups left without items.

Details:
- Add `requiredPermissionId?: string` to `IActionComposerInputItem`. Matching is by permission id and target contract (`defaultValue.to` as `where`); `who` is checked against DAO address.
- `filterItemsByPermission` fails closed while permissions are still loading (`undefined`), always keeps items without a `requiredPermissionId`, and throws (`invariant`) when a permission-tagged item has no resolvable target address (misconfiguration guard).
- `pruneEmptyGroups` drops plugin groups whose actions were all filtered out.
- Tag the relevant plugin actions with their permission ids:
  - Multisig: add/remove members and update settings → `UPDATE_MULTISIG_SETTINGS_PERMISSION`
  - Token: mint → `MINT_PERMISSION`, update voting settings → `UPDATE_VOTING_SETTINGS_PERMISSION`
  - Lock-to-vote: update settings → `UPDATE_SETTINGS_PERMISSION`
  - Metadata: set metadata → `SET_METADATA_PERMISSION`
- Add unit tests for `getDaoActions` covering permission filtering and empty-group pruning.

## Type of Change

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [x] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project