### PR TITLE
fix(APP-1025): Add link to block explorer for external Safe address

### DIFF
--- a/.changeset/app-1025-add-link-to-safe-address.md
+++ b/.changeset/app-1025-add-link-to-safe-address.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Add link to block explorer for external Safe address in proposal creation eligibility

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.test.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.test.ts
@@ -1,12 +1,42 @@
+import * as GovUiKit from '@aragon/gov-ui-kit';
 import { addressUtils } from '@aragon/gov-ui-kit';
 import { renderHook } from '@testing-library/react';
 import type { IPermissionCheckGuardParams } from '@/modules/governance/types';
 import type { IDaoPlugin } from '@/shared/api/daoService';
+import * as daoService from '@/shared/api/daoService';
+import {
+    generateDao,
+    generateReactQueryResultSuccess,
+} from '@/shared/testUtils';
 import { generateSppStagePlugin } from '../../testUtils';
 import { VotingBodyBrandIdentity } from '../../types';
 import { useSppExternalPermissionCheckProposalCreation } from './useSppExternalPermissionCheckProposalCreation';
 
 describe('useSppExternalPermissionCheckProposalCreation', () => {
+    const useDaoSpy = jest.spyOn(daoService, 'useDao');
+    const useBlockExplorerSpy = jest.spyOn(GovUiKit, 'useBlockExplorer');
+
+    const mockChainEntityUrl = jest.fn(
+        ({ type, id }: { type: string; id?: string }) =>
+            `https://etherscan.io/${type}/${id ?? ''}`,
+    );
+
+    beforeEach(() => {
+        useDaoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: generateDao() }),
+        );
+        useBlockExplorerSpy.mockReturnValue({
+            buildEntityUrl: mockChainEntityUrl,
+            getBlockExplorer: jest.fn(),
+        } as ReturnType<typeof GovUiKit.useBlockExplorer>);
+    });
+
+    afterEach(() => {
+        useDaoSpy.mockReset();
+        useBlockExplorerSpy.mockReset();
+        mockChainEntityUrl.mockClear();
+    });
+
     const createParams = (
         plugin: Partial<Parameters<typeof generateSppStagePlugin>[0]>,
     ): IPermissionCheckGuardParams => ({
@@ -38,6 +68,10 @@ describe('useSppExternalPermissionCheckProposalCreation', () => {
                     {
                         term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.pluginLabelName',
                         definition: addressUtils.truncateAddress(safeAddress),
+                        link: {
+                            href: `https://etherscan.io/address/${safeAddress}`,
+                            isExternal: true,
+                        },
                     },
                     {
                         term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppExternalPermissionCheckProposalCreation/useSppExternalPermissionCheckProposalCreation.ts
@@ -1,9 +1,10 @@
-import { addressUtils } from '@aragon/gov-ui-kit';
+import { addressUtils, ChainEntityType } from '@aragon/gov-ui-kit';
 import type {
     IPermissionCheckGuardParams,
     IPermissionCheckGuardResult,
 } from '@/modules/governance/types';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { useDaoChain } from '@/shared/hooks/useDaoChain';
 import type { ISppStagePluginExternal } from '../../types';
 import { VotingBodyBrandIdentity } from '../../types';
 
@@ -21,7 +22,7 @@ export interface IUseSppExternalPermissionCheckProposalCreationParams
 export const useSppExternalPermissionCheckProposalCreation = (
     params: IUseSppExternalPermissionCheckProposalCreationParams,
 ): IPermissionCheckGuardResult | undefined => {
-    const { plugin } = params;
+    const { plugin, daoId } = params;
 
     const { t } = useTranslations();
 
@@ -30,6 +31,12 @@ export const useSppExternalPermissionCheckProposalCreation = (
     const isSafeProposalCreator =
         externalBody.brandId === VotingBodyBrandIdentity.SAFE &&
         externalBody.proposalCreationConditionAddress != null;
+
+    const { buildEntityUrl } = useDaoChain({ daoId });
+    const addressLink = buildEntityUrl({
+        type: ChainEntityType.ADDRESS,
+        id: externalBody.address,
+    });
 
     if (!isSafeProposalCreator) {
         return undefined;
@@ -48,6 +55,10 @@ export const useSppExternalPermissionCheckProposalCreation = (
                     definition: addressUtils.truncateAddress(
                         externalBody.address,
                     ),
+                    link: {
+                        href: addressLink,
+                        isExternal: true,
+                    },
                 },
                 {
                     term: t(

--- a/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.test.ts
+++ b/apps/app/src/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation/useSppPermissionCheckProposalCreation.test.ts
@@ -1,3 +1,4 @@
+import * as GovUiKit from '@aragon/gov-ui-kit';
 import { addressUtils } from '@aragon/gov-ui-kit';
 import { renderHook } from '@testing-library/react';
 import * as useSimulateProposalModule from '@/modules/governance/hooks/useSimulateProposal';
@@ -30,12 +31,27 @@ describe('useSppPermissionCheckProposalCreation', () => {
         pluginRegistryUtils,
         'getSlotFunction',
     );
+    const useBlockExplorerSpy = jest.spyOn(GovUiKit, 'useBlockExplorer');
+
+    const mockChainEntityUrl = jest.fn(
+        ({ type, id }: { type: string; id?: string }) =>
+            `https://etherscan.io/${type}/${id ?? ''}`,
+    );
+
+    beforeEach(() => {
+        useBlockExplorerSpy.mockReturnValue({
+            buildEntityUrl: mockChainEntityUrl,
+            getBlockExplorer: jest.fn(),
+        } as ReturnType<typeof GovUiKit.useBlockExplorer>);
+    });
 
     afterEach(() => {
         useDaoPluginsSpy.mockReset();
         useDaoSpy.mockReset();
         useSimulateProposalCreationSpy.mockReset();
         getSlotFunctionSpy.mockReset();
+        useBlockExplorerSpy.mockReset();
+        mockChainEntityUrl.mockClear();
     });
 
     const createTestParams = (guardResults: IPermissionCheckGuardResult[]) => {
@@ -257,6 +273,10 @@ describe('useSppPermissionCheckProposalCreation', () => {
                 {
                     term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.pluginLabelName',
                     definition: addressUtils.truncateAddress(safeAddress),
+                    link: {
+                        href: `https://etherscan.io/address/${safeAddress}`,
+                        isExternal: true,
+                    },
                 },
                 {
                     term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',
@@ -371,6 +391,10 @@ describe('useSppPermissionCheckProposalCreation', () => {
                 {
                     term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.pluginLabelName',
                     definition: addressUtils.truncateAddress(safeAddress),
+                    link: {
+                        href: `https://etherscan.io/address/${safeAddress}`,
+                        isExternal: true,
+                    },
                 },
                 {
                     term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',
@@ -420,6 +444,10 @@ describe('useSppPermissionCheckProposalCreation', () => {
                     definition: addressUtils.truncateAddress(
                         externalProposerAddress,
                     ),
+                    link: {
+                        href: `https://etherscan.io/address/${externalProposerAddress}`,
+                        isExternal: true,
+                    },
                 },
                 {
                     term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',
@@ -498,6 +526,10 @@ describe('useSppPermissionCheckProposalCreation', () => {
                     definition: addressUtils.truncateAddress(
                         externalProposerAddress,
                     ),
+                    link: {
+                        href: `https://etherscan.io/address/${externalProposerAddress}`,
+                        isExternal: true,
+                    },
                 },
                 {
                     term: 'app.plugins.spp.sppExternalPermissionCheckProposalCreation.function',


### PR DESCRIPTION
# Description

Adds a block explorer link on the external Safe address surfaced in the proposal creation eligibility settings (SPP plugin), so users can inspect the Safe directly instead of only seeing a truncated address.

## Type of Change

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [x] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project