### PR TITLE
feat(APP-1022): support voting on objection-stage proposals

### DIFF
--- a/.changeset/objection-stage-voting.md
+++ b/.changeset/objection-stage-voting.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": minor
+---
+
+Restrict voting to an "Object" option on objection-stage proposals

--- a/apps/app/src/assets/locales/en.json
+++ b/apps/app/src/assets/locales/en.json
@@ -3487,6 +3487,7 @@
             "no": "No",
             "object": "Object",
             "objectionDescription": ", I object",
+            "objectionHelpText": "During the objection phase you can only vote \"No\" to object to the proposal.",
             "objectionLabel": "object to",
             "vetoLabel": "veto",
             "vetoNoDescription": ", I don't veto",

--- a/apps/app/src/assets/locales/en.json
+++ b/apps/app/src/assets/locales/en.json
@@ -3485,6 +3485,9 @@
             "approveYesDescription": ", I approve",
             "label": "Do you want to {{label}} this proposal?",
             "no": "No",
+            "object": "Object",
+            "objectionDescription": ", I object",
+            "objectionLabel": "object to",
             "vetoLabel": "veto",
             "vetoNoDescription": ", I don't veto",
             "vetoYesDescription": ", I veto",
@@ -3492,6 +3495,7 @@
           },
           "voteDescription": {
             "approve": "to approve",
+            "objection": "to object",
             "veto": "to veto"
           }
         },

