### PR TITLE
ci: resolve the finalize guard's release scope at the tested SHA

### DIFF
--- a/.github/workflows/app-release-pr-finalize.yml
+++ b/.github/workflows/app-release-pr-finalize.yml
@@ -31,20 +31,30 @@ jobs:
             .github/actions/gh-pr-get-body
             .github/workflows/scripts/slackNotify.js
 
-      # Full checkout + pnpm install at the merge commit (post-merge main), so the scope
-      # resolution below reads the current release-scopes policy — release branches cut before
-      # the scope mapper landed don't ship it.
+      # Full checkout + pnpm install at the merge commit (post-merge main): releaseScopes.js and
+      # its node_modules must exist regardless of what the release branch ships.
       - name: Setup merge commit
         uses: ./.github/actions/setup
 
       # Resolved before the release-branch checkout: releaseScopes.js needs node_modules, which
       # the next checkout's clean removes. The guard itself only needs the pattern.
+      # The policy file is read from the tested SHA so the guard mirrors the --ignore scoping
+      # that `changeset version` ran with when the release was cut — a scope change merged to
+      # main mid-release must not re-classify the branch's leftover changesets as new. The
+      # merge-commit policy is only a fallback for branches cut before the scope mapper landed.
       - name: Resolve app release scope
         id: scope
         shell: bash
+        env:
+          TESTED_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          packages=$(node -e "console.log(require('./.github/workflows/scripts/releaseScopes.js').resolveReleaseScope('app').join('|'))")
+          scopes_path=.github/release-scopes.yml
+          git fetch --depth=1 origin "$TESTED_SHA" || true
+          if git show "$TESTED_SHA:.github/release-scopes.yml" > "$RUNNER_TEMP/release-scopes.yml" 2>/dev/null; then
+            scopes_path="$RUNNER_TEMP/release-scopes.yml"
+          fi
+          packages=$(SCOPES_PATH="$scopes_path" node -e "console.log(require('./.github/workflows/scripts/releaseScopes.js').resolveReleaseScope('app', process.env.SCOPES_PATH).join('|'))")
           echo "pattern=${packages}" >> "$GITHUB_OUTPUT"
 
       - name: Load secrets

--- a/.github/workflows/assistant-release-pr-finalize.yml
+++ b/.github/workflows/assistant-release-pr-finalize.yml
@@ -43,8 +43,8 @@ jobs:
           sparse-checkout: |
             .github/actions/setup
 
-      # Full checkout + pnpm install at the merge commit (post-merge main), so the scope
-      # resolution below reads the current release-scopes policy.
+      # Full checkout + pnpm install at the merge commit (post-merge main): releaseScopes.js and
+      # its node_modules must exist regardless of what the release branch ships.
       - name: Setup merge commit
         uses: ./.github/actions/setup
         with:
@@ -53,12 +53,23 @@ jobs:
 
       # Resolved before the release-branch checkout: releaseScopes.js needs node_modules, which
       # the next checkout's clean removes. The guard itself only needs the pattern.
+      # The policy file is read from the tested SHA so the guard mirrors the --ignore scoping
+      # that `changeset version` ran with when the release was cut — a scope change merged to
+      # main mid-release must not re-classify the branch's leftover changesets as new. The
+      # merge-commit policy is only a fallback for branches cut before the scope mapper landed.
       - name: Resolve assistant release scope
         id: scope
         shell: bash
+        env:
+          TESTED_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          packages=$(node -e "console.log(require('./.github/workflows/scripts/releaseScopes.js').resolveReleaseScope('assistant').join('|'))")
+          scopes_path=.github/release-scopes.yml
+          git fetch --depth=1 origin "$TESTED_SHA" || true
+          if git show "$TESTED_SHA:.github/release-scopes.yml" > "$RUNNER_TEMP/release-scopes.yml" 2>/dev/null; then
+            scopes_path="$RUNNER_TEMP/release-scopes.yml"
+          fi
+          packages=$(SCOPES_PATH="$scopes_path" node -e "console.log(require('./.github/workflows/scripts/releaseScopes.js').resolveReleaseScope('assistant', process.env.SCOPES_PATH).join('|'))")
           echo "pattern=${packages}" >> "$GITHUB_OUTPUT"
 
       # The guard checks the release-branch head, not the merge commit: the merge commit also


### PR DESCRIPTION
The finalize guard ("no new scope changesets at finalize") classifies leftover changesets using the release-scope policy, but resolved it from the merge commit (post-merge `main`). A scope change merged to `main` mid-release then re-classifies changesets that were legitimately out of scope when `changeset version` ran at release start, and the guard fails a release that added nothing new.

That's exactly how [Release 1.34.0's finalize](https://github.com/aragon/app/actions/runs/30007912997/job/89208358351) failed: the branch was cut on Jul 20 under the pre-mapper scoping (so `.changeset/assistant-chat-widget.md` was correctly left unconsumed), `release-scopes.yml` landed on `main` on Jul 21 and moved `@aragon/assistant-chat` into the app scope, and finalize on Jul 23 judged the old changeset by the new policy. The release was completed manually (tag + GitHub Release).

## Changes

- **Read `release-scopes.yml` from the tested SHA** in both finalize workflows (app and assistant): the guard now mirrors the `--ignore` scoping that `changeset version` actually ran with when the release was cut.
- **Keep the merge-commit policy as a fallback only** for release branches cut before the scope mapper landed (they don't ship the file). `releaseScopes.js` and its `node_modules` still run from the merge-commit checkout, so pre-mapper branches keep working.

After this release ships, every new release branch carries the mapper and the fallback becomes dead weight we can eventually drop.