### PR TITLE
feat(APP-999): add Plausible analytics event hooks

### DIFF
--- a/.changeset/app-999-plausible-analytics-event-hooks.md
+++ b/.changeset/app-999-plausible-analytics-event-hooks.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Instrument privacy-safe Plausible custom events across the wizard, transaction and proposal-action flows, sent through the shared analytics pipeline

--- a/apps/app/config/.env.production
+++ b/apps/app/config/.env.production
@@ -19,5 +19,5 @@ NEXT_PUBLIC_GOVERNANCE_ADVANCED_CUTOFF_TIMESTAMP=1775088001
 # URL of the Aragon assistant service (support chat API)
 NEXT_PUBLIC_ASSISTANT_URL=https://assistant.aragon.org
 
-# Plausible site domain; unset in other environments so tracking only runs in production
+# Plausible site domain; unset in environments that should not send analytics events
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=app.aragon.org

--- a/apps/app/docs/projectDocs/analyticsEvents.md
+++ b/apps/app/docs/projectDocs/analyticsEvents.md
@@ -1,0 +1,306 @@
+# Analytics events
+
+The app uses [Plausible Analytics](https://plausible.io) through the shared `analyticsUtils` pipeline and the typed `plausibleAnalyticsUtils` product-event facade.
+
+## Runtime pipeline
+
+`apps/app/instrumentation-client.ts` calls `analyticsUtils.init()` once on the client. The utility dynamically imports `@plausible-analytics/tracker` because the package reads browser globals and must not load during server rendering.
+
+The tracker is initialised only when `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` is non-empty:
+
+```ts
+const domain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+
+if (!domain) {
+    return;
+}
+
+initPlausibleTracker({ domain, endpoint: '/api/analytics' });
+```
+
+`apps/app/next.config.mjs` rewrites `/api/analytics` to `https://plausible.io/api/event`. This keeps browser requests on our own origin so filter lists that block direct requests to `plausible.io` are less likely to drop events.
+
+The proxy is not an authentication boundary. Plausible event ingestion is a public analytics endpoint keyed by site domain and event URL; no API key is used in client analytics. Do not send secrets, PII, wallet addresses, transaction hashes, calldata, DAO IDs, proposal titles, or free-form user input as event props.
+
+`@plausible-analytics/tracker` defaults `autoCapturePageviews` and `bindToWindow` to `true`, so enabling `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` also enables automatic pageview tracking and exposes `window.plausible` for Plausible's installation verifier. Custom APP-999 events are additional events on top of that pageview surface.
+
+## Environment behavior
+
+Tracking is controlled by committed env config plus deployment overrides:
+
+| Environment config | `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` | Behavior |
+| --- | --- | --- |
+| `config/.env.development` | `dev.app.aragon.org` | Development deploys emit to the dev Plausible site. |
+| `config/.env.production` | `app.aragon.org` | Production emits to the production Plausible site. |
+| `config/.env.preview` | unset | PR previews do not emit unless Vercel/1Password injects an override. |
+| `config/.env.staging` | unset | Staging does not emit unless deployment secrets inject an override. |
+| `.env.local` | IC-local | Never commit local analytics overrides. |
+
+The wrapper treats `undefined` and `''` as disabled. This prevents an empty env var from reaching the tracker as a falsy domain.
+
+## Local and preview verification
+
+Preferred smoke-test target: an Aragon-owned deployment with a real Plausible site configured, currently `dev.app.aragon.org` for development.
+
+Localhost is intentionally not a reliable Network-tab success path. The tracker defaults `captureOnLocalhost` to `false`, and the wrapper does not expose that option. If you run locally with `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` set, the expected local signal is the Plausible ignored-event log for localhost, not a successful `POST /api/analytics` request.
+
+For PR previews, events emit only if the preview deployment receives `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` from deployment secrets or an explicit environment override. Otherwise the analytics utilities no-op.
+
+## Event naming
+
+APP-999 product events use snake_case identifiers, not Title Case dashboard labels.
+
+Use grouped prefixes for lifecycle/funnel telemetry:
+
+- `wizard_*`
+- `transaction_*`
+- `action_*`
+
+Rationale:
+
+- event names are stable code IDs;
+- prefixes group related funnel events;
+- TypeScript unions catch typos;
+- dashboards can segment by event props such as `flow` and `transactionKind`;
+- Title Case click-goal names are too easy to attach to the wrong lifecycle point.
+
+Do not name a click after a later business outcome. For example, a submit-button click before wallet signing is not a DAO publish event. DAO creation success is represented by a transaction terminal event with DAO-specific props.
+
+Plausible funnels are built from defined goals, not raw event rows. Event props can participate in a funnel only by creating property-filtered goals in Plausible (up to three property constraints per goal) and then using those goals as funnel steps. Keep top-level event names meaningful on their own; props are dimensions/constraints, not a replacement for registering goals.
+
+## Event transport API
+
+Application product code should use:
+
+```ts
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
+
+plausibleAnalyticsUtils.track('wizard_submit', {
+    flow: 'create_dao',
+    network,
+    hasEns: ens !== '',
+    hasAvatar: avatar != null,
+});
+```
+
+`plausibleAnalyticsUtils` is the app-owned taxonomy layer. It accepts `string | number | boolean | null | undefined` prop values, drops nullish entries, stringifies numbers and booleans, and delegates to `analyticsUtils.trackEvent` with Plausible-compatible string props.
+
+Use `analyticsUtils.trackEvent` directly only for shared pipeline tests or future non-APP-999 events that intentionally bypass the typed catalog.
+
+## Shared props
+
+| Prop | Type before normalization | Meaning |
+| --- | --- | --- |
+| `flow` | string | Product flow that emitted the event. |
+| `transactionKind` | string | Low-cardinality transaction purpose inside a flow. |
+| `transactionType` | string | Backend transaction type when backend transaction status/indexing is used. |
+| `network` | string | DAO or transaction network. |
+| `chainId` | number | Required EVM chain ID. |
+| `pluginInterfaceType` | string | Governance plugin interface type when relevant. |
+
+Known `flow` values:
+
+| Value | Meaning |
+| --- | --- |
+| `create_dao` | New DAO creation wizard and publish transaction. |
+| `governance_designer` | Add/create governance process wizard. |
+| `create_proposal` | Proposal creation wizard and publish transaction. |
+| `direct_execute_actions` | Direct admin action execution flow. |
+| `proposal_execution` | Execute existing proposal. |
+| `proposal_vote` | Vote on existing proposal. |
+
+Known `transactionKind` values:
+
+| Value | Flow |
+| --- | --- |
+| `dao_create` | `create_dao` |
+| `governance_proposal_create` | `create_proposal` |
+| `admin_instant_execute` | `direct_execute_actions` |
+| `governance_proposal_execute` | `proposal_execution` |
+| `governance_proposal_vote` | `proposal_vote` |
+
+## Event catalog
+
+### `wizard_start`
+
+Fires once when an analytics-enabled wizard mounts with an active step.
+
+Required props:
+
+| Prop | Notes |
+| --- | --- |
+| `flow` | Product flow. |
+
+Optional props:
+
+| Prop | Notes |
+| --- | --- |
+| `pluginInterfaceType` | Present on create-proposal wizards. |
+
+### `wizard_step`
+
+Fires when the active wizard step changes, including the initial active step with `direction: direct`. Duplicate same-step renders are suppressed.
+
+Required props:
+
+| Prop | Notes |
+| --- | --- |
+| `flow` | Product flow. |
+| `stepKey` | Wizard step ID. |
+| `stepIndex` | Zero-based step index. |
+| `direction` | `direct`, `forward`, or `back`. |
+
+Optional props:
+
+| Prop | Notes |
+| --- | --- |
+| `pluginInterfaceType` | Present on create-proposal wizards. |
+
+### `wizard_validation_blocked`
+
+Fires when the user attempts to move forward or submit and validation blocks progress.
+
+Required props:
+
+| Prop | Notes |
+| --- | --- |
+| `flow` | Product flow. |
+| `stepKey` | Active wizard step ID. |
+| `stepIndex` | Zero-based active step index. |
+| `attempt` | `next` or `submit`. |
+| `errorCount` | Number of top-level validation error keys. |
+
+Never send field names, invalid values, validation messages, proposal body text, addresses, ENS, or metadata.
+
+### `wizard_submit`
+
+Fires when a wizard reaches its final submit action and starts/opens the committed next step.
+
+Flow-specific props:
+
+| Flow | Additional props |
+| --- | --- |
+| `create_dao` | `network`, `hasEns`, `hasAvatar` |
+| `governance_designer` | `setupMode`, conditional `stageCount` |
+| `create_proposal` | `actionCount`, `hasActions`, `pluginInterfaceType` |
+| `direct_execute_actions` | `actionCount` |
+
+`create_dao` fires after the wallet guard succeeds and before opening the Publish DAO transaction dialog. DAO transaction submission/success is tracked by transaction events, not by this event.
+
+### `action_added`
+
+Fires when exactly one proposal/direct-execute action is added to the action form.
+
+Required props:
+
+| Prop | Notes |
+| --- | --- |
+| `source` | Currently `form`. |
+| `actionCategory` | Low-cardinality action bucket. |
+| `count` | Omitted for single-action adds. |
+
+Known `actionCategory` values:
+
+| Value | Rule |
+| --- | --- |
+| `native_withdraw` | Action type contains `withdraw`. |
+| `native_metadata_update` | Action type contains `metadata`. |
+| `external_contract_call` | Action type contains `external`. |
+| `unknown_native` | Fallback for unrecognized single/native actions. |
+| `mixed` | Batch-only category when added actions span categories. |
+
+### `action_added_batch`
+
+Fires when multiple proposal/direct-execute actions are added in one operation.
+
+Required props:
+
+| Prop | Notes |
+| --- | --- |
+| `source` | Currently `form`. |
+| `actionCategory` | Shared category if all added actions match one; otherwise `mixed`. |
+| `count` | Number of actions added. |
+
+### `transaction_start`
+
+Fires when a transaction send attempt starts.
+
+Required props:
+
+| Prop | Notes |
+| --- | --- |
+| `flow` | Product flow. |
+| `transactionKind` | Low-cardinality transaction purpose. |
+| `network` | Transaction network. |
+| `chainId` | Required chain ID. |
+| `attemptKind` | `new` or `resume`. |
+
+Optional props:
+
+| Prop | Notes |
+| --- | --- |
+| `transactionType` | Present when backend transaction status/indexing is used. |
+| `actionCount` | Present for direct execute-actions. |
+
+DAO publish/create attempt is `transaction_start` with `flow: 'create_dao'` and `transactionKind: 'dao_create'`.
+
+### `transaction_stage`
+
+Fires for intermediate transaction lifecycle milestones.
+
+Required props:
+
+| Prop | Notes |
+| --- | --- |
+| `flow` | Product flow. |
+| `transactionKind` | Low-cardinality transaction purpose. |
+| `network` | Transaction network. |
+| `chainId` | Required chain ID. |
+| `status` | Currently `submitted` or `confirmed`. |
+
+### `transaction_end`
+
+Fires when a transaction reaches a terminal success milestone.
+
+Required props:
+
+| Prop | Notes |
+| --- | --- |
+| `flow` | Product flow. |
+| `transactionKind` | Low-cardinality transaction purpose. |
+| `network` | Transaction network. |
+| `chainId` | Required chain ID. |
+| `status` | `confirmed` or `indexed`. |
+
+DAO creation success is `transaction_end` with `flow: 'create_dao'`, `transactionKind: 'dao_create'`, and a success `status`.
+
+### `transaction_failed`
+
+Fires once per transaction dialog lifecycle when a transaction flow fails.
+
+Required props:
+
+| Prop | Notes |
+| --- | --- |
+| `flow` | Product flow. |
+| `transactionKind` | Low-cardinality transaction purpose. |
+| `network` | Transaction network. |
+| `chainId` | Required chain ID. |
+| `errorClass` | Error class name only, or `unknown`. |
+
+Optional props:
+
+| Prop | Notes |
+| --- | --- |
+| `step` | Step where failure happened, e.g. `PREPARE`, `APPROVE`, `CONFIRM`, `INDEXING`. |
+
+Never send raw error messages, stacks, revert reasons, provider payloads, calldata, addresses, hashes, or proposal metadata.
+
+## Adding a new event
+
+1. Extend `PlausibleAnalyticsEventName` in `plausibleAnalyticsUtils.ts` when a new top-level event name is needed.
+2. Emit from the lifecycle point that matches the event name. Do not emit a business-outcome event from an earlier click handler.
+3. Keep props low-cardinality. Use booleans for presence/absence (`hasEns`, `hasAvatar`, `hasActions`) and buckets for broad categories.
+4. Add tests at the owner component/hook boundary and at the utility boundary if the normalization contract changes.
+5. Register the exact custom-event Goal in each Plausible site that should report it.
+

--- a/apps/app/src/modules/createDao/dialogs/publishDaoDialog/publishDaoDialog.tsx
+++ b/apps/app/src/modules/createDao/dialogs/publishDaoDialog/publishDaoDialog.tsx
@@ -170,6 +170,10 @@ export const PublishDaoDialog: React.FC<IPublishDaoDialogProps> = (props) => {
 
     return (
         <TransactionDialog<PublishDaoStep>
+            analytics={{
+                flow: 'create_dao',
+                transactionKind: 'dao_create',
+            }}
             customSteps={customSteps}
             description={t('app.createDao.publishDaoDialog.description')}
             network={network}

--- a/apps/app/src/modules/createDao/pages/createDaoPage/createDaoPageClient.test.tsx
+++ b/apps/app/src/modules/createDao/pages/createDaoPage/createDaoPageClient.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import * as connectedWalletGuard from '@/modules/application/hooks/useConnectedWalletGuard';
+import { Network } from '@/shared/api/daoService';
+import * as DialogProvider from '@/shared/components/dialogProvider';
+import { generateDialogContext } from '@/shared/testUtils';
+import { analyticsUtils } from '@/shared/utils/analyticsUtils';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
+import { CreateDaoDialogId } from '../../constants/createDaoDialogId';
+import { CreateDaoPageClient } from './createDaoPageClient';
+
+const daoFormValues = {
+    name: 'Test DAO',
+    description: 'Description',
+    ens: 'test-dao',
+    network: Network.ETHEREUM_SEPOLIA,
+    resources: [],
+    avatar: { file: new File(['avatar'], 'avatar.png') },
+};
+
+jest.mock('@/shared/components/wizards/wizardPage', () => {
+    const { plausibleAnalyticsUtils } = jest.requireActual(
+        '@/shared/utils/plausibleAnalyticsUtils',
+    );
+
+    return {
+        WizardPage: {
+            Container: ({
+                analytics,
+                children,
+                onSubmit,
+            }: {
+                analytics?: {
+                    flow: string;
+                    props?: Record<string, string | number | boolean>;
+                };
+                children: React.ReactNode;
+                onSubmit: (values: typeof daoFormValues) => void;
+            }) => {
+                if (analytics != null) {
+                    plausibleAnalyticsUtils.track('wizard_start', {
+                        ...analytics.props,
+                        flow: analytics.flow,
+                    });
+                }
+
+                return (
+                    <form
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            onSubmit(daoFormValues);
+                        }}
+                    >
+                        {children}
+                        <button data-testid="submit" type="submit" />
+                    </form>
+                );
+            },
+            Step: ({ children }: { children: React.ReactNode }) => (
+                <div>{children}</div>
+            ),
+        },
+    };
+});
+
+jest.mock('../../components/createDaoForm', () => ({
+    CreateDaoForm: {
+        Debug: () => null,
+        Metadata: () => null,
+        Network: () => null,
+    },
+}));
+
+describe('<CreateDaoPageClient /> component', () => {
+    const useDialogContextSpy = jest.spyOn(DialogProvider, 'useDialogContext');
+    const useConnectedWalletGuardSpy = jest.spyOn(
+        connectedWalletGuard,
+        'useConnectedWalletGuard',
+    );
+    const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');
+    const trackEventSpy = jest.spyOn(analyticsUtils, 'trackEvent');
+
+    beforeEach(() => {
+        useDialogContextSpy.mockReturnValue(generateDialogContext());
+        useConnectedWalletGuardSpy.mockReturnValue({
+            check: (params) => params?.onSuccess?.(),
+            result: true,
+        });
+        trackAnalyticsSpy.mockImplementation(() => undefined);
+        trackEventSpy.mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        useDialogContextSpy.mockReset();
+        useConnectedWalletGuardSpy.mockReset();
+        trackAnalyticsSpy.mockReset();
+        trackEventSpy.mockReset();
+    });
+
+    it('tracks create-DAO wizard start once on render', async () => {
+        render(<CreateDaoPageClient />);
+
+        await waitFor(() =>
+            expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_start', {
+                flow: 'create_dao',
+            }),
+        );
+    });
+
+    it('tracks create-DAO wizard submit when the wallet guard opens the publish dialog', async () => {
+        const open = jest.fn();
+        useDialogContextSpy.mockReturnValue(generateDialogContext({ open }));
+
+        render(<CreateDaoPageClient />);
+        await userEvent.click(screen.getByTestId('submit'));
+
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_submit', {
+            flow: 'create_dao',
+            network: daoFormValues.network,
+            hasEns: true,
+            hasAvatar: true,
+        });
+        expect(trackEventSpy).not.toHaveBeenCalled();
+        expect(open).toHaveBeenCalledWith(CreateDaoDialogId.PUBLISH_DAO, {
+            params: { values: daoFormValues },
+        });
+    });
+});