--- a/apps/app/src/daos/alchemix/components/alchemixSubmitVote/alchemixSubmitVote.tsx
+++ b/apps/app/src/daos/alchemix/components/alchemixSubmitVote/alchemixSubmitVote.tsx
@@ -210,7 +210,7 @@ export const AlchemixSubmitVote: React.FC<IAlchemixSubmitVoteProps> = (
             voteLabel === 'abstain'
                 ? undefined
                 : t(
-                      `app.plugins.token.tokenSubmitVote.voteDescription.${isVeto ? 'veto' : 'approve'}`,
+                      `app.plugins.token.tokenSubmitVote.voteDescription.${settings.isObjection ? 'objection' : isVeto ? 'veto' : 'approve'}`,
                   );
         // Without override permission the delegated power cannot be moved: leave the vote type unset so that the
         // DAO-level build-vote-data slot falls back to the plain vote of the token plugin.
@@ -410,6 +410,7 @@ export const AlchemixSubmitVote: React.FC<IAlchemixSubmitVoteProps> = (
                 <>
                     <TokenVotingOptions
                         disabledOptions={disabledOptions}
+                        isObjection={settings.isObjection}
                         isVeto={isVeto}
                         onChange={setSelectedOption}
                         value={selectedOption}

--- a/apps/app/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.test.ts
+++ b/apps/app/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.test.ts
@@ -575,6 +575,73 @@ describe('SppStageUtils', () => {
             );
         });
 
+        it('returns active for an objection stage while the window is open, even though approval is already reached', () => {
+            const now = '2023-01-01T12:00:00.000Z';
+            const startDate = DateTime.fromISO(now).minus({ days: 2 });
+            const minAdvance = DateTime.fromISO(now).minus({ days: 1 });
+            const maxAdvance = DateTime.fromISO(now).plus({ days: 3 });
+            const endDate = DateTime.fromISO(now).plus({ days: 10 });
+
+            const stages = [
+                generateSppStage({ stageIndex: 0 }),
+                generateSppStage({ stageIndex: 1, approvalThreshold: 1 }),
+                generateSppStage({ stageIndex: 2 }),
+            ];
+            const subProposal = generateSppSubProposal({ stageIndex: 1 });
+            subProposal.settings = {
+                ...subProposal.settings,
+                isObjection: true,
+            };
+            const proposal = generateSppProposal({
+                hasActions: true,
+                stageIndex: 1,
+                settings: generateSppPluginSettings({ stages }),
+                subProposals: [subProposal],
+            });
+
+            getStageStartDateSpy.mockReturnValue(startDate);
+            getStageEndDateSpy.mockReturnValue(endDate);
+            getStageMaxAdvanceSpy.mockReturnValue(maxAdvance);
+            getStageMinAdvanceSpy.mockReturnValue(minAdvance);
+            isApprovalReachedSpy.mockReturnValue(true);
+            timeUtils.setTime(now);
+
+            expect(sppStageUtils.getStageStatus(proposal, stages[1])).toBe(
+                ProposalStatus.ACTIVE,
+            );
+        });
+
+        it('returns advanceable for the same open stage with approval reached when it is not an objection stage', () => {
+            const now = '2023-01-01T12:00:00.000Z';
+            const startDate = DateTime.fromISO(now).minus({ days: 2 });
+            const minAdvance = DateTime.fromISO(now).minus({ days: 1 });
+            const maxAdvance = DateTime.fromISO(now).plus({ days: 3 });
+            const endDate = DateTime.fromISO(now).plus({ days: 10 });
+
+            const stages = [
+                generateSppStage({ stageIndex: 0 }),
+                generateSppStage({ stageIndex: 1, approvalThreshold: 1 }),
+                generateSppStage({ stageIndex: 2 }),
+            ];
+            const proposal = generateSppProposal({
+                hasActions: true,
+                stageIndex: 1,
+                settings: generateSppPluginSettings({ stages }),
+                subProposals: [generateSppSubProposal({ stageIndex: 1 })],
+            });
+
+            getStageStartDateSpy.mockReturnValue(startDate);
+            getStageEndDateSpy.mockReturnValue(endDate);
+            getStageMaxAdvanceSpy.mockReturnValue(maxAdvance);
+            getStageMinAdvanceSpy.mockReturnValue(minAdvance);
+            isApprovalReachedSpy.mockReturnValue(true);
+            timeUtils.setTime(now);
+
+            expect(sppStageUtils.getStageStatus(proposal, stages[1])).toBe(
+                ProposalStatus.ADVANCEABLE,
+            );
+        });
+
         it('returns advanceable for optimistic stage once voting period is over and not vetoed', () => {
             const now = '2023-01-01T12:00:00.000Z';
             const startDate = DateTime.fromISO(now).minus({ days: 2 });

--- a/apps/app/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.test.ts
+++ b/apps/app/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.test.ts
@@ -1244,6 +1244,33 @@ describe('SppStageUtils', () => {
         });
     });
 
+    describe('isObjectionStage', () => {
+        it('returns true when the stage sub-proposal has the isObjection settings flag', () => {
+            const stage = generateSppStage({ stageIndex: 1 });
+            const subProposal = generateSppSubProposal({ stageIndex: 1 });
+            subProposal.settings = {
+                ...subProposal.settings,
+                isObjection: true,
+            };
+            const proposal = generateSppProposal({
+                settings: generateSppPluginSettings({ stages: [stage] }),
+                subProposals: [subProposal],
+            });
+            expect(
+                sppStageUtils.isObjectionStage(proposal, stage),
+            ).toBeTruthy();
+        });
+
+        it('returns false when neither sub-proposals nor stage plugins are objection bodies', () => {
+            const stage = generateSppStage({ stageIndex: 1 });
+            const proposal = generateSppProposal({
+                settings: generateSppPluginSettings({ stages: [stage] }),
+                subProposals: [generateSppSubProposal({ stageIndex: 1 })],
+            });
+            expect(sppStageUtils.isObjectionStage(proposal, stage)).toBeFalsy();
+        });
+    });
+
     describe('getBodyResult', () => {
         it('returns the result for the given address and stage index if present', () => {
             const externalAddress =

--- a/apps/app/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.ts
+++ b/apps/app/src/plugins/sppPlugin/utils/sppStageUtils/sppStageUtils.ts
@@ -20,8 +20,12 @@ class SppStageUtils {
 
         // A stage with no approval requirement (pure veto / optimistic) stays
         // active for its whole voting window; any stage that requires approvals
-        // (approval-only or mixed) follows the approval path below.
-        const isOptimisticStage = stage.approvalThreshold === 0;
+        // (approval-only or mixed) follows the approval path below. Objection
+        // stages inherit the first stage's tallies, so their approval is reached
+        // from the start — they must stay active until the window closes too.
+        const isOptimisticStage =
+            stage.approvalThreshold === 0 ||
+            this.isObjectionStage(proposal, stage);
 
         const now = DateTime.now();
         const startDate = this.getStageStartDate(proposal, stage);
@@ -309,6 +313,20 @@ class SppStageUtils {
 
     isVetoBody = (plugin: ISppStagePlugin): boolean =>
         plugin.proposalType === SppProposalType.VETO;
+
+    // An objection stage only allows "No" votes on tallies carried over from the previous
+    // stage, so its result must not be considered final while the window is still open.
+    isObjectionStage = (proposal: ISppProposal, stage: ISppStage): boolean =>
+        proposal.subProposals.some(
+            (subProposal) =>
+                subProposal.stageIndex === stage.stageIndex &&
+                subProposal.settings?.isObjection === true,
+        ) ||
+        stage.plugins.some(
+            (plugin) =>
+                plugin.interfaceType != null &&
+                plugin.settings?.isObjection === true,
+        );
 
     isLastStage = (proposal: ISppProposal, stage: ISppStage): boolean =>
         proposal.settings.stages.length - 1 === stage.stageIndex;

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenSubmitVoteDefault.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenSubmitVoteDefault.tsx
@@ -82,7 +82,7 @@ export const TokenSubmitVoteDefault: React.FC<ITokenSubmitVoteDefaultProps> = (
             voteLabel === 'abstain'
                 ? undefined
                 : t(
-                      `app.plugins.token.tokenSubmitVote.voteDescription.${isVeto ? 'veto' : 'approve'}`,
+                      `app.plugins.token.tokenSubmitVote.voteDescription.${proposal.settings.isObjection ? 'objection' : isVeto ? 'veto' : 'approve'}`,
                   );
         const vote = {
             value: Number(selectedOption),
@@ -190,6 +190,7 @@ export const TokenSubmitVoteDefault: React.FC<ITokenSubmitVoteDefaultProps> = (
             {showOptions && (
                 <Card className="border border-neutral-100 p-6 shadow-neutral-sm">
                     <TokenVotingOptions
+                        isObjection={proposal.settings.isObjection}
                         isVeto={isVeto}
                         onChange={setSelectedOption}
                         value={selectedOption}

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.test.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import {
+    type ITokenVotingOptionsProps,
+    TokenVotingOptions,
+} from './tokenVotingOptions';
+
+describe('<TokenVotingOptions /> component', () => {
+    const createTestComponent = (props?: Partial<ITokenVotingOptionsProps>) => {
+        const completeProps: ITokenVotingOptionsProps = {
+            onChange: jest.fn(),
+            ...props,
+        };
+
+        return <TokenVotingOptions {...completeProps} />;
+    };
+
+    it('renders the yes, abstain and no vote options', () => {
+        render(createTestComponent());
+        expect(
+            screen.getByText('app.plugins.token.tokenSubmitVote.options.yes'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'app.plugins.token.tokenSubmitVote.options.abstain',
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('app.plugins.token.tokenSubmitVote.options.no'),
+        ).toBeInTheDocument();
+    });
+
+    it('only renders the object option when the isObjection property is set', () => {
+        render(createTestComponent({ isObjection: true }));
+        expect(
+            screen.getByText(
+                'app.plugins.token.tokenSubmitVote.options.object',
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('app.plugins.token.tokenSubmitVote.options.no'),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText('app.plugins.token.tokenSubmitVote.options.yes'),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText(
+                'app.plugins.token.tokenSubmitVote.options.abstain',
+            ),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.test.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.test.tsx
@@ -29,23 +29,30 @@ describe('<TokenVotingOptions /> component', () => {
         ).toBeInTheDocument();
     });
 
-    it('only renders the object option when the isObjection property is set', () => {
+    it('disables all options but object and renders a help text when the isObjection property is set', () => {
         render(createTestComponent({ isObjection: true }));
+
+        const objectOption = screen.getByText(
+            'app.plugins.token.tokenSubmitVote.options.object',
+        );
+        expect(objectOption).toBeInTheDocument();
+        expect(objectOption.closest('button')).toBeEnabled();
+
+        expect(
+            screen
+                .getByText('app.plugins.token.tokenSubmitVote.options.yes')
+                .closest('button'),
+        ).toBeDisabled();
+        expect(
+            screen
+                .getByText('app.plugins.token.tokenSubmitVote.options.abstain')
+                .closest('button'),
+        ).toBeDisabled();
+
         expect(
             screen.getByText(
-                'app.plugins.token.tokenSubmitVote.options.object',
+                'app.plugins.token.tokenSubmitVote.options.objectionHelpText',
             ),
         ).toBeInTheDocument();
-        expect(
-            screen.queryByText('app.plugins.token.tokenSubmitVote.options.no'),
-        ).not.toBeInTheDocument();
-        expect(
-            screen.queryByText('app.plugins.token.tokenSubmitVote.options.yes'),
-        ).not.toBeInTheDocument();
-        expect(
-            screen.queryByText(
-                'app.plugins.token.tokenSubmitVote.options.abstain',
-            ),
-        ).not.toBeInTheDocument();
     });
 });

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.tsx
@@ -24,6 +24,10 @@ export interface ITokenVotingOptionsProps {
      * Options that cannot be selected, each with an optional reason displayed next to the option label.
      */
     disabledOptions?: IDisabledVotingOption[];
+    /**
+     * Restricts the vote options to "No" for objection-stage proposals.
+     */
+    isObjection?: boolean;
 }
 
 export interface IDisabledVotingOption {
@@ -46,6 +50,7 @@ export const TokenVotingOptions: React.FC<ITokenVotingOptionsProps> = (
         onChange,
         disableOptions,
         disabledOptions,
+        isObjection,
     } = props;
     const { t } = useTranslations();
     const id = useRandomId();
@@ -66,24 +71,40 @@ export const TokenVotingOptions: React.FC<ITokenVotingOptionsProps> = (
             description: undefined,
         },
         {
-            label: t('app.plugins.token.tokenSubmitVote.options.no'),
-            value: VoteOption.NO.toString(),
-            variant: isVeto ? 'success' : 'critical',
-            description: t(
-                `app.plugins.token.tokenSubmitVote.options.${isVeto ? 'vetoNoDescription' : 'approveNoDescription'}`,
+            label: t(
+                `app.plugins.token.tokenSubmitVote.options.${isObjection ? 'object' : 'no'}`,
             ),
+            value: VoteOption.NO.toString(),
+            variant: isVeto && !isObjection ? 'success' : 'critical',
+            description: isObjection
+                ? t(
+                      'app.plugins.token.tokenSubmitVote.options.objectionDescription',
+                  )
+                : t(
+                      `app.plugins.token.tokenSubmitVote.options.${isVeto ? 'vetoNoDescription' : 'approveNoDescription'}`,
+                  ),
         },
     ] as const;
+
+    const availableOptions = isObjection
+        ? voteOptions.filter(
+              (option) => option.value === VoteOption.NO.toString(),
+          )
+        : voteOptions;
 
     return (
         <InputContainer
             id={id}
             label={t('app.plugins.token.tokenSubmitVote.options.label', {
-                label: isVeto
-                    ? t('app.plugins.token.tokenSubmitVote.options.vetoLabel')
-                    : t(
-                          'app.plugins.token.tokenSubmitVote.options.approveLabel',
-                      ),
+                label: isObjection
+                    ? t(
+                          'app.plugins.token.tokenSubmitVote.options.objectionLabel',
+                      )
+                    : isVeto
+                      ? t('app.plugins.token.tokenSubmitVote.options.vetoLabel')
+                      : t(
+                            'app.plugins.token.tokenSubmitVote.options.approveLabel',
+                        ),
             })}
             useCustomWrapper={true}
         >
@@ -95,7 +116,7 @@ export const TokenVotingOptions: React.FC<ITokenVotingOptionsProps> = (
                 orientation="vertical"
                 value={selectedValue ?? ''}
             >
-                {voteOptions.map(({ label, value, variant, description }) => {
+                {availableOptions.map(({ label, value, variant, description }) => {
                     const disabledOption = disabledOptions?.find(
                         (option) => option.value === value,
                     );

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.tsx
@@ -25,7 +25,7 @@ export interface ITokenVotingOptionsProps {
      */
     disabledOptions?: IDisabledVotingOption[];
     /**
-     * Restricts the vote options to "No" for objection-stage proposals.
+     * Disables all options but "No" for objection-stage proposals, where only objecting is allowed.
      */
     isObjection?: boolean;
 }
@@ -86,14 +86,15 @@ export const TokenVotingOptions: React.FC<ITokenVotingOptionsProps> = (
         },
     ] as const;
 
-    const availableOptions = isObjection
-        ? voteOptions.filter(
-              (option) => option.value === VoteOption.NO.toString(),
-          )
-        : voteOptions;
-
     return (
         <InputContainer
+            helpText={
+                isObjection
+                    ? t(
+                          'app.plugins.token.tokenSubmitVote.options.objectionHelpText',
+                      )
+                    : undefined
+            }
             id={id}
             label={t('app.plugins.token.tokenSubmitVote.options.label', {
                 label: isObjection
@@ -116,7 +117,7 @@ export const TokenVotingOptions: React.FC<ITokenVotingOptionsProps> = (
                 orientation="vertical"
                 value={selectedValue ?? ''}
             >
-                {availableOptions.map(({ label, value, variant, description }) => {
+                {voteOptions.map(({ label, value, variant, description }) => {
                     const disabledOption = disabledOptions?.find(
                         (option) => option.value === value,
                     );
@@ -130,7 +131,9 @@ export const TokenVotingOptions: React.FC<ITokenVotingOptionsProps> = (
                             }
                             disabled={
                                 disableOptions === true ||
-                                disabledOption != null
+                                disabledOption != null ||
+                                (isObjection === true &&
+                                    value !== VoteOption.NO.toString())
                             }
                             isSelected={value === selectedValue}
                             key={value}

--- a/apps/app/src/plugins/tokenPlugin/hooks/useTokenPermissionCheckVoteSubmission/useTokenPermissionCheckVoteSubmission.tsx
+++ b/apps/app/src/plugins/tokenPlugin/hooks/useTokenPermissionCheckVoteSubmission/useTokenPermissionCheckVoteSubmission.tsx
@@ -54,13 +54,18 @@ export const useTokenPermissionCheckVoteSubmission = (
 
     const { chainId, buildEntityUrl } = useDaoChain({ network });
 
+    // The probed option only matters on objection stages, where the contract rejects
+    // everything except "No" — for regular token voting any option reflects the permission.
+    const probeVoteOption = plugin.settings.isObjection
+        ? VoteOption.NO
+        : VoteOption.YES;
+
     const { data: hasPermission, isLoading } = useReadContract({
         address: pluginAddress as Hex,
         chainId,
         abi: tokenVotingAbi,
         functionName: 'canVote',
-        // Passing YES as vote option because we are only checking permission to vote and the option does not matter
-        args: [BigInt(proposalIndex), address as Hex, VoteOption.YES],
+        args: [BigInt(proposalIndex), address as Hex, probeVoteOption],
         query: { enabled: address != null },
     });
 

--- a/apps/app/src/plugins/tokenPlugin/types/tokenPluginSettings.ts
+++ b/apps/app/src/plugins/tokenPlugin/types/tokenPluginSettings.ts
@@ -36,4 +36,8 @@ export interface ITokenPluginSettings extends IPluginSettings {
      * The settings of the voting escrow.
      */
     votingEscrow?: ITokenPluginSettingsEscrowSettings;
+    /**
+     * Set when the plugin is an objection stage, where members can only vote "No".
+     */
+    isObjection?: boolean;
 }

--- a/apps/app/src/plugins/tokenPlugin/types/tokenPluginSettings.ts
+++ b/apps/app/src/plugins/tokenPlugin/types/tokenPluginSettings.ts
@@ -36,8 +36,4 @@ export interface ITokenPluginSettings extends IPluginSettings {
      * The settings of the voting escrow.
      */
     votingEscrow?: ITokenPluginSettingsEscrowSettings;
-    /**
-     * Set when the plugin is an objection stage, where members can only vote "No".
-     */
-    isObjection?: boolean;
 }

--- a/apps/app/src/shared/api/daoService/domain/pluginSettings.ts
+++ b/apps/app/src/shared/api/daoService/domain/pluginSettings.ts
@@ -3,4 +3,8 @@ export interface IPluginSettings {
      * Address of the plugin.
      */
     pluginAddress: string;
+    /**
+     * Set when the plugin is an objection stage, where members can only vote "No".
+     */
+    isObjection?: boolean;
 }


### PR DESCRIPTION
# Description

Adds app support for the Alchemix objection stage ([APP-1022](https://linear.app/aragon/issue/APP-1022/app-voting-on-the-objection-stage), subtask of APP-986).

When a proposal has the `isObjection` flag in its settings, the voting terminal keeps all three options visible but only "Object" (the No option relabelled) can be selected — Yes and Abstain are disabled with a help text explaining that only No votes are allowed during the objection phase. The copy changes accordingly ("Do you want to object to this proposal?", the vote dialog says "to object"). The flag lives on the shared `IPluginSettings` since the SPP module needs to read it as well.

Two more fixes that came out of testing the full flow end to end on Sepolia against the sandbox backend:

* Objection stages start with the first stage's tallies carried over, so their approval is reached the moment they open. The stage status logic treated that as final and showed "accepted" while the window was still running, which hid the voting UI completely. Objection stages are now treated like optimistic stages and stay active until the window closes (`sppStageUtils.isObjectionStage`).
* The vote eligibility guard probed `canVote` with a hardcoded Yes option. The objection contract only accepts No, so every user was told they are not eligible. The probe now uses No on objection bodies.

The results breakdown needed no changes here, the backend already seeds `votesByOption` with the carried-over tallies at proposal creation.

Needs the backend PRs aragon/app-backend#1478, aragon/app-backend#1481 and aragon/app-backend#1479 (deployed together to sandbox via aragon/app-backend#1484). Full flow verified on Sepolia: create → vote → advance → object, with the tally correctly moving from Yes to No after the objection. One open point for design: objection votes still show as "No" in the vote list, we might rename that to "Objected" later.

Note for reviewers: `sppStageUtils.getStageStatus` is also touched by #1256 (APP-985) — whichever merges second has a known one-line conflict in the `isOptimisticStage` computation.

## Type of Change

- [x] Minor: Feature (non-breaking change which adds new functionality)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project