### PR TITLE
Release @aragon/app@1.35.0

### DIFF
--- a/.changeset/app-1007-show-safe-body-proposal-creation-eligibility.md
+++ b/.changeset/app-1007-show-safe-body-proposal-creation-eligibility.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Show proposal creation eligibility for external Safe bodies in advanced processes

--- a/.changeset/app-117-safe-logo-process-details.md
+++ b/.changeset/app-117-safe-logo-process-details.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Show Safe branding for external Safe bodies on governance process details pages and preserve external body addresses instead of showing Unknown.

--- a/.changeset/app-998-chat-widget-copy-and-escape-hatches.md
+++ b/.changeset/app-998-chat-widget-copy-and-escape-hatches.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant-chat": minor
----
-
-Chat escape hatches point to support@aragon.org instead of the support portal; all widget copy is centralized in a single copy module

--- a/.changeset/app-998-support-chat-side-panel.md
+++ b/.changeset/app-998-support-chat-side-panel.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Support chat opens as a side panel the layout resizes around (toggled from the navigation bar) instead of a blur overlay

--- a/.changeset/assistant-chat-widget.md
+++ b/.changeset/assistant-chat-widget.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant-chat": minor
----
-
-Add the assistant-chat widget package: side-drawer support chat backed by the assistant service, with live collected-fields summary, file attachments (picker, drag-and-drop, paste) with upload progress, explicit ticket creation with retry, session rotation after a created issue and a monitoring DI seam for the host app.

--- a/.changeset/plausible-analytics-tracking.md
+++ b/.changeset/plausible-analytics-tracking.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Track "Create a DAO" and "Publish DAO" button clicks via Plausible Analytics, proxied through `/api/analytics` so ad blockers don't drop the events; enabled per environment via `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`.

--- a/.changeset/show-spp-external-proposer-eligibility.md
+++ b/.changeset/show-spp-external-proposer-eligibility.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Show proposal creation eligibility for SPP external proposer Safes

--- a/.github/actions/generate-release-summary/action.yml
+++ b/.github/actions/generate-release-summary/action.yml
@@ -1,5 +1,8 @@
 name: Generate Release Summary
-description: Generates a package-scoped PR/Slack summary from its release commit range.
+description: |
+  Generates the detailed, team-facing PR/Slack summary from the package's release commit range
+  (previous release tag → HEAD). The outward-facing release notes are built separately from the
+  changesets-generated CHANGELOG (see the finalize flow).
 
 inputs:
   package_name:
@@ -14,8 +17,9 @@ inputs:
     default: ""
   base_ref:
     description: |
-      Override the resolved release boundary (optional, not recommended).
-      Auto-detection finds the latest <package>@* tag and its mainline integration commit.
+      Override the release boundary ref (optional, not recommended).
+      Auto-detection uses the latest <package>@* tag: everything the tag already contains is
+      excluded, so PRs merged to main while that release was staging still get summarized here.
       Only use this for debugging or edge cases.
     required: false
     default: ""

--- a/.github/workflows/app-release-pr-deploy.yml
+++ b/.github/workflows/app-release-pr-deploy.yml
@@ -149,6 +149,7 @@ jobs:
           SLACK_CHANNEL_ID: op://kv_app_infra/SLACK_CHANNEL_ID/credential
           ARABOT_PAT: op://kv_app_infra/ARABOT_PAT/credential
           LINEAR_API_TOKEN: op://kv_app_infra/LINEAR_API_TOKEN/credential
+          SLACK_CODEOWNERS_GROUP_ID: op://kv_app_infra/SLACK_CODEOWNERS_GROUP_ID/credential
 
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -180,6 +181,21 @@ jobs:
             ${{ steps.summary.outputs.summary }}
 
             <!-- slack_ts: ${{ needs.notify-start.outputs.slack-ts }} -->