--- a/apps/app/src/modules/createDao/pages/createDaoPage/createDaoPageClient.tsx
+++ b/apps/app/src/modules/createDao/pages/createDaoPage/createDaoPageClient.tsx
@@ -6,7 +6,7 @@ import { useDialogContext } from '@/shared/components/dialogProvider';
 import { Page } from '@/shared/components/page';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { WizardPage } from '@/shared/components/wizards/wizardPage';
-import { analyticsUtils } from '@/shared/utils/analyticsUtils';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import {
     CreateDaoForm,
     type ICreateDaoFormData,
@@ -27,13 +27,17 @@ export const CreateDaoPageClient: React.FC<ICreateDaoPageClientProps> = () => {
     const { check: checkWalletConnection } = useConnectedWalletGuard();
 
     const handleFormSubmit = (values: ICreateDaoFormData) => {
-        analyticsUtils.trackEvent('Publish DAO Click', {
-            network: values.network,
-        });
-
         const params: IPublishDaoDialogParams = { values };
         checkWalletConnection({
-            onSuccess: () => open(CreateDaoDialogId.PUBLISH_DAO, { params }),
+            onSuccess: () => {
+                plausibleAnalyticsUtils.track('wizard_submit', {
+                    flow: 'create_dao',
+                    network: values.network,
+                    hasEns: values.ens !== '',
+                    hasAvatar: values.avatar != null,
+                });
+                open(CreateDaoDialogId.PUBLISH_DAO, { params });
+            },
         });
     };
 
@@ -51,6 +55,7 @@ export const CreateDaoPageClient: React.FC<ICreateDaoPageClientProps> = () => {
     return (
         <Page.Main fullWidth={true}>
             <WizardPage.Container
+                analytics={{ flow: 'create_dao' }}
                 finalStep={t('app.createDao.createDaoPage.finalStep')}
                 initialSteps={processedSteps}
                 onSubmit={handleFormSubmit}

--- a/apps/app/src/modules/createDao/pages/createProcessPage/createProcessPageClient.test.tsx
+++ b/apps/app/src/modules/createDao/pages/createProcessPage/createProcessPageClient.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import * as proposalPermissionGuard from '@/modules/governance/hooks/useProposalPermissionCheckGuard';
+import * as DialogProvider from '@/shared/components/dialogProvider';
+import { generateDialogContext } from '@/shared/testUtils';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
+import {
+    GovernanceType,
+    ProcessPermission,
+    ProposalCreationMode,
+} from '../../components/createProcessForm';
+import { CreateDaoDialogId } from '../../constants/createDaoDialogId';
+import { CreateProcessPageClient } from './createProcessPageClient';
+
+const processFormValues = {
+    name: 'Governance',
+    processKey: 'GOV',
+    description: 'Description',
+    resources: [],
+    proposalCreationMode: ProposalCreationMode.ANY_WALLET,
+    governanceType: GovernanceType.ADVANCED,
+    permissions: ProcessPermission.ANY,
+    permissionSelectors: [],
+    stages: [
+        { internalId: 'stage-1', name: 'Stage 1', bodies: [], settings: {} },
+    ],
+    existingProposalCreationConditions: [],
+};
+
+jest.mock('@/shared/components/wizards/wizardPage', () => {
+    const { plausibleAnalyticsUtils } = jest.requireActual(
+        '@/shared/utils/plausibleAnalyticsUtils',
+    );
+
+    return {
+        WizardPage: {
+            Container: ({
+                analytics,
+                children,
+                onSubmit,
+            }: {
+                analytics?: {
+                    flow: string;
+                    props?: Record<string, string | number | boolean>;
+                };
+                children: React.ReactNode;
+                onSubmit: (values: typeof processFormValues) => void;
+            }) => {
+                if (analytics != null) {
+                    plausibleAnalyticsUtils.track('wizard_start', {
+                        ...analytics.props,
+                        flow: analytics.flow,
+                    });
+                }
+
+                return (
+                    <form
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            onSubmit(processFormValues);
+                        }}
+                    >
+                        {children}
+                        <button data-testid="submit" type="submit" />
+                    </form>
+                );
+            },
+            Step: ({ children }: { children: React.ReactNode }) => (
+                <div>{children}</div>
+            ),
+        },
+    };
+});
+
+jest.mock('./createProcessPageSteps', () => ({
+    CreateProcessPageClientSteps: () => null,
+}));
+
+describe('<CreateProcessPageClient /> component', () => {
+    const useDialogContextSpy = jest.spyOn(DialogProvider, 'useDialogContext');
+    const useProposalPermissionCheckGuardSpy = jest.spyOn(
+        proposalPermissionGuard,
+        'useProposalPermissionCheckGuard',
+    );
+    const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');
+
+    beforeEach(() => {
+        useDialogContextSpy.mockReturnValue(generateDialogContext());
+        useProposalPermissionCheckGuardSpy.mockImplementation(() => undefined);
+        trackAnalyticsSpy.mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        useDialogContextSpy.mockReset();
+        useProposalPermissionCheckGuardSpy.mockReset();
+        trackAnalyticsSpy.mockReset();
+    });
+
+    const renderPage = () =>
+        render(
+            <CreateProcessPageClient daoId="dao-id" pluginAddress="0xPlugin" />,
+        );
+
+    it('tracks governance-designer wizard start on render', async () => {
+        renderPage();
+
+        await waitFor(() =>
+            expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_start', {
+                flow: 'governance_designer',
+            }),
+        );
+    });
+
+    it('tracks governance-designer wizard submit with flow-specific props', async () => {
+        const open = jest.fn();
+        useDialogContextSpy.mockReturnValue(generateDialogContext({ open }));
+
+        renderPage();
+        await userEvent.click(screen.getByTestId('submit'));
+
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_submit', {
+            flow: 'governance_designer',
+            setupMode: 'advanced',
+            stageCount: 1,
+        });
+        expect(open).toHaveBeenCalledWith(CreateDaoDialogId.PREPARE_PROCESS, {
+            params: {
+                daoId: 'dao-id',
+                pluginAddress: '0xPlugin',
+                values: processFormValues,
+            },
+        });
+    });
+});

