### PR TITLE
feat(APP-1017): Show proposal creation eligibility for SPP external proposer Safes

### DIFF
--- a/.changeset/show-spp-external-proposer-eligibility.md
+++ b/.changeset/show-spp-external-proposer-eligibility.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Show proposal creation eligibility for SPP external proposer Safes

--- a/apps/app/src/assets/locales/en.json
+++ b/apps/app/src/assets/locales/en.json
@@ -3067,9 +3067,9 @@
           "description": "You are not connected to the correct address. If you are one of its owners, you can connect it with WalletConnect.",
           "title": "Not eligible to vote"
         },
-        "sppPermissionCheckProposalCreation": {
+        "sppExternalPermissionCheckProposalCreation": {
           "function": "Proposal creation",
-          "pluginLabelName": "Name",
+          "pluginLabelName": "Address",
           "requirement": "Safe multisig member"
         },
         "sppProposalListItem": {

--- a/apps/app/src/modules/governance/components/permissionsDefinitionList/permissionsDefinitionList.tsx
+++ b/apps/app/src/modules/governance/components/permissionsDefinitionList/permissionsDefinitionList.tsx
@@ -38,7 +38,7 @@ export const PermissionsDefinitionList: React.FC<
     const hasSettingsGroups = settings.length > 1;
 
     if (!hasSettings) {
-        // A special case when Safes are used (we still miss settings for Safe bodies).
+        // No eligibility settings to display: render nothing rather than an empty card (APP-137).
         return null;
     }
 

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.test.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.test.ts
@@ -36,13 +36,13 @@ describe('useSppExternalPermissionCheckProposalCreation', () => {
             settings: [
                 [
                     {
-                        term: 'app.plugins.spp.sppPermissionCheckProposalCreation.pluginLabelName',
+                        term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.pluginLabelName',
                         definition: addressUtils.truncateAddress(safeAddress),
                     },
                     {
-                        term: 'app.plugins.spp.sppPermissionCheckProposalCreation.function',
+                        term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',
                         definition:
-                            'app.plugins.spp.sppPermissionCheckProposalCreation.requirement',
+                            'app.plugins.spp.sppExternalPermissionCheckProposalCreation.requirement',
                     },
                 ],
             ],

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.ts
@@ -43,7 +43,7 @@ export const useSppExternalPermissionCheckProposalCreation = (
             [
                 {
                     term: t(
-                        'app.plugins.spp.sppPermissionCheckProposalCreation.pluginLabelName',
+                        'app.plugins.spp.sppExternalPermissionCheckProposalCreation.pluginLabelName',
                     ),
                     definition: addressUtils.truncateAddress(
                         externalBody.address,
@@ -51,10 +51,10 @@ export const useSppExternalPermissionCheckProposalCreation = (
                 },
                 {
                     term: t(
-                        'app.plugins.spp.sppPermissionCheckProposalCreation.function',
+                        'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',
                     ),
                     definition: t(
-                        'app.plugins.spp.sppPermissionCheckProposalCreation.requirement',
+                        'app.plugins.spp.sppExternalPermissionCheckProposalCreation.requirement',
                     ),
                 },
             ],

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.test.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.test.ts
@@ -255,13 +255,13 @@ describe('useSppPermissionCheckProposalCreation', () => {
         expect(result.current.settings).toEqual([
             [
                 {
-                    term: 'app.plugins.spp.sppPermissionCheckProposalCreation.pluginLabelName',
+                    term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.pluginLabelName',
                     definition: addressUtils.truncateAddress(safeAddress),
                 },
                 {
-                    term: 'app.plugins.spp.sppPermissionCheckProposalCreation.function',
+                    term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',
                     definition:
-                        'app.plugins.spp.sppPermissionCheckProposalCreation.requirement',
+                        'app.plugins.spp.sppExternalPermissionCheckProposalCreation.requirement',
                 },
             ],
         ]);
@@ -369,13 +369,140 @@ describe('useSppPermissionCheckProposalCreation', () => {
             ...internalSettings,
             [
                 {
-                    term: 'app.plugins.spp.sppPermissionCheckProposalCreation.pluginLabelName',
+                    term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.pluginLabelName',
                     definition: addressUtils.truncateAddress(safeAddress),
                 },
                 {
-                    term: 'app.plugins.spp.sppPermissionCheckProposalCreation.function',
+                    term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',
                     definition:
-                        'app.plugins.spp.sppPermissionCheckProposalCreation.requirement',
+                        'app.plugins.spp.sppExternalPermissionCheckProposalCreation.requirement',
+                },
+            ],
+        ]);
+    });
+
+    it('surfaces an external proposer Safe in the eligibility settings', () => {
+        const externalProposerAddress = `0x${'e'.repeat(40)}`;
+        const sppPlugin = generateDaoPlugin({
+            address: `0x${'a'.repeat(40)}`,
+            settings: generateSppPluginSettings({
+                stages: [],
+                externalProposers: [
+                    {
+                        address: externalProposerAddress,
+                        proposalCreationConditionAddress: `0x${'c'.repeat(40)}`,
+                    },
+                ],
+            }),
+        });
+
+        // External proposers are not DAO plugins, so no meta matches by address.
+        useDaoPluginsSpy.mockReturnValue([]);
+        useDaoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: generateDao() }),
+        );
+        mockSimulation({ isLoading: false, isSuccess: true });
+
+        const params = { daoId: 'dao-test', plugin: sppPlugin };
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.isRestricted).toBeTruthy();
+        expect(result.current.settings).toEqual([
+            [
+                {
+                    term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.pluginLabelName',
+                    definition: addressUtils.truncateAddress(
+                        externalProposerAddress,
+                    ),
+                },
+                {
+                    term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',
+                    definition:
+                        'app.plugins.spp.sppExternalPermissionCheckProposalCreation.requirement',
+                },
+            ],
+        ]);
+    });
+
+    it('appends external proposer Safe groups after stage-body groups', () => {
+        const internalAddress = `0x${'1'.repeat(40)}`;
+        const externalProposerAddress = `0x${'e'.repeat(40)}`;
+
+        const internalMeta = generateDaoPlugin({ address: internalAddress });
+        const internalSettings = [
+            [{ term: 'Members', definition: 'Listed only' }],
+        ];
+        const internalGuardResult = generateGuardResult({
+            isRestricted: true,
+            settings: internalSettings,
+        });
+
+        const sppPlugin = generateDaoPlugin({
+            address: `0x${'a'.repeat(40)}`,
+            settings: generateSppPluginSettings({
+                stages: [
+                    generateSppStage({
+                        plugins: [
+                            generateSppStagePlugin({
+                                address: internalAddress,
+                            }),
+                        ],
+                    }),
+                ],
+                externalProposers: [
+                    {
+                        address: externalProposerAddress,
+                        proposalCreationConditionAddress: `0x${'c'.repeat(40)}`,
+                    },
+                ],
+            }),
+        });
+
+        useDaoPluginsSpy.mockReturnValue([
+            generateFilterComponentPlugin({ meta: internalMeta }),
+        ]);
+        useDaoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: generateDao() }),
+        );
+        // Only the internal body resolves to a slot function; the external proposer Safe
+        // (pluginId 'external') falls through to the fallback hook.
+        getSlotFunctionSpy.mockImplementation(((slotParams: {
+            pluginId: string;
+        }) =>
+            slotParams.pluginId === internalMeta.interfaceType
+                ? () => internalGuardResult
+                : undefined) as never);
+        mockSimulation({ isLoading: false, isSuccess: true });
+
+        const params = { daoId: 'dao-test', plugin: sppPlugin };
+        const { result } = renderHook(() =>
+            useSppPermissionCheckProposalCreation(
+                params as Parameters<
+                    typeof useSppPermissionCheckProposalCreation
+                >[0],
+            ),
+        );
+
+        expect(result.current.isRestricted).toBeTruthy();
+        expect(result.current.settings).toEqual([
+            ...internalSettings,
+            [
+                {
+                    term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.pluginLabelName',
+                    definition: addressUtils.truncateAddress(
+                        externalProposerAddress,
+                    ),
+                },
+                {
+                    term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',
+                    definition:
+                        'app.plugins.spp.sppExternalPermissionCheckProposalCreation.requirement',
                 },
             ],
         ]);

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.ts
@@ -8,7 +8,8 @@ import type {
 import { type IDaoPlugin, useDao } from '@/shared/api/daoService';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
 import { pluginRegistryUtils } from '@/shared/utils/pluginRegistryUtils';
-import type { ISppPluginSettings } from '../../types';
+import type { ISppPluginSettings, ISppStagePlugin } from '../../types';
+import { SppProposalType, VotingBodyBrandIdentity } from '../../types';
 import { useSppExternalPermissionCheckProposalCreation } from '../useSppExternalPermissionCheckProposalCreation';
 
 export interface IUseSppPermissionCheckProposalCreationParams
@@ -36,7 +37,24 @@ export const useSppPermissionCheckProposalCreation = (
             plugin,
             network: dao?.network,
         });
-    const sppPlugins = plugin.settings.stages.flatMap((stage) => stage.plugins);
+    const stageBodies = plugin.settings.stages.flatMap(
+        (stage) => stage.plugins,
+    );
+
+    // Non-body proposer Safes: shape them as external bodies so the existing external-body fallback
+    // (useSppExternalPermissionCheckProposalCreation) resolves them into a Safe eligibility group.
+    const externalProposers = (plugin.settings.externalProposers ?? []).map(
+        (proposer): ISppStagePlugin => ({
+            proposalType: SppProposalType.NONE, // non-body proposers do not vote
+            interfaceType: undefined, // marks it external, resolving to pluginId 'external'
+            brandId: VotingBodyBrandIdentity.SAFE,
+            address: proposer.address,
+            proposalCreationConditionAddress:
+                proposer.proposalCreationConditionAddress,
+        }),
+    );
+
+    const sppPlugins = [...stageBodies, ...externalProposers];
 
     const pluginProposalCreationGuardResults = sppPlugins.map((sppPlugin) => {
         const subPlugin = daoPlugins.find(({ meta }) =>

--- a/apps/app/src/plugins/sppPlugin/types/index.ts
+++ b/apps/app/src/plugins/sppPlugin/types/index.ts
@@ -1,4 +1,5 @@
 export * from './enum';
+export type { ISppExternalProposer } from './sppExternalProposer';
 export type { ISppPluginSettings } from './sppPluginSettings';
 export type { ISppProposal } from './sppProposal';
 export type { ISppProposalBodyResult } from './sppProposalBodyResult';

--- a/apps/app/src/plugins/sppPlugin/types/sppExternalProposer.ts
+++ b/apps/app/src/plugins/sppPlugin/types/sppExternalProposer.ts
@@ -1,0 +1,10 @@
+export interface ISppExternalProposer {
+    /**
+     * Address of the Safe granted proposal-creation permission that is not a stage body.
+     */
+    address: string;
+    /**
+     * Address of the SafeOwnerCondition guarding the Safe's proposal-creation permission.
+     */
+    proposalCreationConditionAddress: string;
+}

--- a/apps/app/src/plugins/sppPlugin/types/sppPluginSettings.ts
+++ b/apps/app/src/plugins/sppPlugin/types/sppPluginSettings.ts
@@ -1,4 +1,5 @@
 import type { IPluginSettings } from '@/shared/api/daoService';
+import type { ISppExternalProposer } from './sppExternalProposer';
 import type { ISppStage } from './sppStage';
 
 export interface ISppPluginSettings extends IPluginSettings {
@@ -6,4 +7,9 @@ export interface ISppPluginSettings extends IPluginSettings {
      * List of stages of the SPP plugin.
      */
     stages: ISppStage[];
+    /**
+     * Safes granted proposal-creation permission that are not stage bodies of any stage. Undefined
+     * until the backend resolves them.
+     */
+    externalProposers?: ISppExternalProposer[];
 }


### PR DESCRIPTION
# Description

Integrates [aragon/app-backend#1477](https://github.com/aragon/app-backend/pull/1477): SPP plugin settings now include `externalProposers` — Safes granted permission to create proposals on a process without being a body of any stage. Until now, `useSppPermissionCheckProposalCreation` only inspected stage bodies, so these Safes were invisible in the "who can create proposals" eligibility UI (the create-proposal permission dialog and the process-details "Creation eligibility" card).

This PR folds `externalProposers` into the eligibility computation by reusing the existing external-Safe-body resolution path (`useSppExternalPermissionCheckProposalCreation`) — no parallel logic, same rendering. Scope is limited to eligibility **display**; wiring these proposers into the on-chain condition-rebuild flow when editing a process (`existingProposalCreationConditions`) is a separate, larger concern and is out of scope here.

Also fixes two pre-existing failing test suites: a prior commit on this branch (`feat: update labels`) renamed the external-body i18n namespace to `sppExternalPermissionCheckProposalCreation` but left the test assertions on the old key, so both SPP permission-check suites were red before this change.

## Type of Change

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [x] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project