+
+      # Keep the Slack head message in sync with the PR description it just regenerated
+      # (chat.update); thread replies below it carry the per-deploy lifecycle updates.
+      - name: Update Slack head message
+        if: needs.notify-start.outputs.slack-ts && steps.secrets.outputs.SLACK_BOT_TOKEN
+        uses: ./.github/actions/slack-notify
+        with:
+          slack_bot_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack_channel_id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          update_ts: ${{ needs.notify-start.outputs.slack-ts }}
+          message: |
+            🚀 *${{ github.event.pull_request.title }} — Started* ${{ steps.secrets.outputs.SLACK_CODEOWNERS_GROUP_ID && format('<!subteam^{0}>', steps.secrets.outputs.SLACK_CODEOWNERS_GROUP_ID) || '' }}
+            *PR:* ${{ github.event.pull_request.html_url }}
+
+            ${{ steps.summary.outputs.summary }}
 
       - name: Notify Slack
         if: needs.notify-start.outputs.slack-ts && steps.secrets.outputs.SLACK_BOT_TOKEN

--- a/.github/workflows/scripts/generateReleaseSummary.js
+++ b/.github/workflows/scripts/generateReleaseSummary.js
@@ -29,47 +29,6 @@ const detectLatestPackageTag = (packageName, git = runGit) => {
     return out.split('\n')[0]?.trim() ?? '';
 };
 