--- a/apps/app/src/modules/createDao/pages/createProcessPage/createProcessPageClient.tsx
+++ b/apps/app/src/modules/createDao/pages/createProcessPage/createProcessPageClient.tsx
@@ -6,7 +6,11 @@ import { useDialogContext } from '@/shared/components/dialogProvider';
 import { Page } from '@/shared/components/page';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { WizardPage } from '@/shared/components/wizards/wizardPage';
-import type { ICreateProcessFormData } from '../../components/createProcessForm';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
+import {
+    GovernanceType,
+    type ICreateProcessFormData,
+} from '../../components/createProcessForm';
 import { CreateDaoDialogId } from '../../constants/createDaoDialogId';
 import type { IPrepareProcessDialogParams } from '../../dialogs/prepareProcessDialog';
 import { createProcessWizardSteps } from './createProcessPageDefinitions';
@@ -43,6 +47,17 @@ export const CreateProcessPageClient: React.FC<
             values,
             pluginAddress,
         };
+        plausibleAnalyticsUtils.track('wizard_submit', {
+            flow: 'governance_designer',
+            setupMode:
+                values.governanceType === GovernanceType.ADVANCED
+                    ? 'advanced'
+                    : 'basic',
+            stageCount:
+                values.governanceType === GovernanceType.ADVANCED
+                    ? values.stages.length
+                    : undefined,
+        });
         open(CreateDaoDialogId.PREPARE_PROCESS, { params: dialogParams });
     };
 
@@ -58,6 +73,7 @@ export const CreateProcessPageClient: React.FC<
     return (
         <Page.Main fullWidth={true}>
             <WizardPage.Container
+                analytics={{ flow: 'governance_designer' }}
                 defaultValues={{
                     stages: [],
                     existingProposalCreationConditions: [],

--- a/apps/app/src/modules/explore/pages/exploreDaosPage/exploreDaosPageClient.test.tsx
+++ b/apps/app/src/modules/explore/pages/exploreDaosPage/exploreDaosPageClient.test.tsx
@@ -1,6 +1,8 @@
 import { GukModulesProvider } from '@aragon/gov-ui-kit';
 import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import * as Wagmi from 'wagmi';
+import { CreateDaoDialogId } from '@/modules/createDao/constants/createDaoDialogId';
 import * as CmsService from '@/shared/api/cmsService';
 import { Network } from '@/shared/api/daoService';
 import * as useDialogContext from '@/shared/components/dialogProvider';
@@ -8,6 +10,7 @@ import {
     generateDialogContext,
     generateReactQueryInfiniteResultSuccess,
 } from '@/shared/testUtils';
+import { analyticsUtils } from '@/shared/utils/analyticsUtils';
 import {
     ExploreDaosPageClient,
     type IExploreDaosPageClientProps,
@@ -28,6 +31,7 @@ describe('<ExploreDaosPageClient /> component', () => {
         'useDialogContext',
     );
     const useFeaturedDaosSpy = jest.spyOn(CmsService, 'useFeaturedDaos');
+    const trackEventSpy = jest.spyOn(analyticsUtils, 'trackEvent');
 
     beforeEach(() => {
         useConnectionSpy.mockReturnValue({} as Wagmi.UseConnectionReturnType);
@@ -35,12 +39,14 @@ describe('<ExploreDaosPageClient /> component', () => {
         useFeaturedDaosSpy.mockReturnValue(
             generateReactQueryInfiniteResultSuccess({ data: [] }),
         );
+        trackEventSpy.mockImplementation(() => undefined);
     });
 
     afterEach(() => {
         useConnectionSpy.mockReset();
         useDialogContextSpy.mockReset();
         useFeaturedDaosSpy.mockReset();
+        trackEventSpy.mockReset();
     });
 
     const createTestComponent = (
@@ -63,5 +69,20 @@ describe('<ExploreDaosPageClient /> component', () => {
     it('renders the list of DAOs', () => {
         render(createTestComponent());
         expect(screen.getByTestId('dao-list-mock')).toBeInTheDocument();
+    });
+
+    it('opens the create DAO dialog without firing the seed click event', async () => {
+        const open = jest.fn();
+        useDialogContextSpy.mockReturnValue(generateDialogContext({ open }));
+
+        render(createTestComponent());
+        await userEvent.click(
+            screen.getByRole('button', {
+                name: 'app.explore.exploreDaosPage.noCodeSetup.actionLabel',
+            }),
+        );
+
+        expect(trackEventSpy).not.toHaveBeenCalled();
+        expect(open).toHaveBeenCalledWith(CreateDaoDialogId.CREATE_DAO_DETAILS);
     });
 });

--- a/apps/app/src/modules/explore/pages/exploreDaosPage/exploreDaosPageClient.tsx
+++ b/apps/app/src/modules/explore/pages/exploreDaosPage/exploreDaosPageClient.tsx
@@ -11,7 +11,6 @@ import { Container } from '@/shared/components/container';
 import { CtaCard } from '@/shared/components/ctaCard';
 import { useDialogContext } from '@/shared/components/dialogProvider';
 import { useTranslations } from '@/shared/components/translationsProvider';
-import { analyticsUtils } from '@/shared/utils/analyticsUtils';
 import NetBackground from '../../../../assets/images/net_bg.svg';
 import type { IGetDaoListParams } from '../../api/daoExplorerService';
 import { DaoCarouselCard } from '../../components/daoCarouselCard';
@@ -130,9 +129,6 @@ export const ExploreDaosPageClient: React.FC<IExploreDaosPageClientProps> = (
                                         'app.explore.exploreDaosPage.noCodeSetup.actionLabel',
                                     ),
                                     onClick: () => {
-                                        analyticsUtils.trackEvent(
-                                            'Create DAO Click',
-                                        );
                                         open(
                                             CreateDaoDialogId.CREATE_DAO_DETAILS,
                                         );

--- a/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.test.tsx
+++ b/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.test.tsx
@@ -12,6 +12,7 @@ import {
     generateDao,
     generateReactQueryResultSuccess,
 } from '@/shared/testUtils';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import { testLogger } from '@/test/utils';
 import { ExecuteActionsDialog } from './executeActionsDialog';
 import type {
@@ -37,6 +38,7 @@ describe('<ExecuteActionsDialog /> component', () => {
         BlockNavigation,
         'useBlockNavigationContext',
     );
+    const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');
 
     const network = Network.ETHEREUM_MAINNET;
 
@@ -58,6 +60,7 @@ describe('<ExecuteActionsDialog /> component', () => {
             isBlocked: false,
             setIsBlocked: jest.fn(),
         });
+        trackAnalyticsSpy.mockImplementation(() => undefined);
     });
 
     afterEach(() => {
@@ -66,6 +69,7 @@ describe('<ExecuteActionsDialog /> component', () => {
         useMutationSpy.mockReset();
         useDaoSpy.mockReset();
         useBlockNavigationContextSpy.mockReset();
+        trackAnalyticsSpy.mockReset();
     });
 
     const generateLocation = (
@@ -150,6 +154,21 @@ describe('<ExecuteActionsDialog /> component', () => {
             expect.objectContaining(transaction),
             expect.anything(),
         );
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_start', {
+            flow: 'direct_execute_actions',
+            transactionKind: 'admin_instant_execute',
+            network,
+            chainId: networkDefinitions[network].id,
+            actionCount: 0,
+        });
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_stage', {
+            flow: 'direct_execute_actions',
+            transactionKind: 'admin_instant_execute',
+            network,
+            chainId: networkDefinitions[network].id,
+            status: 'submitted',
+            actionCount: 0,
+        });
         expect(
             screen.getByRole('link', {
                 name: /executeActionsDialog.button.success/,
@@ -178,6 +197,15 @@ describe('<ExecuteActionsDialog /> component', () => {
                 name: /transactionDialog.footer.retry/,
             }),
         ).toBeInTheDocument();
+
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_failed', {
+            flow: 'direct_execute_actions',
+            transactionKind: 'admin_instant_execute',
+            network,
+            chainId: networkDefinitions[network].id,
+            status: 'send_error',
+            actionCount: 0,
+        });
     });
 
     it('pins the send to the required chain id of the DAO', () => {

--- a/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogFooter, IconType, invariant } from '@aragon/gov-ui-kit';
 import { useMutation } from '@tanstack/react-query';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { match } from 'ts-pattern';
 import { useSendTransaction } from 'wagmi';
 import { useWalletAccount } from '@/modules/application/hooks/useWalletAccount';
@@ -17,6 +17,7 @@ import {
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useNetworkSwitch } from '@/shared/hooks/useNetworkSwitch';
 import { daoUtils } from '@/shared/utils/daoUtils';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import type { IExecuteActionsDialogProps } from './executeActionsDialog.api';
 import { executeActionsDialogUtils } from './executeActionsDialogUtils';
 
@@ -82,6 +83,18 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
             ? switchChainStatus
             : 'idle';
 
+    const failureTrackedRef = useRef(false);
+    const analyticsProps = useMemo(
+        () => ({
+            flow: 'direct_execute_actions',
+            transactionKind: 'admin_instant_execute',
+            network,
+            chainId: requiredChainId,
+            actionCount: actions.length,
+        }),
+        [network, requiredChainId, actions.length],
+    );
+
     // Once the transaction is successfully submitted, unblock navigation so that clicking the
     // success link does not trigger the confirm-exit guard of the still-dirty wizard form behind
     // the dialog. The submitted state is optimistic, so re-block if the send later fails (e.g. the
@@ -93,6 +106,18 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
             setIsBlocked(false);
         }
     }, [sendFailed, submitState, setIsBlocked]);
+
+    useEffect(() => {
+        if (!sendFailed || failureTrackedRef.current) {
+            return;
+        }
+
+        failureTrackedRef.current = true;
+        plausibleAnalyticsUtils.track('transaction_failed', {
+            ...analyticsProps,
+            status: 'send_error',
+        });
+    }, [sendFailed, analyticsProps]);
 
     const monitorError = useCallback(
         (error: unknown) =>
@@ -146,11 +171,16 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
         withNetworkSwitch(() => {
             // Pin the send to the required chain so wagmi rejects (instead of silently signing) if
             // the wallet is still on the wrong chain after the switch.
+            plausibleAnalyticsUtils.track('transaction_start', analyticsProps);
             sendTransaction(
                 { ...transaction, chainId: requiredChainId },
                 { onError: monitorError },
             );
             setIsSubmitted(true);
+            plausibleAnalyticsUtils.track('transaction_stage', {
+                ...analyticsProps,
+                status: 'submitted',
+            });
         });
     }, [
         transaction,
@@ -158,6 +188,7 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
         sendTransaction,
         monitorError,
         withNetworkSwitch,
+        analyticsProps,
     ]);
 
     const isPreparing = prepareStatus === 'pending';

--- a/apps/app/src/modules/governance/dialogs/executeDialog/executeDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/executeDialog/executeDialog.tsx
@@ -87,6 +87,10 @@ export const ExecuteDialog: React.FC<IExecuteDialogProps> = (props) => {
 
     return (
         <TransactionDialog
+            analytics={{
+                flow: 'proposal_execution',
+                transactionKind: 'governance_proposal_execute',
+            }}
             description={t('app.governance.executeDialog.description')}
             indexingFallbackUrl={daoUtils.getDaoUrl(dao, `proposals/${slug}`)}
             network={network}

--- a/apps/app/src/modules/governance/dialogs/publishProposalDialog/publishProposalDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/publishProposalDialog/publishProposalDialog.tsx
@@ -184,6 +184,10 @@ export const PublishProposalDialog: React.FC<IPublishProposalDialogProps> = (
 
     return (
         <TransactionDialog<PublishProposalStep>
+            analytics={{
+                flow: 'create_proposal',
+                transactionKind: 'governance_proposal_create',
+            }}
             customSteps={customSteps}
             description={t(`${namespace}.description`)}
             indexingFallbackUrl={daoUtils.getDaoUrl(dao, 'proposals')}

--- a/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
@@ -104,6 +104,10 @@ export const VoteDialog: React.FC<IVoteDialogProps> = (props) => {
 
     return (
         <TransactionDialog
+            analytics={{
+                flow: 'proposal_vote',
+                transactionKind: 'governance_proposal_vote',
+            }}
             description={t('app.governance.voteDialog.description')}
             indexingFallbackUrl={
                 slug != null

--- a/apps/app/src/modules/governance/hooks/useProposalActionsField/useProposalActionsField.test.ts
+++ b/apps/app/src/modules/governance/hooks/useProposalActionsField/useProposalActionsField.test.ts
@@ -1,9 +1,20 @@
 import { act, renderHook } from '@testing-library/react';
 import { FormWrapper } from '@/shared/testUtils';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import type { IProposalActionData } from '../../components/createProposalForm';
 import { useProposalActionsField } from './useProposalActionsField';
 
 describe('useProposalActionsField hook', () => {
+    const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');
+
+    beforeEach(() => {
+        trackAnalyticsSpy.mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        trackAnalyticsSpy.mockReset();
+    });
+
     const generateAction = (
         action?: Partial<IProposalActionData>,
     ): IProposalActionData =>
@@ -35,8 +46,29 @@ describe('useProposalActionsField hook', () => {
         });
 
         expect(result.current.actionsMerged).toHaveLength(2);
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('action_added_batch', {
+            source: 'form',
+            count: 2,
+            actionCategory: 'unknown_native',
+        });
     });
 
+    it('tracks a single native withdrawal action', () => {
+        const { result } = renderHook(() => useProposalActionsField(), {
+            wrapper: FormWrapper,
+        });
+
+        act(() => {
+            result.current.handleAddAction([
+                generateAction({ type: 'withdraw' }),
+            ]);
+        });
+
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('action_added', {
+            source: 'form',
+            actionCategory: 'native_withdraw',
+        });
+    });
     it('removes all actions', () => {
         const { result } = renderHook(() => useProposalActionsField(), {
             wrapper: FormWrapper,

--- a/apps/app/src/modules/governance/hooks/useProposalActionsField/useProposalActionsField.ts
+++ b/apps/app/src/modules/governance/hooks/useProposalActionsField/useProposalActionsField.ts
@@ -2,6 +2,7 @@ import type { IProposalActionsArrayControls } from '@aragon/gov-ui-kit';
 import { useCallback } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import type {
     ICreateProposalFormData,
     IProposalActionData,
@@ -13,6 +14,32 @@ import type {
  * keeps rendered data in sync with view edits, and the add/remove/reorder
  * handlers. Must be called within a form context holding an `actions` array.
  */
+const resolveActionCategory = (action: IProposalActionData) => {
+    const actionType = action.type.toLowerCase();
+
+    if (actionType.includes('withdraw')) {
+        return 'native_withdraw';
+    }
+
+    if (actionType.includes('uninstall')) {
+        return 'native_uninstall_plugin';
+    }
+
+    if (actionType.includes('install')) {
+        return 'native_install_plugin';
+    }
+
+    if (actionType.includes('metadata')) {
+        return 'native_metadata_update';
+    }
+
+    if (actionType.includes('external')) {
+        return 'external_contract_call';
+    }
+
+    return 'unknown_native';
+};
+
 export const useProposalActionsField = () => {
     const { t } = useTranslations();
 
@@ -84,6 +111,17 @@ export const useProposalActionsField = () => {
             ...action,
             fieldId: action.fieldId ?? crypto.randomUUID(),
         }));
+        const actionCategories = new Set(newActions.map(resolveActionCategory));
+        const actionCategory =
+            actionCategories.size === 1 ? [...actionCategories][0] : 'mixed';
+        plausibleAnalyticsUtils.track(
+            newActions.length === 1 ? 'action_added' : 'action_added_batch',
+            {
+                source: 'form',
+                actionCategory,
+                count: newActions.length === 1 ? undefined : newActions.length,
+            },
+        );
         append(actionsWithId);
     };
 

--- a/apps/app/src/modules/governance/pages/createExecuteActionsPage/createExecuteActionsPageClient.test.tsx
+++ b/apps/app/src/modules/governance/pages/createExecuteActionsPage/createExecuteActionsPageClient.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import * as executePermissionGuard from '@/modules/governance/hooks/useExecutePermissionCheckGuard';
+import * as DialogProvider from '@/shared/components/dialogProvider';
+import { generateDialogContext } from '@/shared/testUtils';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
+import { GovernanceDialogId } from '../../constants/governanceDialogId';
+import { CreateExecuteActionsPageClient } from './createExecuteActionsPageClient';
+
+const executeFormValues = {
+    actions: [
+        {
+            type: 'withdraw',
+            from: '0x0',
+            to: '0x1',
+            data: '0x',
+            value: '0',
+        },
+    ],
+};
+
+jest.mock('@/shared/components/wizards/wizardPage', () => {
+    const { plausibleAnalyticsUtils } = jest.requireActual(
+        '@/shared/utils/plausibleAnalyticsUtils',
+    );
+
+    return {
+        WizardPage: {
+            Container: ({
+                analytics,
+                children,
+                onSubmit,
+            }: {
+                analytics?: {
+                    flow: string;
+                    props?: Record<string, string | number | boolean>;
+                };
+                children: React.ReactNode;
+                onSubmit: (values: typeof executeFormValues) => void;
+            }) => {
+                if (analytics != null) {
+                    plausibleAnalyticsUtils.track('wizard_start', {
+                        ...analytics.props,
+                        flow: analytics.flow,
+                    });
+                }
+
+                return (
+                    <form
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            onSubmit(executeFormValues);
+                        }}
+                    >
+                        {children}
+                        <button data-testid="submit" type="submit" />
+                    </form>
+                );
+            },
+            Step: ({ children }: { children: React.ReactNode }) => (
+                <div>{children}</div>
+            ),
+        },
+    };
+});
+
+jest.mock('./createExecuteActionsPageClientSteps', () => ({
+    CreateExecuteActionsPageClientSteps: () => null,
+}));
+
+describe('<CreateExecuteActionsPageClient /> component', () => {
+    const useDialogContextSpy = jest.spyOn(DialogProvider, 'useDialogContext');
+    const useExecutePermissionCheckGuardSpy = jest.spyOn(
+        executePermissionGuard,
+        'useExecutePermissionCheckGuard',
+    );
+    const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');
+
+    beforeEach(() => {
+        useDialogContextSpy.mockReturnValue(generateDialogContext());
+        useExecutePermissionCheckGuardSpy.mockImplementation(() => undefined);
+        trackAnalyticsSpy.mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        useDialogContextSpy.mockReset();
+        useExecutePermissionCheckGuardSpy.mockReset();
+        trackAnalyticsSpy.mockReset();
+    });
+
+    it('tracks direct-execute wizard start on render', async () => {
+        render(<CreateExecuteActionsPageClient daoId="dao-id" />);
+
+        await waitFor(() =>
+            expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_start', {
+                flow: 'direct_execute_actions',
+            }),
+        );
+    });
+
+    it('tracks direct-execute wizard submit with action count', async () => {
+        const open = jest.fn();
+        useDialogContextSpy.mockReturnValue(generateDialogContext({ open }));
+
+        render(<CreateExecuteActionsPageClient daoId="dao-id" />);
+        await userEvent.click(screen.getByTestId('submit'));
+
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_submit', {
+            flow: 'direct_execute_actions',
+            actionCount: executeFormValues.actions.length,
+        });
+        expect(open).toHaveBeenCalledWith(GovernanceDialogId.EXECUTE_ACTIONS, {
+            params: {
+                daoId: 'dao-id',
+                actions: executeFormValues.actions,
+                prepareActions: {},
+            },
+        });
+    });
+});

--- a/apps/app/src/modules/governance/pages/createExecuteActionsPage/createExecuteActionsPageClient.tsx
+++ b/apps/app/src/modules/governance/pages/createExecuteActionsPage/createExecuteActionsPageClient.tsx
@@ -5,6 +5,7 @@ import { useDialogContext } from '@/shared/components/dialogProvider';
 import { Page } from '@/shared/components/page';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { WizardPage } from '@/shared/components/wizards/wizardPage';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import type { IExecuteActionsFormData } from '../../components/createExecuteActionsForm';
 import { CreateExecuteActionsForm } from '../../components/createExecuteActionsForm';
 import { GovernanceDialogId } from '../../constants/governanceDialogId';
@@ -60,6 +61,10 @@ export const CreateExecuteActionsPageClient: React.FC<
             actions: values.actions,
             prepareActions,
         };
+        plausibleAnalyticsUtils.track('wizard_submit', {
+            flow: 'direct_execute_actions',
+            actionCount: values.actions.length,
+        });
         open(GovernanceDialogId.EXECUTE_ACTIONS, { params });
     };
 
@@ -75,6 +80,7 @@ export const CreateExecuteActionsPageClient: React.FC<
     return (
         <Page.Main fullWidth={true}>
             <WizardPage.Container
+                analytics={{ flow: 'direct_execute_actions' }}
                 defaultValues={{ actions: [] }}
                 id={createExecuteActionsWizardId}
                 initialSteps={processedSteps}

--- a/apps/app/src/modules/governance/pages/createProposalPage/createProposalPageClient.test.tsx
+++ b/apps/app/src/modules/governance/pages/createProposalPage/createProposalPageClient.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import * as usePermissionCheckGuard from '@/modules/governance/hooks/usePermissionCheckGuard';
 import * as daoService from '@/shared/api/daoService';
@@ -16,6 +16,7 @@ import {
     PendingTransactionStatus,
     pendingTransactionManager,
 } from '@/shared/utils/pendingTransactionManager';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import { GovernanceDialogId } from '../../constants/governanceDialogId';
 import { proposalResumeRegistry } from '../../utils/proposalResumeRegistry';
 import {
@@ -44,11 +45,13 @@ describe('<CreateProposalPageClient /> component', () => {
     const getActiveSpy = jest.spyOn(pendingTransactionManager, 'getActive');
     const clearActiveSpy = jest.spyOn(pendingTransactionManager, 'clearActive');
     const resumeRegistryGetSpy = jest.spyOn(proposalResumeRegistry, 'get');
+    const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');
 
     beforeEach(() => {
         getActiveSpy.mockReturnValue([]);
         clearActiveSpy.mockImplementation(() => undefined);
         resumeRegistryGetSpy.mockReturnValue(undefined);
+        trackAnalyticsSpy.mockImplementation(() => undefined);
         useDialogContextSpy.mockReturnValue(generateDialogContext());
         usePermissionCheckGuardSpy.mockReturnValue({
             check: jest.fn(),
@@ -68,6 +71,7 @@ describe('<CreateProposalPageClient /> component', () => {
         getActiveSpy.mockReset();
         clearActiveSpy.mockReset();
         resumeRegistryGetSpy.mockReset();
+        trackAnalyticsSpy.mockReset();
     });
 
     const createTestComponent = (
@@ -91,6 +95,27 @@ describe('<CreateProposalPageClient /> component', () => {
             screen.getByText(/wizardPage.container.total \(total=3\)/),
         ).toBeInTheDocument();
         expect(screen.getByTestId('steps-mock')).toBeInTheDocument();
+    });
+
+    it('tracks create-proposal wizard start once on render', async () => {
+        const daoId = 'test-id';
+        const pluginAddress = '0x472839';
+        const plugins = [
+            generateFilterComponentPlugin({
+                id: 'multisig',
+                meta: generateDaoPlugin({ address: pluginAddress }),
+            }),
+        ];
+        useDaoPluginsSpy.mockReturnValue(plugins);
+
+        render(createTestComponent({ daoId, pluginAddress }));
+
+        await waitFor(() =>
+            expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_start', {
+                flow: 'create_proposal',
+                pluginInterfaceType: plugins[0].meta.interfaceType,
+            }),
+        );
     });
 
     it('opens the publish proposal dialog on form submit', async () => {
@@ -118,6 +143,12 @@ describe('<CreateProposalPageClient /> component', () => {
         };
         expect(open).toHaveBeenCalledWith(GovernanceDialogId.PUBLISH_PROPOSAL, {
             params: expectedParams,
+        });
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_submit', {
+            flow: 'create_proposal',
+            actionCount: 0,
+            hasActions: false,
+            pluginInterfaceType: plugins[0].meta.interfaceType,
         });
     });
 
@@ -159,6 +190,10 @@ describe('<CreateProposalPageClient /> component', () => {
             GovernanceDialogId.PUBLISH_PROPOSAL,
             expect.anything(),
         );
+        expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+            'wizard_submit',
+            expect.anything(),
+        );
 
         const warnParams = open.mock.calls.find(
             ([id]) => id === GovernanceDialogId.DUPLICATE_PROPOSAL_WARNING,
@@ -173,6 +208,12 @@ describe('<CreateProposalPageClient /> component', () => {
             GovernanceDialogId.PUBLISH_PROPOSAL,
             expect.anything(),
         );
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_submit', {
+            flow: 'create_proposal',
+            actionCount: 0,
+            hasActions: false,
+            pluginInterfaceType: expect.any(String),
+        });
 
         // "Resume existing transaction" reopens the conflicting proposal's dialog with its params.
         warnParams.onResume();

--- a/apps/app/src/modules/governance/pages/createProposalPage/createProposalPageClient.tsx
+++ b/apps/app/src/modules/governance/pages/createProposalPage/createProposalPageClient.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from '@/shared/components/translationsProvider';
 import { WizardPage } from '@/shared/components/wizards/wizardPage';
 import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
 import { pendingTransactionManager } from '@/shared/utils/pendingTransactionManager';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import {
     CreateProposalForm,
     type ICreateProposalFormData,
@@ -106,11 +107,22 @@ export const CreateProposalPageClient: React.FC<
             excludeIntentId: intentId,
         };
 
+        const trackWizardSubmit = () => {
+            const actionCount = proposal.actions.length;
+            plausibleAnalyticsUtils.track('wizard_submit', {
+                flow: 'create_proposal',
+                actionCount,
+                hasActions: actionCount > 0,
+                pluginInterfaceType: plugin.interfaceType,
+            });
+        };
+
         const openPublishDialog = () => {
             // "New transaction" / no conflict: the user has committed to this proposal, so supersede any
             // other in-flight creation for this DAO + plugin that would otherwise keep warning forever.
             pendingTransactionManager.clearActive(conflictFilter);
             proposalResumeRegistry.set(intentId, params);
+            trackWizardSubmit();
             open(GovernanceDialogId.PUBLISH_PROPOSAL, { params });
         };
 
@@ -151,6 +163,10 @@ export const CreateProposalPageClient: React.FC<
     return (
         <Page.Main fullWidth={true}>
             <WizardPage.Container
+                analytics={{
+                    flow: 'create_proposal',
+                    props: { pluginInterfaceType: plugin.interfaceType },
+                }}
                 defaultValues={{ actions: [] }}
                 finalStep={t('app.governance.createProposalPage.finalStep')}
                 id={createProposalWizardId}

--- a/apps/app/src/shared/components/transactionDialog/transactionDialog.api.ts
+++ b/apps/app/src/shared/components/transactionDialog/transactionDialog.api.ts
@@ -70,6 +70,17 @@ export interface ITransactionDialogSuccessLink {
     onClick?: (receipt: TransactionReceipt) => void;
 }
 
+export interface ITransactionDialogAnalytics {
+    /**
+     * Product flow that opened this transaction dialog.
+     */
+    flow?: string;
+    /**
+     * Low-cardinality transaction kind within the product flow.
+     */
+    transactionKind?: string;
+}
+
 export interface ITransactionDialogProps<
     TCustomStepId extends string = string,
 > {
@@ -157,6 +168,10 @@ export interface ITransactionDialogProps<
      * Fallback URL shown when the indexing step takes too long.
      */
     indexingFallbackUrl?: string;
+    /**
+     * Low-cardinality analytics metadata for transaction lifecycle events.
+     */
+    analytics?: ITransactionDialogAnalytics;
     /**
      * When true, the cancel button in the dialog footer is permanently disabled.
      */

--- a/apps/app/src/shared/components/transactionDialog/transactionDialog.test.tsx
+++ b/apps/app/src/shared/components/transactionDialog/transactionDialog.test.tsx
@@ -22,6 +22,7 @@ import {
     PendingTransactionStatus,
     pendingTransactionManager,
 } from '@/shared/utils/pendingTransactionManager';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import type { IStepperStep } from '@/shared/utils/stepperUtils';
 import { TransactionDialog } from './transactionDialog';
 import {
@@ -65,6 +66,7 @@ describe('<TransactionDialog /> component', () => {
     const managerSendSpy = jest.spyOn(pendingTransactionManager, 'send');
     const managerClearSpy = jest.spyOn(pendingTransactionManager, 'clear');
     const managerGetSpy = jest.spyOn(pendingTransactionManager, 'get');
+    const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');
 
     beforeEach(() => {
         useSendTransactionSpy.mockReturnValue(
@@ -84,6 +86,7 @@ describe('<TransactionDialog /> component', () => {
         managerSendSpy.mockImplementation(() => undefined);
         managerClearSpy.mockImplementation(() => undefined);
         managerGetSpy.mockReturnValue(undefined);
+        trackAnalyticsSpy.mockImplementation(() => undefined);
     });
 
     afterEach(() => {
@@ -97,6 +100,7 @@ describe('<TransactionDialog /> component', () => {
         managerSendSpy.mockReset();
         managerClearSpy.mockReset();
         managerGetSpy.mockReset();
+        trackAnalyticsSpy.mockReset();
     });
 
     const createTestComponent = (props?: Partial<ITransactionDialogProps>) => {
@@ -217,6 +221,52 @@ describe('<TransactionDialog /> component', () => {
                 onError: expect.any(Function) as unknown,
             }),
         );
+    });
+
+    it('keeps the automatic step action scheduled when analytics props are recreated', () => {
+        jest.useFakeTimers();
+
+        const stepAction = jest.fn();
+        const steps = [
+            {
+                id: TransactionDialogStep.PREPARE,
+                meta: {
+                    label: 'prepare',
+                    action: stepAction,
+                    auto: true,
+                    state: 'idle',
+                },
+            },
+        ] as unknown as IStepperStep<ITransactionDialogStepMeta>[];
+        const stepper = generateStepperResult({
+            steps,
+            activeStep: TransactionDialogStep.PREPARE,
+            activeStepIndex: 0,
+        });
+
+        try {
+            const { rerender } = render(
+                createTestComponent({
+                    analytics: { flow: 'create_dao' },
+                    stepper,
+                }),
+            );
+
+            act(() => jest.advanceTimersByTime(50));
+            rerender(
+                createTestComponent({
+                    analytics: { flow: 'create_dao' },
+                    stepper,
+                }),
+            );
+            act(() => jest.advanceTimersByTime(50));
+
+            expect(stepAction).toHaveBeenCalledWith({
+                onError: expect.any(Function) as unknown,
+            });
+        } finally {
+            jest.useRealTimers();
+        }
     });
 
     it('does not trigger the step action when its auto property is set to false', async () => {
@@ -361,6 +411,85 @@ describe('<TransactionDialog /> component', () => {
             expect.objectContaining(transaction),
             undefined,
         );
+    });
+
+    it('tracks a transaction start when the approve step sends the request', () => {
+        const transaction = { from: '0x123', data: '0x000' };
+        const network = Network.POLYGON_MAINNET;
+        useConnectionSpy.mockReturnValue({
+            chainId: networkDefinitions[network].id,
+        } as unknown as Wagmi.UseConnectionReturnType);
+        useMutationSpy.mockReturnValue({
+            data: transaction,
+        } as unknown as ReactQuery.UseMutationResult);
+        const updateSteps = jest.fn() as jest.Mock<
+            void,
+            IStepperStep<ITransactionDialogStepMeta>[][]
+        >;
+        const stepper = generateStepperResult<
+            ITransactionDialogStepMeta,
+            string
+        >({ updateSteps });
+
+        render(
+            createTestComponent({
+                analytics: {
+                    flow: 'create_proposal',
+                    transactionKind: 'governance_proposal_create',
+                },
+                stepper,
+                network,
+                transactionType: TransactionType.PROPOSAL_CREATE,
+                intent: { id: 'intent' },
+            }),
+        );
+
+        const { action: approveStepAction } =
+            updateSteps.mock.calls[0][0][1].meta;
+        act(() => approveStepAction?.({ onError: jest.fn() }));
+
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_start', {
+            flow: 'create_proposal',
+            transactionKind: 'governance_proposal_create',
+            transactionType: TransactionType.PROPOSAL_CREATE,
+            network,
+            chainId: networkDefinitions[network].id,
+            attemptKind: 'new',
+        });
+    });
+
+    it('does not track a transaction start when analytics are not configured', () => {
+        const transaction = { from: '0x123', data: '0x000' };
+        const network = Network.POLYGON_MAINNET;
+        useConnectionSpy.mockReturnValue({
+            chainId: networkDefinitions[network].id,
+        } as unknown as Wagmi.UseConnectionReturnType);
+        useMutationSpy.mockReturnValue({
+            data: transaction,
+        } as unknown as ReactQuery.UseMutationResult);
+        const updateSteps = jest.fn() as jest.Mock<
+            void,
+            IStepperStep<ITransactionDialogStepMeta>[][]
+        >;
+        const stepper = generateStepperResult<
+            ITransactionDialogStepMeta,
+            string
+        >({ updateSteps });
+
+        render(
+            createTestComponent({
+                stepper,
+                network,
+                transactionType: TransactionType.PROPOSAL_CREATE,
+                intent: { id: 'intent' },
+            }),
+        );
+
+        const { action: approveStepAction } =
+            updateSteps.mock.calls[0][0][1].meta;
+        act(() => approveStepAction?.({ onError: jest.fn() }));
+
+        expect(trackAnalyticsSpy).not.toHaveBeenCalled();
     });
 
     it('derives an intent id from the prepared transaction when none is provided', () => {
@@ -619,6 +748,38 @@ describe('<TransactionDialog /> component', () => {
             from: address,
             transaction: undefined,
         });
+        expect(trackAnalyticsSpy).not.toHaveBeenCalled();
+    });
+
+    it('tracks a transaction failure without sending the raw error', () => {
+        const error = new Error('RPC exploded');
+        const waitTxError = {
+            queryKey: [''],
+            ...generateReactQueryResultError({ error }),
+        };
+        useWaitForTransactionReceiptSpy.mockReturnValue(
+            waitTxError as unknown as Wagmi.UseWaitForTransactionReceiptReturnType,
+        );
+
+        render(
+            createTestComponent({
+                analytics: {
+                    flow: 'create_proposal',
+                    transactionKind: 'governance_proposal_create',
+                },
+                transactionType: TransactionType.PROPOSAL_CREATE,
+            }),
+        );
+
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_failed', {
+            flow: 'create_proposal',
+            transactionKind: 'governance_proposal_create',
+            transactionType: TransactionType.PROPOSAL_CREATE,
+            network: Network.ETHEREUM_MAINNET,
+            chainId: networkDefinitions[Network.ETHEREUM_MAINNET].id,
+            step: TransactionDialogStep.CONFIRM,
+            errorClass: 'Error',
+        });
     });
 
     it('overrides the approve error label for a known wallet error', () => {
@@ -809,6 +970,7 @@ describe('<TransactionDialog /> onIndexed callback', () => {
     const managerSendSpy = jest.spyOn(pendingTransactionManager, 'send');
     const managerClearSpy = jest.spyOn(pendingTransactionManager, 'clear');
     const managerGetSpy = jest.spyOn(pendingTransactionManager, 'get');
+    const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');
 
     beforeEach(() => {
         useSendTransactionSpy.mockReturnValue(
@@ -832,6 +994,7 @@ describe('<TransactionDialog /> onIndexed callback', () => {
         useTransactionStatusSpy.mockReturnValue(
             generateReactQueryResultSuccess({ data: { isProcessed: false } }),
         );
+        trackAnalyticsSpy.mockImplementation(() => undefined);
     });
 
     afterEach(() => {
@@ -845,6 +1008,7 @@ describe('<TransactionDialog /> onIndexed callback', () => {
         managerClearSpy.mockReset();
         managerGetSpy.mockReset();
         useTransactionStatusSpy.mockReset();
+        trackAnalyticsSpy.mockReset();
     });
 
     const createTestComponent = (props?: Partial<ITransactionDialogProps>) => {
@@ -882,6 +1046,10 @@ describe('<TransactionDialog /> onIndexed callback', () => {
         );
 
         const propsWithCallback: Partial<ITransactionDialogProps> = {
+            analytics: {
+                flow: 'create_proposal',
+                transactionKind: 'governance_proposal_create',
+            },
             onIndexed,
         };
 
@@ -903,6 +1071,14 @@ describe('<TransactionDialog /> onIndexed callback', () => {
 
         expect(onIndexed).toHaveBeenCalledTimes(1);
         expect(onIndexed).toHaveBeenCalledWith({ slug: 'abc' });
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_end', {
+            flow: 'create_proposal',
+            transactionKind: 'governance_proposal_create',
+            transactionType: TransactionType.PROPOSAL_CREATE,
+            chainId: networkDefinitions[Network.ETHEREUM_MAINNET].id,
+            network: Network.ETHEREUM_MAINNET,
+            status: 'indexed',
+        });
 
         // React Query polling can replace the status object, and consumers can pass
         // inline callbacks. Neither should trigger the callback a second time.
@@ -945,5 +1121,6 @@ describe('<TransactionDialog /> onIndexed callback', () => {
 
         // Dialog survives the indexed signal with no callback attached.
         expect(screen.getByTestId('footer-mock')).toBeInTheDocument();
+        expect(trackAnalyticsSpy).not.toHaveBeenCalled();
     });
 });

--- a/apps/app/src/shared/components/transactionDialog/transactionDialog.tsx
+++ b/apps/app/src/shared/components/transactionDialog/transactionDialog.tsx
@@ -15,6 +15,11 @@ import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import { useNetworkSwitch } from '@/shared/hooks/useNetworkSwitch';
 import { monitoringUtils } from '@/shared/utils/monitoringUtils';
 import { buildIntentId } from '@/shared/utils/pendingTransactionManager';
+import {
+    type PlausibleAnalyticsEventName,
+    type PlausibleAnalyticsProps,
+    plausibleAnalyticsUtils,
+} from '@/shared/utils/plausibleAnalyticsUtils';
 import { NetworkSwitchAlert } from '../networkSwitchAlert';
 import {
     type ITransactionStatusStepMetaAddon,
@@ -58,10 +63,10 @@ export const TransactionDialog = <TCustomStepId extends string>(
         onIndexed,
         network = Network.ETHEREUM_MAINNET,
         transactionType,
+        analytics,
         indexingFallbackUrl,
         disableCancel,
     } = props;
-
     const {
         activeStep,
         steps,
@@ -79,11 +84,16 @@ export const TransactionDialog = <TCustomStepId extends string>(
 
     // Make the onSuccess property stable to only trigger it once on transaction success
     const onSuccessRef = useRef(onSuccess);
+    const analyticsRef = useRef(analytics);
+    analyticsRef.current = analytics;
 
     // Guard so onIndexed fires exactly once: react-query polling yields new status-object
     // identities on re-render, so without this the indexed effect would refire.
     const onIndexedFiredRef = useRef(false);
+    const confirmedAnalyticsFiredRef = useRef(false);
+    const terminalAnalyticsFiredRef = useRef(false);
 
+    const failedAnalyticsFiredRef = useRef(false);
     const { address } = useWalletAccount();
     const { buildEntityUrl } = useDaoChain({ network });
     const {
@@ -94,15 +104,61 @@ export const TransactionDialog = <TCustomStepId extends string>(
         withNetworkSwitch,
     } = useNetworkSwitch({ network });
 
+    const getTransactionAnalyticsProps = useCallback(
+        () => ({
+            ...analyticsRef.current,
+            transactionType,
+            network,
+            chainId: requiredChainId,
+        }),
+        [transactionType, network, requiredChainId],
+    );
+
+    const trackTransactionAnalytics = useCallback(
+        (
+            eventName: Extract<
+                PlausibleAnalyticsEventName,
+                `transaction_${string}`
+            >,
+            props?: PlausibleAnalyticsProps,
+        ) => {
+            if (analyticsRef.current == null) {
+                return;
+            }
+
+            plausibleAnalyticsUtils.track(eventName, {
+                ...getTransactionAnalyticsProps(),
+                ...props,
+            });
+        },
+        [getTransactionAnalyticsProps],
+    );
+
+    const trackTransactionFailure = useCallback(
+        (error: unknown, stepId?: string) => {
+            if (failedAnalyticsFiredRef.current) {
+                return;
+            }
+
+            failedAnalyticsFiredRef.current = true;
+            trackTransactionAnalytics('transaction_failed', {
+                step: stepId,
+                errorClass: error instanceof Error ? error.name : 'unknown',
+            });
+        },
+        [trackTransactionAnalytics],
+    );
     const handleTransactionError = useCallback(
         (stepId?: string) =>
-            (error: unknown, context?: Record<string, unknown>) =>
+            (error: unknown, context?: Record<string, unknown>) => {
+                trackTransactionFailure(error, stepId);
                 transactionDialogUtils.monitorTransactionError(error, {
                     stepId,
                     from: address,
                     ...context,
-                }),
-        [address],
+                });
+            },
+        [address, trackTransactionFailure],
     );
 
     const {
@@ -218,8 +274,14 @@ export const TransactionDialog = <TCustomStepId extends string>(
         }
 
         onIndexedFiredRef.current = true;
+        trackTransactionAnalytics('transaction_end', { status: 'indexed' });
         onIndexed?.({ slug: indexedProposalSlug });
-    }, [isTransactionIndexed, indexedProposalSlug, onIndexed]);
+    }, [
+        isTransactionIndexed,
+        indexedProposalSlug,
+        onIndexed,
+        trackTransactionAnalytics,
+    ]);
 
     const handleSendTransaction = useCallback(() => {
         const onError = handleTransactionError(TransactionDialogStep.APPROVE);
@@ -227,13 +289,18 @@ export const TransactionDialog = <TCustomStepId extends string>(
         // No prepared transaction = a resumed dialog that skipped prepare: re-send the stored
         // request, or surface a failure if there is none (e.g. lost after a reload).
         if (transaction == null) {
-            if (!resend()) {
-                onError(
-                    new Error(
-                        'TransactionDialog: no prepared transaction and nothing to re-send.',
-                    ),
-                );
+            if (resend()) {
+                trackTransactionAnalytics('transaction_start', {
+                    attemptKind: 'resume',
+                });
+                return;
             }
+
+            onError(
+                new Error(
+                    'TransactionDialog: no prepared transaction and nothing to re-send.',
+                ),
+            );
             return;
         }
 
@@ -247,6 +314,8 @@ export const TransactionDialog = <TCustomStepId extends string>(
             return;
         }
 
+        trackTransactionAnalytics('transaction_start', { attemptKind: 'new' });
+
         // Pin to the required chain so wagmi rejects instead of silently signing on the wrong one.
         send({ ...transaction, chainId: requiredChainId });
     }, [
@@ -256,6 +325,7 @@ export const TransactionDialog = <TCustomStepId extends string>(
         send,
         resend,
         handleTransactionError,
+        trackTransactionAnalytics,
     ]);
 
     const handleRetryTransaction = useCallback(() => {
@@ -494,11 +564,33 @@ export const TransactionDialog = <TCustomStepId extends string>(
     }, [waitTxError, transaction, handleTransactionError]);
 
     useEffect(() => {
-        if (waitTxStatus === 'success') {
-            onSuccessRef.current?.(txReceipt);
-            nextStep();
+        if (waitTxStatus !== 'success') {
+            return;
         }
-    }, [waitTxStatus, nextStep, txReceipt]);
+
+        if (!confirmedAnalyticsFiredRef.current) {
+            confirmedAnalyticsFiredRef.current = true;
+            trackTransactionAnalytics('transaction_stage', {
+                status: 'confirmed',
+            });
+        }
+
+        if (transactionType == null && !terminalAnalyticsFiredRef.current) {
+            terminalAnalyticsFiredRef.current = true;
+            trackTransactionAnalytics('transaction_end', {
+                status: 'confirmed',
+            });
+        }
+
+        onSuccessRef.current?.(txReceipt);
+        nextStep();
+    }, [
+        waitTxStatus,
+        nextStep,
+        txReceipt,
+        transactionType,
+        trackTransactionAnalytics,
+    ]);
 
     // Advance to confirm once the wallet has signed (the hash appears). Failures go to the subscriber.
     useEffect(() => {

--- a/apps/app/src/shared/components/wizards/wizard/wizardForm/wizardForm.test.tsx
+++ b/apps/app/src/shared/components/wizards/wizard/wizardForm/wizardForm.test.tsx
@@ -3,21 +3,25 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as ReactHookForm from 'react-hook-form';
 import { generateFormContext, generateWizardContext } from '@/shared/testUtils';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import * as WizardProvider from '../wizardProvider';
 import { type IWizardFormProps, WizardForm } from './wizardForm';
 
 describe('<WizardForm /> component', () => {
     const useWizardContextSpy = jest.spyOn(WizardProvider, 'useWizardContext');
     const useFormContextSpy = jest.spyOn(ReactHookForm, 'useFormContext');
+    const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');
 
     beforeEach(() => {
         useWizardContextSpy.mockReturnValue(generateWizardContext());
         useFormContextSpy.mockReturnValue(generateFormContext());
+        trackAnalyticsSpy.mockImplementation(() => undefined);
     });
 
     afterEach(() => {
         useWizardContextSpy.mockReset();
         useFormContextSpy.mockReset();
+        trackAnalyticsSpy.mockReset();
     });
 
     const createTestComponent = (props?: Partial<IWizardFormProps>) => {
@@ -46,7 +50,10 @@ describe('<WizardForm /> component', () => {
         );
         render(createTestComponent({ children }));
         await userEvent.click(screen.getByRole('button'));
-        expect(handleSubmit).toHaveBeenCalledWith(nextStep);
+        expect(handleSubmit).toHaveBeenCalledWith(
+            nextStep,
+            expect.any(Function),
+        );
     });
 
     it('triggers the onSubmit property when current is the last step on form submit', async () => {
@@ -61,7 +68,55 @@ describe('<WizardForm /> component', () => {
         );
         render(createTestComponent({ children, onSubmit }));
         await userEvent.click(screen.getByRole('button'));
-        expect(handleSubmit).toHaveBeenCalledWith(onSubmit);
+        expect(handleSubmit).toHaveBeenCalledWith(
+            onSubmit,
+            expect.any(Function),
+        );
+    });
+
+    it('tracks a validation-blocked attempt for the active wizard step', async () => {
+        const children = <Button type="submit" />;
+        const handleSubmit = jest.fn(
+            (
+                _onValid: ReactHookForm.SubmitHandler<object>,
+                onInvalid?: ReactHookForm.SubmitErrorHandler<object>,
+            ) =>
+                () =>
+                    onInvalid?.({
+                        metadata: { message: 'Required', type: 'required' },
+                        network: { message: 'Required', type: 'required' },
+                    } as unknown as ReactHookForm.FieldErrors<object>),
+        ) as ReactHookForm.UseFormHandleSubmit<object>;
+        useWizardContextSpy.mockReturnValue(
+            generateWizardContext({
+                activeStep: 'metadata',
+                activeStepIndex: 0,
+                analytics: {
+                    flow: 'create_dao',
+                    props: { network: 'ethereum-mainnet' },
+                },
+                hasNext: true,
+            }),
+        );
+        useFormContextSpy.mockReturnValue(
+            generateFormContext({ handleSubmit }),
+        );
+
+        render(createTestComponent({ children }));
+
+        await userEvent.click(screen.getByRole('button'));
+
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+            'wizard_validation_blocked',
+            {
+                flow: 'create_dao',
+                network: 'ethereum-mainnet',
+                stepKey: 'metadata',
+                stepIndex: 0,
+                attempt: 'next',
+                errorCount: 2,
+            },
+        );
     });
 
     it('does not throw error when the onSubmit property is not defined', async () => {

--- a/apps/app/src/shared/components/wizards/wizard/wizardForm/wizardForm.tsx
+++ b/apps/app/src/shared/components/wizards/wizard/wizardForm/wizardForm.tsx
@@ -1,5 +1,10 @@
 import type { ComponentProps, FormEvent } from 'react';
-import { type FieldValues, useFormContext } from 'react-hook-form';
+import {
+    type FieldErrors,
+    type FieldValues,
+    useFormContext,
+} from 'react-hook-form';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import { useWizardContext } from '../wizardProvider';
 
 export interface IWizardFormProps<TFormData extends FieldValues = FieldValues>
@@ -15,14 +20,30 @@ export const WizardForm = <TFormData extends FieldValues = FieldValues>(
 ) => {
     const { children, onSubmit = () => null, ...otherProps } = props;
 
-    const { hasNext, nextStep } = useWizardContext();
+    const { activeStep, activeStepIndex, analytics, hasNext, nextStep } =
+        useWizardContext();
     const { handleSubmit } = useFormContext<TFormData>();
+
+    const handleInvalidSubmit = (errors: FieldErrors<TFormData>) => {
+        if (analytics == null || activeStep == null) {
+            return;
+        }
+
+        plausibleAnalyticsUtils.track('wizard_validation_blocked', {
+            ...analytics.props,
+            flow: analytics.flow,
+            stepKey: activeStep,
+            stepIndex: activeStepIndex,
+            attempt: hasNext ? 'next' : 'submit',
+            errorCount: Object.keys(errors).length,
+        });
+    };
 
     const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         event.stopPropagation();
         const submitCallback = hasNext ? nextStep : onSubmit;
-        void handleSubmit(submitCallback)(event);
+        void handleSubmit(submitCallback, handleInvalidSubmit)(event);
     };
 
     return (

--- a/apps/app/src/shared/components/wizards/wizard/wizardProvider/index.ts
+++ b/apps/app/src/shared/components/wizards/wizard/wizardProvider/index.ts
@@ -1,4 +1,5 @@
 export {
+    type IWizardAnalytics,
     type IWizardContext,
     type IWizardStepperStep,
     useWizardContext,

--- a/apps/app/src/shared/components/wizards/wizard/wizardProvider/wizardProvider.tsx
+++ b/apps/app/src/shared/components/wizards/wizard/wizardProvider/wizardProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext } from 'react';
 import type { IUseStepperReturn } from '@/shared/hooks/useStepper';
+import type { PlausibleAnalyticsProps } from '@/shared/utils/plausibleAnalyticsUtils';
 import type { IStepperStep } from '@/shared/utils/stepperUtils';
 
 export interface IWizardContainerStepMeta {
@@ -12,6 +13,17 @@ export interface IWizardContainerStepMeta {
 export interface IWizardStepperStep
     extends IStepperStep<IWizardContainerStepMeta> {}
 
+export interface IWizardAnalytics {
+    /**
+     * Product flow represented by the wizard.
+     */
+    flow: string;
+    /**
+     * Low-cardinality, privacy-safe event properties shared by wizard events.
+     */
+    props?: PlausibleAnalyticsProps;
+}
+
 export interface IWizardContext
     extends IUseStepperReturn<IWizardContainerStepMeta> {
     /**
@@ -22,6 +34,10 @@ export interface IWizardContext
      * Help text to be displayed under the submit button at the end of the wizard.
      */
     submitHelpText?: string;
+    /**
+     * Optional analytics metadata for stepper-level product telemetry.
+     */
+    analytics?: IWizardAnalytics;
 }
 
 const wizardContext = createContext<IWizardContext | null>(null);

--- a/apps/app/src/shared/components/wizards/wizard/wizardRoot/wizardRoot.test.tsx
+++ b/apps/app/src/shared/components/wizards/wizard/wizardRoot/wizardRoot.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useEffect } from 'react';
 import * as ReactHookForm from 'react-hook-form';
 import {
     generateFormContext,
     generateFormContextState,
 } from '@/shared/testUtils';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
+import { type IWizardAnalytics, useWizardContext } from '../wizardProvider';
 import { type IWizardRootProps, WizardRoot } from './wizardRoot';
 
 jest.mock('next/dynamic', () => ({
@@ -13,14 +17,42 @@ jest.mock('next/dynamic', () => ({
 
 describe('<WizardRoot /> component', () => {
     const useFormSpy = jest.spyOn(ReactHookForm, 'useForm');
-
+    const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');
     beforeEach(() => {
         useFormSpy.mockReturnValue(generateFormContext());
+        trackAnalyticsSpy.mockImplementation(() => undefined);
     });
 
     afterEach(() => {
         useFormSpy.mockReset();
+        trackAnalyticsSpy.mockReset();
     });
+
+    const wizardSteps = [
+        { id: 'metadata', order: 0, meta: { name: 'Metadata' } },
+        { id: 'network', order: 1, meta: { name: 'Network' } },
+    ];
+
+    const NextStepButton = () => {
+        const { nextStep } = useWizardContext();
+
+        return (
+            <button onClick={nextStep} type="button">
+                Next
+            </button>
+        );
+    };
+
+    const AnalyticsChangeObserver = (props: {
+        onChange: (analytics: IWizardAnalytics | undefined) => void;
+    }) => {
+        const { onChange } = props;
+        const { analytics } = useWizardContext();
+
+        useEffect(() => onChange(analytics), [analytics, onChange]);
+
+        return null;
+    };
 
     const createTestComponent = (props?: Partial<IWizardRootProps>) => {
         const completeProps: IWizardRootProps = {
@@ -57,5 +89,81 @@ describe('<WizardRoot /> component', () => {
             keepDirty: true,
             keepValues: true,
         });
+    });
+
+    it('tracks wizard start and initial step when analytics are configured', async () => {
+        render(
+            createTestComponent({
+                analytics: {
+                    flow: 'create_dao',
+                    props: { network: 'ethereum-mainnet' },
+                },
+                initialSteps: wizardSteps,
+            }),
+        );
+
+        await waitFor(() =>
+            expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_start', {
+                flow: 'create_dao',
+                network: 'ethereum-mainnet',
+            }),
+        );
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_step', {
+            flow: 'create_dao',
+            network: 'ethereum-mainnet',
+            stepKey: 'metadata',
+            stepIndex: 0,
+            direction: 'direct',
+        });
+    });
+
+    it('tracks wizard step transitions with direction', async () => {
+        render(
+            createTestComponent({
+                analytics: { flow: 'create_dao' },
+                children: <NextStepButton />,
+                initialSteps: wizardSteps,
+            }),
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith('wizard_step', {
+            flow: 'create_dao',
+            stepKey: 'network',
+            stepIndex: 1,
+            direction: 'forward',
+        });
+    });
+
+    it('keeps the wizard analytics context stable when props are recreated with the same values', () => {
+        const onContextChange = jest.fn();
+        const { rerender } = render(
+            createTestComponent({
+                analytics: {
+                    flow: 'create_proposal',
+                    props: { pluginInterfaceType: 'multisig' },
+                },
+                children: (
+                    <AnalyticsChangeObserver onChange={onContextChange} />
+                ),
+                initialSteps: wizardSteps,
+            }),
+        );
+
+        rerender(
+            createTestComponent({
+                analytics: {
+                    flow: 'create_proposal',
+                    props: { pluginInterfaceType: 'multisig' },
+                },
+                children: (
+                    <AnalyticsChangeObserver onChange={onContextChange} />
+                ),
+                initialSteps: wizardSteps,
+            }),
+        );
+
+        expect(onContextChange).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/app/src/shared/components/wizards/wizard/wizardRoot/wizardRoot.tsx
+++ b/apps/app/src/shared/components/wizards/wizard/wizardRoot/wizardRoot.tsx
@@ -1,5 +1,11 @@
 import dynamic from 'next/dynamic';
-import { type ElementType, type ReactNode, useEffect, useMemo } from 'react';
+import {
+    type ElementType,
+    type ReactNode,
+    useEffect,
+    useMemo,
+    useRef,
+} from 'react';
 import {
     type FieldValues,
     FormProvider,
@@ -8,7 +14,12 @@ import {
 } from 'react-hook-form';
 import { useConfirmWizardExit } from '@/shared/hooks/useConfirmWizardExit';
 import { useStepper } from '@/shared/hooks/useStepper';
-import { type IWizardStepperStep, WizardProvider } from '../wizardProvider';
+import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
+import {
+    type IWizardAnalytics,
+    type IWizardStepperStep,
+    WizardProvider,
+} from '../wizardProvider';
 
 // Dynamically import react-hook-form dev-tools to avoid NextJs hydration errors
 const DevTool: ElementType = dynamic(
@@ -40,6 +51,10 @@ export interface IWizardRootProps<TFormData extends FieldValues = FieldValues> {
      */
     useDevTool?: boolean;
     /**
+     * Optional analytics metadata for stepper-level product telemetry.
+     */
+    analytics?: IWizardAnalytics;
+    /**
      * Children of the component.
      */
     children?: ReactNode;
@@ -55,6 +70,7 @@ export const WizardRoot = <TFormData extends FieldValues = FieldValues>(
         defaultValues,
         useDevTool,
         submitHelpText,
+        analytics,
     } = props;
 
     const formMethods = useForm<TFormData>({
@@ -64,6 +80,71 @@ export const WizardRoot = <TFormData extends FieldValues = FieldValues>(
     const { formState, reset, control } = formMethods;
 
     const wizardStepper = useStepper({ initialSteps });
+    const previousStepRef = useRef<
+        | {
+              id?: string;
+              index: number;
+          }
+        | undefined
+    >(undefined);
+    const hasTrackedStartRef = useRef(false);
+    const activeStep = wizardStepper.activeStep;
+    const activeStepIndex = wizardStepper.activeStepIndex;
+    const analyticsFlow = analytics?.flow;
+    const analyticsPropsKey = JSON.stringify(analytics?.props ?? null);
+    const stableAnalytics = useMemo(() => {
+        if (analyticsFlow == null) {
+            return undefined;
+        }
+
+        return {
+            flow: analyticsFlow,
+            props:
+                analyticsPropsKey === 'null'
+                    ? undefined
+                    : (JSON.parse(
+                          analyticsPropsKey,
+                      ) as IWizardAnalytics['props']),
+        };
+    }, [analyticsFlow, analyticsPropsKey]);
+
+    useEffect(() => {
+        if (stableAnalytics == null || activeStep == null) {
+            return;
+        }
+
+        const baseProps = {
+            ...stableAnalytics.props,
+            flow: stableAnalytics.flow,
+        };
+
+        if (!hasTrackedStartRef.current) {
+            hasTrackedStartRef.current = true;
+            plausibleAnalyticsUtils.track('wizard_start', baseProps);
+        }
+
+        if (previousStepRef.current?.id === activeStep) {
+            return;
+        }
+
+        const previousStep = previousStepRef.current;
+        const direction =
+            previousStep == null
+                ? 'direct'
+                : activeStepIndex > previousStep.index
+                  ? 'forward'
+                  : activeStepIndex < previousStep.index
+                    ? 'back'
+                    : 'direct';
+
+        previousStepRef.current = { id: activeStep, index: activeStepIndex };
+        plausibleAnalyticsUtils.track('wizard_step', {
+            ...baseProps,
+            stepKey: activeStep,
+            stepIndex: activeStepIndex,
+            direction,
+        });
+    }, [stableAnalytics, activeStep, activeStepIndex]);
 
     // Reset submitted form state to only display validation alerts when user clicks again on "next" button
     useEffect(() => {
@@ -73,8 +154,13 @@ export const WizardRoot = <TFormData extends FieldValues = FieldValues>(
     }, [formState, reset]);
 
     const wizardContextValues = useMemo(
-        () => ({ ...wizardStepper, submitLabel, submitHelpText }),
-        [wizardStepper, submitLabel, submitHelpText],
+        () => ({
+            ...wizardStepper,
+            analytics: stableAnalytics,
+            submitLabel,
+            submitHelpText,
+        }),
+        [wizardStepper, stableAnalytics, submitLabel, submitHelpText],
     );
 
     useConfirmWizardExit(formState.isDirty);

--- a/apps/app/src/shared/components/wizards/wizardPage/wizardPageContainer/wizardPageContainer.tsx
+++ b/apps/app/src/shared/components/wizards/wizardPage/wizardPageContainer/wizardPageContainer.tsx
@@ -28,6 +28,7 @@ export const WizardPageContainer = <
         initialSteps,
         defaultValues,
         finalStep,
+        analytics,
         children,
         className,
         ...wizardFormProps
@@ -35,6 +36,7 @@ export const WizardPageContainer = <
 
     return (
         <Wizard.Root
+            analytics={analytics}
             defaultValues={defaultValues}
             initialSteps={initialSteps}
             submitHelpText={submitHelpText}

--- a/apps/app/src/shared/utils/analyticsUtils/analyticsUtils.test.ts
+++ b/apps/app/src/shared/utils/analyticsUtils/analyticsUtils.test.ts
@@ -41,6 +41,17 @@ describe('analytics utils', () => {
 
             expect(init).not.toHaveBeenCalled();
         });
+
+        it('does not initialise the tracker when the domain is empty', async () => {
+            process.env = {
+                ...originalEnv,
+                NEXT_PUBLIC_PLAUSIBLE_DOMAIN: '',
+            };
+
+            await analyticsUtils.init();
+
+            expect(init).not.toHaveBeenCalled();
+        });
     });
 
     describe('trackEvent', () => {
@@ -54,11 +65,11 @@ describe('analytics utils', () => {
         it('forwards the event name and props once initialised', async () => {
             await analyticsUtils.init();
 
-            analyticsUtils.trackEvent('Publish DAO Click', {
+            analyticsUtils.trackEvent('test_event', {
                 network: 'ethereum-mainnet',
             });
 
-            expect(track).toHaveBeenCalledWith('Publish DAO Click', {
+            expect(track).toHaveBeenCalledWith('test_event', {
                 props: { network: 'ethereum-mainnet' },
             });
         });
@@ -66,15 +77,15 @@ describe('analytics utils', () => {
         it('omits the options argument when no props are given', async () => {
             await analyticsUtils.init();
 
-            analyticsUtils.trackEvent('Create DAO Click');
+            analyticsUtils.trackEvent('test_event');
 
-            expect(track).toHaveBeenCalledWith('Create DAO Click', {
+            expect(track).toHaveBeenCalledWith('test_event', {
                 props: undefined,
             });
         });
 
         it('does not call track before init (e.g. domain not configured)', () => {
-            analyticsUtils.trackEvent('Create DAO Click');
+            analyticsUtils.trackEvent('test_event');
 
             expect(track).not.toHaveBeenCalled();
         });

--- a/apps/app/src/shared/utils/analyticsUtils/analyticsUtils.ts
+++ b/apps/app/src/shared/utils/analyticsUtils/analyticsUtils.ts
@@ -15,7 +15,7 @@ class AnalyticsUtils {
     init = async () => {
         const domain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
 
-        if (domain == null) {
+        if (!domain) {
             return;
         }
 

--- a/apps/app/src/shared/utils/plausibleAnalyticsUtils/index.ts
+++ b/apps/app/src/shared/utils/plausibleAnalyticsUtils/index.ts
@@ -1,0 +1,1 @@
+export * from './plausibleAnalyticsUtils';

--- a/apps/app/src/shared/utils/plausibleAnalyticsUtils/plausibleAnalyticsUtils.test.ts
+++ b/apps/app/src/shared/utils/plausibleAnalyticsUtils/plausibleAnalyticsUtils.test.ts
@@ -1,0 +1,43 @@
+import { analyticsUtils } from '@/shared/utils/analyticsUtils';
+import { plausibleAnalyticsUtils } from './plausibleAnalyticsUtils';
+
+describe('plausibleAnalyticsUtils', () => {
+    const trackEventSpy = jest.spyOn(analyticsUtils, 'trackEvent');
+
+    beforeEach(() => {
+        trackEventSpy.mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        trackEventSpy.mockReset();
+    });
+
+    it('forwards the event name to the analytics pipeline with no props', () => {
+        plausibleAnalyticsUtils.track('wizard_start');
+
+        expect(trackEventSpy).toHaveBeenCalledWith('wizard_start', undefined);
+    });
+
+    it('stringifies numeric and boolean prop values', () => {
+        plausibleAnalyticsUtils.track('transaction_start', {
+            flow: 'create_proposal',
+            chainId: 1,
+            hasActions: true,
+        });
+
+        expect(trackEventSpy).toHaveBeenCalledWith('transaction_start', {
+            flow: 'create_proposal',
+            chainId: '1',
+            hasActions: 'true',
+        });
+    });
+
+    it('omits nullish props and sends no props when none remain', () => {
+        plausibleAnalyticsUtils.track('action_added', {
+            source: undefined,
+            count: null,
+        });
+
+        expect(trackEventSpy).toHaveBeenCalledWith('action_added', undefined);
+    });
+});

--- a/apps/app/src/shared/utils/plausibleAnalyticsUtils/plausibleAnalyticsUtils.ts
+++ b/apps/app/src/shared/utils/plausibleAnalyticsUtils/plausibleAnalyticsUtils.ts
@@ -1,0 +1,51 @@
+import { analyticsUtils } from '@/shared/utils/analyticsUtils';
+
+export type PlausibleAnalyticsEventName =
+    | 'wizard_start'
+    | 'wizard_submit'
+    | 'wizard_step'
+    | 'wizard_validation_blocked'
+    | 'action_added'
+    | 'action_added_batch'
+    | 'transaction_start'
+    | 'transaction_stage'
+    | 'transaction_end'
+    | 'transaction_failed';
+
+export type PlausibleAnalyticsPropValue = string | number | boolean;
+
+export type PlausibleAnalyticsProps = Record<
+    string,
+    PlausibleAnalyticsPropValue | null | undefined
+>;
+
+/**
+ * Typed event catalog for the app's product analytics. This is the taxonomy layer owned by the
+ * app (event names + payload shapes); the underlying transport/pipeline is `analyticsUtils`
+ * (Plausible tracker + proxied endpoint). Keeping the catalog here gives compile-time safety on
+ * event names and centralizes payload hygiene, so a typo can't silently mint a junk goal.
+ */
+class PlausibleAnalyticsUtils {
+    track = (
+        eventName: PlausibleAnalyticsEventName,
+        props?: PlausibleAnalyticsProps,
+    ) => {
+        analyticsUtils.trackEvent(eventName, this.normalizeProps(props));
+    };
+
+    // Plausible props are string-valued on the wire, so coerce numbers/booleans and drop nullish
+    // entries. Returns undefined when nothing remains so the tracker sends a bare event.
+    private normalizeProps = (props?: PlausibleAnalyticsProps) => {
+        if (props == null) {
+            return undefined;
+        }
+
+        const entries = Object.entries(props)
+            .filter(([, value]) => value != null)
+            .map(([key, value]) => [key, String(value)] as const);
+
+        return entries.length === 0 ? undefined : Object.fromEntries(entries);
+    };
+}
+
+export const plausibleAnalyticsUtils = new PlausibleAnalyticsUtils();


### PR DESCRIPTION
## Summary

Instruments privacy-safe Plausible custom events across the app's core funnels (APP-999). Runtime loading, the proxied endpoint and env gating are owned by the Plausible pipeline integration (#1260 / SREDO-733) — this PR **only adds events**, sent through the shared `analyticsUtils` pipeline.

## Events

- **Wizard** — `wizard_start` / `wizard_step` (with direction) / `wizard_submit` / `wizard_validation_blocked`.
- **Transaction** — `transaction_start` (`attemptKind`) / `transaction_stage` / `transaction_end` / `transaction_failed`, keyed by `flow` + `transactionKind`, idempotent per lifecycle.
- **Actions** — `action_added` / `action_added_batch` with a low-cardinality `actionCategory`.

## Design

- `plausibleAnalyticsUtils` is a **typed event catalog** (event-name union + payload hygiene) that delegates to `analyticsUtils.trackEvent`, coercing values to strings and dropping nullish props — compile-time safety on event names atop the untyped pipeline.
- **Privacy/cardinality:** failures send `errorClass` only (never raw errors); PII is booleanized (`hasEns`, `hasAvatar`, `hasActions`); action types collapse to a small category set.

## Open items

- **Taxonomy sign-off (Evan):** our names are snake_case; the pipeline's seed events (`'Publish DAO Click'`/`'Create DAO Click'`) are Title-Case prose — both coexist on the create-DAO path today.
- **`deposit_address_copied`** is in the catalog but intentionally unwired (no deposit-address UI yet).
- **Smoke test** needs a non-prod Plausible site (SREDO-733).

## Verification

- Affected Jest suites green (18); `tsc` clean for changed files; Biome clean. Rebased onto `main` after #1260.