-// Some release flows tag the tested release-branch SHA. Once that branch is merged, the first
-// mainline commit containing the tag is the integration commit and the real release boundary.
-const detectReleaseBaseFromTag = (tag, headRef = 'HEAD', git = runGit) => {
-    if (!tag || !isSafeGitRef(tag) || !isSafeGitRef(headRef)) {
-        return '';
-    }
-
-    const tagSha = git(['rev-list', '-n', '1', tag]);
-    const mergeBase = git(['merge-base', tag, headRef]);
-    if (!(tagSha && mergeBase)) {
-        return '';
-    }
-
-    const firstParentHistory = git(['rev-list', '--first-parent', headRef])
-        .split('\n')
-        .filter(Boolean);
-    if (firstParentHistory.includes(tagSha)) {
-        return tagSha;
-    }
-
-    if (mergeBase === tagSha) {
-        const candidates = git([
-            'rev-list',
-            '--first-parent',
-            '--reverse',
-            `${tag}..${headRef}`,
-        ])
-            .split('\n')
-            .filter(Boolean);
-
-        return (
-            candidates.find(
-                (candidate) => git(['merge-base', tag, candidate]) === tagSha,
-            ) ?? ''
-        );
-    }
-
-    // A divergent tag (for example an unmerged hotfix) falls back to its common cut point.
-    return mergeBase;
-};
-
 const readPathFilter = (filterPath, filterName) => {
     const filters = parse(fs.readFileSync(filterPath, 'utf8'));
     const patterns = filters?.[filterName];
@@ -109,6 +68,26 @@ const commitMatchesPathFilter = (commit, patterns, git = runGit) => {
 // and would otherwise leak into the summary as "Other Changes".
 const RELEASE_COMMIT_RE = /^Release @aragon\/[^@\s]+@\d+\.\d+\.\d+/;
 
+// A PR landed as a merge commit carries its PR title in the commit body; the subject only says
+// "Merge pull request #N from org/branch". Surface the title so the entry reads like a squash.
+const resolveCommitTitle = (commit, subject, git = runGit) => {
+    const merge = subject.match(/^Merge pull request #(\d+)\b/);
+    if (!merge) {
+        return subject;
+    }
+
+    const bodyTitle = git(['show', '-s', '--format=%b', commit])
+        .split('\n')
+        .map((line) => line.trim())
+        .find(Boolean);
+
+    return bodyTitle ? `${bodyTitle} (#${merge[1]})` : subject;
+};
+
+// Mainline commits since the release boundary. The boundary is the previous release tag itself:
+// everything the tag already contains is excluded, while PRs merged to main during the previous
+// release window (after its branch was cut, before it merged) stay in — they ship with THIS
+// release, even though they sit below the previous release's integration commit on the mainline.
 const collectScopedCommits = ({
     baseRef,
     headRef = 'HEAD',
@@ -134,7 +113,11 @@ const collectScopedCommits = ({
             ({ commit, subject }) =>
                 !RELEASE_COMMIT_RE.test(subject) &&
                 commitMatchesPathFilter(commit, patterns, git),
-        );
+        )
+        .map(({ commit, subject }) => ({
+            commit,
+            subject: resolveCommitTitle(commit, subject, git),
+        }));
 };
 
 // Helper to fetch Linear issue details
@@ -187,29 +170,19 @@ const generateSummary = async ({ core }) => {
         throw new Error(`Refusing unsafe package name: ${packageName}`);
     }
 
-    if (!baseRef) {
-        const latestTag = detectLatestPackageTag(packageName);
-        if (latestTag) {
-            const releaseBase = detectReleaseBaseFromTag(latestTag, 'HEAD');
-            if (releaseBase) {
-                baseRef = releaseBase;
-                console.log(`Auto-detected base from ${latestTag}: ${baseRef}`);
-            } else {
-                console.log(
-                    `Found tag ${latestTag} but its release base could not be resolved. Using full scoped history.`,
-                );
-            }
+    if (baseRef) {
+        if (!isSafeGitRef(baseRef)) {
+            throw new Error(`Refusing unsafe BASE_REF: ${baseRef}`);
+        }
+    } else {
+        baseRef = detectLatestPackageTag(packageName);
+        if (baseRef) {
+            console.log(`Auto-detected release boundary: ${baseRef}`);
         } else {
             console.log(
                 `No ${packageName}@* tags found. Treating this as the first release.`,
             );
         }
-    } else if (!isSafeGitRef(baseRef)) {
-        throw new Error(`Refusing unsafe BASE_REF: ${baseRef}`);
-    }
-
-    if (baseRef && !isSafeGitRef(baseRef)) {
-        throw new Error(`Refusing unsafe resolved base ref: ${baseRef}`);
     }
 
     const range = baseRef ? `${baseRef}..HEAD` : 'HEAD';
@@ -316,9 +289,9 @@ module.exports = {
     collectScopedCommits,
     commitMatchesPathFilter,
     detectLatestPackageTag,
-    detectReleaseBaseFromTag,
     generateSummary,
     readPathFilter,
+    resolveCommitTitle,
     runGit,
 };
 

--- a/.github/workflows/scripts/generateReleaseSummary.js
+++ b/.github/workflows/scripts/generateReleaseSummary.js
@@ -102,22 +102,27 @@ const collectScopedCommits = ({
         '--pretty=format:%H%x00%s',
     ]);
 
-    return log
-        .split('\n')
-        .filter(Boolean)
-        .map((line) => {
-            const [commit, subject] = line.split('\0');
-            return { commit, subject };
-        })
-        .filter(
-            ({ commit, subject }) =>
-                !RELEASE_COMMIT_RE.test(subject) &&
-                commitMatchesPathFilter(commit, patterns, git),
-        )
-        .map(({ commit, subject }) => ({
-            commit,
-            subject: resolveCommitTitle(commit, subject, git),
-        }));
+    return (
+        log
+            .split('\n')
+            .filter(Boolean)
+            .map((line) => {
+                const [commit, subject] = line.split('\0');
+                return { commit, subject };
+            })
+            // Resolve titles before filtering: a release PR merged with GitHub's default
+            // merge subject only reveals its "Release @aragon/…" title after resolution,
+            // and RELEASE_COMMIT_RE must see that title to drop the commit.
+            .map(({ commit, subject }) => ({
+                commit,
+                subject: resolveCommitTitle(commit, subject, git),
+            }))
+            .filter(
+                ({ commit, subject }) =>
+                    !RELEASE_COMMIT_RE.test(subject) &&
+                    commitMatchesPathFilter(commit, patterns, git),
+            )
+    );
 };
 
 // Helper to fetch Linear issue details

--- a/.github/workflows/scripts/generateReleaseSummary.test.js
+++ b/.github/workflows/scripts/generateReleaseSummary.test.js
@@ -122,6 +122,25 @@ test('keeps release-window commits and excludes everything the tag already ships
             '{"version":"0.2.0"}',
             'Release @aragon/assistant@0.2.0',
         );
+        // A release PR merged with GitHub's default merge subject only reveals its
+        // release title in the body: it must be dropped after title resolution.
+        git(repository, ['checkout', '-b', 'release/assistant/0.3.0']);
+        commitFile(
+            repository,
+            'packages/assistant-chat/package.json',
+            '{"version":"0.3.0"}',
+            'version packages',
+        );
+        git(repository, ['checkout', 'main']);
+        git(repository, [
+            'merge',
+            '--no-ff',
+            'release/assistant/0.3.0',
+            '-m',
+            'Merge pull request #44 from release/assistant/0.3.0',
+            '-m',
+            'Release @aragon/assistant@0.3.0',
+        ]);
 
         git(repository, ['checkout', '-b', 'feature/multi-commit']);
         commitFile(

--- a/.github/workflows/scripts/generateReleaseSummary.test.js
+++ b/.github/workflows/scripts/generateReleaseSummary.test.js
@@ -7,10 +7,18 @@ const assert = require('node:assert/strict');
 const {
     collectScopedCommits,
     detectLatestPackageTag,
-    detectReleaseBaseFromTag,
     readPathFilter,
+    resolveCommitTitle,
     runGit,
 } = require('./generateReleaseSummary');
+
+// Ignore the developer's git config: a global commit.gpgsign would make every
+// fixture commit block on a pinentry prompt.
+const gitEnvironment = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: os.devNull,
+    GIT_CONFIG_SYSTEM: os.devNull,
+};
 
 const createRepository = () => {
     const directory = fs.mkdtempSync(
@@ -19,6 +27,7 @@ const createRepository = () => {
     execFileSync('git', ['init', '--initial-branch=main'], {
         cwd: directory,
         stdio: 'ignore',
+        env: gitEnvironment,
     });
 
     return directory;
@@ -34,7 +43,11 @@ const git = (repository, args) =>
             'user.email=release-summary@example.com',
             ...args,
         ],
-        { cwd: repository, stdio: ['ignore', 'pipe', 'pipe'] },
+        {
+            cwd: repository,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: gitEnvironment,
+        },
     )
         .toString()
         .trim();
@@ -47,7 +60,7 @@ const commitFile = (repository, file, content, subject) => {
     git(repository, ['commit', '-m', subject]);
 };
 
-test('uses the package tag integration commit and filters first-parent history', () => {
+test('keeps release-window commits and excludes everything the tag already ships', () => {
     const repository = createRepository();
 
     try {
@@ -57,7 +70,7 @@ test('uses the package tag integration commit and filters first-parent history',
             'base',
             'feat: initial app',
         );
-        git(repository, ['tag', 'v9.0.0']);
+        // The release branch is cut here; the tag points at the tested branch SHA.
         git(repository, ['checkout', '-b', 'release/app/1.0.0']);
         commitFile(
             repository,
@@ -66,22 +79,22 @@ test('uses the package tag integration commit and filters first-parent history',
             'Release @aragon/app@1.0.0',
         );
         git(repository, ['tag', '@aragon/app@1.0.0']);
-        git(repository, ['tag', '@aragon/assistant@9.0.0']);
         git(repository, ['checkout', 'main']);
+        // Merged to main while the release branch was open: ships with the NEXT release and
+        // must stay in its summary even though it sits below the integration commit.
         commitFile(
             repository,
-            'apps/assistant/before-release-merge.ts',
-            'main advanced',
-            'feat: main advances while release is tested',
+            'apps/app/window.ts',
+            'window',
+            'feat(APP-9): merged during release window (#41)',
         );
         git(repository, [
             'merge',
             '--no-ff',
             'release/app/1.0.0',
             '-m',
-            'Merge pull request #1 from release/app/1.0.0',
+            'Release @aragon/app@1.0.0 (#1)',
         ]);
-        const integrationCommit = git(repository, ['rev-parse', 'HEAD']);
 
         commitFile(
             repository,
@@ -124,12 +137,15 @@ test('uses the package tag integration commit and filters first-parent history',
             'feat: internal branch commit B',
         );
         git(repository, ['checkout', 'main']);
+        // A PR landed as a merge commit: GitHub puts the PR title into the commit body.
         git(repository, [
             'merge',
             '--no-ff',
             'feature/multi-commit',
             '-m',
             'Merge pull request #43 from feature/multi-commit',
+            '-m',
+            'feat(APP-77): multi-commit feature',
         ]);
         commitFile(
             repository,
@@ -140,13 +156,8 @@ test('uses the package tag integration commit and filters first-parent history',
 
         const repositoryGit = (args) => runGit(args, { cwd: repository });
         const packageTag = detectLatestPackageTag('@aragon/app', repositoryGit);
-        const baseRef = detectReleaseBaseFromTag(
-            packageTag,
-            'HEAD',
-            repositoryGit,
-        );
         const commits = collectScopedCommits({
-            baseRef,
+            baseRef: packageTag,
             patterns: [
                 'apps/app/**',
                 'packages/assistant-chat/**',
@@ -156,14 +167,50 @@ test('uses the package tag integration commit and filters first-parent history',
         });
 
         assert.equal(packageTag, '@aragon/app@1.0.0');
-        assert.equal(baseRef, integrationCommit);
         assert.deepEqual(
             commits.map(({ subject }) => subject),
             [
-                'Merge pull request #43 from feature/multi-commit',
+                'feat(APP-77): multi-commit feature (#43)',
                 'feat(APP-123): add app feature (#42)',
                 'chore: update shared lockfile',
+                'feat(APP-9): merged during release window (#41)',
             ],
+        );
+    } finally {
+        fs.rmSync(repository, { recursive: true, force: true });
+    }
+});
+
+test('keeps the subject of a merge commit without a PR title in its body', () => {
+    const repository = createRepository();
+
+    try {
+        commitFile(repository, 'apps/app/a.txt', 'a', 'feat: base');
+        git(repository, ['checkout', '-b', 'feature/no-body']);
+        commitFile(repository, 'apps/app/b.txt', 'b', 'feat: branch work');
+        git(repository, ['checkout', 'main']);
+        git(repository, [
+            'merge',
+            '--no-ff',
+            'feature/no-body',
+            '-m',
+            'Merge pull request #7 from feature/no-body',
+        ]);
+
+        const repositoryGit = (args) => runGit(args, { cwd: repository });
+        const mergeCommit = repositoryGit(['rev-parse', 'HEAD']);
+
+        assert.equal(
+            resolveCommitTitle(
+                mergeCommit,
+                'Merge pull request #7 from feature/no-body',
+                repositoryGit,
+            ),
+            'Merge pull request #7 from feature/no-body',
+        );
+        assert.equal(
+            resolveCommitTitle('irrelevant', 'feat: squash subject (#8)'),
+            'feat: squash subject (#8)',
         );
     } finally {
         fs.rmSync(repository, { recursive: true, force: true });
@@ -194,7 +241,6 @@ test('treats a workspace without package tags as a first release', () => {
         );
         const commits = collectScopedCommits({
             baseRef: '',
-            packageName: '@aragon/new-app',
             patterns: ['apps/new-app/**'],
             git: repositoryGit,
         });

--- a/.github/workflows/scripts/generateVersionSummary.test.js
+++ b/.github/workflows/scripts/generateVersionSummary.test.js
@@ -7,6 +7,14 @@ const assert = require('node:assert/strict');
 const { generateSummary } = require('./generateVersionSummary');
 const { extractChangelogSection } = require('./readChangelog');
 
+// Ignore the developer's git config: a global commit.gpgsign would make every
+// fixture commit block on a pinentry prompt.
+const gitEnvironment = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: os.devNull,
+    GIT_CONFIG_SYSTEM: os.devNull,
+};
+
 const createWorkspaceRepository = () => {
     const directory = fs.realpathSync(
         fs.mkdtempSync(path.join(os.tmpdir(), 'version-summary-')),
@@ -14,6 +22,7 @@ const createWorkspaceRepository = () => {
     execFileSync('git', ['init', '--initial-branch=main'], {
         cwd: directory,
         stdio: 'ignore',
+        env: gitEnvironment,
     });
     writeFile(
         directory,
@@ -39,7 +48,11 @@ const git = (repository, args) =>
             'user.email=version-summary@example.com',
             ...args,
         ],
-        { cwd: repository, stdio: ['ignore', 'pipe', 'pipe'] },
+        {
+            cwd: repository,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: gitEnvironment,
+        },
     );
 
 const writeFile = (repository, file, content) => {

--- a/apps/app/CHANGELOG.md
+++ b/apps/app/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @aragon/app
 
+## 1.35.0
+
+### Minor Changes
+
+- [#1244](https://github.com/aragon/app/pull/1244) [`3aeab8d`](https://github.com/aragon/app/commit/3aeab8d18bb7c121284ba901ebc15460f382ddd6) Thanks [@milosh86](https://github.com/milosh86)! - Show proposal creation eligibility for external Safe bodies in advanced processes
+
+- [#1242](https://github.com/aragon/app/pull/1242) [`4977e3e`](https://github.com/aragon/app/commit/4977e3e565c58842853835796a0a040e28cb5b75) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Support chat opens as a side panel the layout resizes around (toggled from the navigation bar) instead of a blur overlay
+
+- [#1260](https://github.com/aragon/app/pull/1260) [`ff824a0`](https://github.com/aragon/app/commit/ff824a0f24360da7fd0e4090c537779b5adf8ba6) Thanks [@jjavieralv](https://github.com/jjavieralv)! - Track "Create a DAO" and "Publish DAO" button clicks via Plausible Analytics, proxied through `/api/analytics` so ad blockers don't drop the events; enabled per environment via `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`.
+
+- [#1254](https://github.com/aragon/app/pull/1254) [`207f3e3`](https://github.com/aragon/app/commit/207f3e373df062ef8f85101f275af2f0dd6eb671) Thanks [@milosh86](https://github.com/milosh86)! - Show proposal creation eligibility for SPP external proposer Safes
+
+### Patch Changes
+
+- [#1246](https://github.com/aragon/app/pull/1246) [`eeebd43`](https://github.com/aragon/app/commit/eeebd43d7435308c9f522afef383ed40c4933285) Thanks [@thekidnamedkd](https://github.com/thekidnamedkd)! - Show Safe branding for external Safe bodies on governance process details pages and preserve external body addresses instead of showing Unknown.
+
+- Updated dependencies [[`4977e3e`](https://github.com/aragon/app/commit/4977e3e565c58842853835796a0a040e28cb5b75), [`903fbfe`](https://github.com/aragon/app/commit/903fbfe7cf3b5c3112621c028830b8aace8c4cde)]:
+    - @aragon/assistant-chat@0.2.0
+
 ## 1.34.0
 
 ### Minor Changes

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/app",
-    "version": "1.34.0",
+    "version": "1.35.0",
     "description": "Human-centered DAO infrastructure",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",

--- a/packages/assistant-chat/CHANGELOG.md
+++ b/packages/assistant-chat/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @aragon/assistant-chat
+
+## 0.2.0
+
+### Minor Changes
+
+- [#1242](https://github.com/aragon/app/pull/1242) [`4977e3e`](https://github.com/aragon/app/commit/4977e3e565c58842853835796a0a040e28cb5b75) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Chat escape hatches point to support@aragon.org instead of the support portal; all widget copy is centralized in a single copy module
+
+- [#1231](https://github.com/aragon/app/pull/1231) [`903fbfe`](https://github.com/aragon/app/commit/903fbfe7cf3b5c3112621c028830b8aace8c4cde) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Add the assistant-chat widget package: side-drawer support chat backed by the assistant service, with live collected-fields summary, file attachments (picker, drag-and-drop, paste) with upload progress, explicit ticket creation with retry, session rotation after a created issue and a monitoring DI seam for the host app.

--- a/packages/assistant-chat/package.json
+++ b/packages/assistant-chat/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/assistant-chat",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Support-chat widget for the Aragon App, backed by the Aragon assistant service",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",


### PR DESCRIPTION
## Features
- Show proposal creation eligibility for SPP external proposer Safes ([#1254](https://github.com/aragon/app/pull/1254)) — [APP-1017: QA feedback](https://linear.app/aragon/issue/APP-1017/qa-feedback)
- Add Safe logo to process details ([#1246](https://github.com/aragon/app/pull/1246)) — [APP-117: Add Safe logo to governance process details page](https://linear.app/aragon/issue/APP-117/add-safe-logo-to-governance-process-details-page)
- Show proposal creation eligibility for external Safe bodies ([#1244](https://github.com/aragon/app/pull/1244)) — [APP-1007: [FE] Show proposal creation eligibility for Safe bodies](https://linear.app/aragon/issue/APP-1007/fe-show-proposal-creation-eligibility-for-safe-bodies)
- support chat side panel, email escape hatch, centralized copy ([#1242](https://github.com/aragon/app/pull/1242)) — [APP-998: Polish chat assistant UX and centralize chat copy](https://linear.app/aragon/issue/APP-998/polish-chat-assistant-ux-and-centralize-chat-copy)

## Fixes
- resolve merge-commit titles before the release-commit filter
- summarize all commits since the previous release tag

## Other Changes
- Added plausible ([#1260](https://github.com/aragon/app/pull/1260))
- ci: resolve the finalize guard's release scope at the tested SHA ([#1257](https://github.com/aragon/app/pull/1257))
- update dependencies, patch audit, prune overrides ([#1252](https://github.com/aragon/app/pull/1252))
- Bump actions/checkout ([#1247](https://github.com/aragon/app/pull/1247))



<!-- slack_ts: 1785167917.700809 -->
