### PR TITLE
fix(APP-1031): refresh vote action after indexing

### DIFF
--- a/.changeset/refresh-vote-actions-after-indexing.md
+++ b/.changeset/refresh-vote-actions-after-indexing.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Refresh connected-user vote and approval actions after their transactions finish indexing

--- a/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.test.tsx
+++ b/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.test.tsx
@@ -1,0 +1,134 @@
+import { GukModulesProvider } from '@aragon/gov-ui-kit';
+import type * as ReactQuery from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import { act, type ReactNode } from 'react';
+import * as Wagmi from 'wagmi';
+import * as DaoService from '@/shared/api/daoService';
+import { Network } from '@/shared/api/daoService';
+import type { IDialogLocation } from '@/shared/components/dialogProvider';
+import {
+    type ITransactionDialogProps,
+    TransactionDialog,
+} from '@/shared/components/transactionDialog';
+import {
+    generateDao,
+    generateDaoPlugin,
+    generateReactQueryResultSuccess,
+} from '@/shared/testUtils';
+import {
+    governanceServiceKeys,
+    type IProposal,
+} from '../../api/governanceService';
+import { generateProposal } from '../../testUtils';
+import {
+    type IVoteDialogParams,
+    type IVoteDialogProps,
+    VoteDialog,
+} from './voteDialog';
+
+jest.mock('@tanstack/react-query', () => {
+    const actual = jest.requireActual<typeof ReactQuery>(
+        '@tanstack/react-query',
+    );
+    return {
+        ...actual,
+        useQueryClient: jest.fn(),
+    };
+});
+
+jest.mock('@/shared/components/transactionDialog', () => {
+    const actual = jest.requireActual<
+        typeof import('@/shared/components/transactionDialog')
+    >('@/shared/components/transactionDialog');
+    return {
+        ...actual,
+        TransactionDialog: jest.fn((props: { children: ReactNode }) => (
+            <div data-testid="transaction-dialog">{props.children}</div>
+        )),
+    };
+});
+
+jest.mock('next/navigation', () => ({
+    useRouter: jest.fn(() => ({ refresh: jest.fn() })),
+    useParams: jest.fn(() => ({})),
+}));
+
+describe('<VoteDialog />', () => {
+    const useConnectionSpy = jest.spyOn(Wagmi, 'useConnection');
+    const useDaoSpy = jest.spyOn(DaoService, 'useDao');
+    const invalidateQueries = jest.fn();
+
+    beforeEach(() => {
+        useConnectionSpy.mockReturnValue({
+            address: '0xVoter',
+        } as unknown as Wagmi.UseConnectionReturnType);
+        useDaoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({
+                data: generateDao({
+                    plugins: [generateDaoPlugin({ address: '0xVotePlugin' })],
+                }),
+            }),
+        );
+        (useQueryClient as jest.Mock).mockReturnValue({ invalidateQueries });
+    });
+
+    afterEach(() => {
+        useConnectionSpy.mockReset();
+        useDaoSpy.mockReset();
+        invalidateQueries.mockReset();
+        (TransactionDialog as jest.Mock).mockClear();
+    });
+
+    const generateDialogLocation = (
+        proposal: IProposal,
+    ): IDialogLocation<IVoteDialogParams> => ({
+        id: 'test',
+        params: {
+            daoId: 'test-dao',
+            plugin: generateDaoPlugin({ address: proposal.pluginAddress }),
+            proposal,
+            vote: { label: 'yes', value: 1 },
+        },
+    });
+
+    const createTestComponent = (props: IVoteDialogProps) => (
+        <GukModulesProvider>
+            <VoteDialog {...props} />
+        </GukModulesProvider>
+    );
+
+    it('invalidates the connected user vote query after indexing completes', () => {
+        const proposal = generateProposal({
+            id: 'proposal-id',
+            network: Network.ETHEREUM_SEPOLIA,
+            pluginAddress: '0xVotePlugin',
+        });
+        const location = generateDialogLocation(proposal);
+
+        render(createTestComponent({ location }));
+
+        expect(invalidateQueries).not.toHaveBeenCalled();
+
+        const { onIndexed } = (TransactionDialog as jest.Mock).mock
+            .calls[0][0] as ITransactionDialogProps;
+
+        expect(onIndexed).toBeInstanceOf(Function);
+
+        act(() => {
+            onIndexed!({ slug: undefined });
+        });
+
+        const queryKey = governanceServiceKeys.voteList({
+            queryParams: {
+                proposalId: proposal.id,
+                pluginAddress: proposal.pluginAddress,
+                address: '0xVoter',
+                network: proposal.network,
+            },
+        });
+
+        expect(invalidateQueries).toHaveBeenCalledTimes(1);
+        expect(invalidateQueries).toHaveBeenCalledWith({ queryKey });
+    });
+});

--- a/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
@@ -3,6 +3,7 @@ import {
     type VoteIndicator,
     VoteProposalDataListItemStructure,
 } from '@aragon/gov-ui-kit';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useWalletAccount } from '@/modules/application/hooks/useWalletAccount';
 import { type IDaoPlugin, useDao } from '@/shared/api/daoService';
@@ -16,7 +17,10 @@ import {
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useStepper } from '@/shared/hooks/useStepper';
 import { daoUtils } from '@/shared/utils/daoUtils';
-import type { IProposal } from '../../api/governanceService';
+import {
+    governanceServiceKeys,
+    type IProposal,
+} from '../../api/governanceService';
 import type { IBuildVoteDataOption } from '../../types';
 import { proposalUtils } from '../../utils/proposalUtils';
 import { voteDialogUtils } from './voteDialogUtils';
@@ -72,6 +76,7 @@ export const VoteDialog: React.FC<IVoteDialogProps> = (props) => {
 
     const { t } = useTranslations();
     const router = useRouter();
+    const queryClient = useQueryClient();
 
     invariant(
         location.params != null,
@@ -95,6 +100,18 @@ export const VoteDialog: React.FC<IVoteDialogProps> = (props) => {
     const handlePrepareTransaction = () =>
         voteDialogUtils.buildTransaction({ proposal, vote, target });
 
+    const handleIndexed = () => {
+        const queryKey = governanceServiceKeys.voteList({
+            queryParams: {
+                proposalId: proposal.id,
+                pluginAddress: proposal.pluginAddress,
+                address,
+                network: proposal.network,
+            },
+        });
+        void queryClient.invalidateQueries({ queryKey });
+    };
+
     // Fallback to the parent plugin to display the slug of the parent proposal (if exists)
     const pluginAddress = plugin.parentPlugin ?? plugin.address;
     const slug = proposalUtils.getProposalSlug(
@@ -115,6 +132,7 @@ export const VoteDialog: React.FC<IVoteDialogProps> = (props) => {
                     : undefined
             }
             network={proposal.network}
+            onIndexed={handleIndexed}
             prepareTransaction={handlePrepareTransaction}
             stepper={stepper}
             submitLabel={t('app.governance.voteDialog.button.submit')}


### PR DESCRIPTION
# Description

Refresh the connected user's vote query when a proposal vote transaction finishes
indexing so the Vote/Approve action immediately reflects the indexed vote.

The proposal breakdown already refreshes through the server-rendered
proposal-by-slug data. The action has a separate, client-only,
wallet-address-filtered `useUserVote` query, which previously retained its stale
pre-vote result.

Linked intent: user-reported bug in the current task conversation. The local
operating-model contract is intentionally excluded from this PR at the user's
request.

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Implemented Change

- Wire `VoteDialog` to `TransactionDialog.onIndexed`.
- Invalidate the exact connected-user `voteList` key after backend indexing.
- Add a focused regression test covering the indexed callback and exact key.
- Add a patch changeset for `@aragon/app`.

## Proof

Proof decision:

- Artifacts added/updated:
  - `voteDialog.test.tsx`
  - Existing `TransactionDialog` indexed-callback tests
- Existing proof relied on:
  - `TransactionDialog` tests proving `onIndexed` fires once only after indexing
- Proof intentionally not added:
  - Wallet end-to-end test
- Rationale:
  - The regression is deterministic cache wiring with a stable component-test
    oracle; wallet automation would not provide better fault localization.
- Deferred/manual proof:
  - Browser smoke testing is deferred to preview review.

TDD evidence:

- Red: the focused `VoteDialog` test failed before the production change because
  `TransactionDialog.onIndexed` was undefined.
- Green: focused `VoteDialog` and `TransactionDialog` suites pass: 2 suites,
  33 tests.

Architecture:

- Impact: local
- Direction: the domain-aware `VoteDialog` invalidates the read model made stale
  by its indexed transaction; shared `TransactionDialog` remains
  governance-agnostic.
- Architectural proof: the exact
  `VoteDialog.onIndexed` → `governanceServiceKeys.voteList` →
  `useUserVote`/`useVoteList` key path is asserted by the regression test.
- ADR status: not required
- Approval before coding: satisfied by the user's implementation request

Commands run:

- [x] `pnpm --filter @aragon/app test -- --runInBand src/modules/governance/dialogs/voteDialog/voteDialog.test.tsx src/shared/components/transactionDialog/transactionDialog.test.tsx`
  - 2 suites and 33 tests passed.
- [x] `pnpm exec biome check apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.test.tsx`
  - Passed.
- [x] `pnpm validate:changesets`
  - Passed.
- [x] `git diff --check`
  - Passed.
- [ ] `pnpm type-check`
  - Repository baseline remains red on unchanged `@aragon/assistant-chat`
    gov-ui-kit/dropzone type mismatches; no changed-file diagnostic was reported.
- [ ] `pnpm lint:check`
  - Repository baseline remains red on checkout-wide CRLF formatting; Biome
    passes for both changed TypeScript files.

## Agent Trace Ledger

### Trace Summary

| Path | Type | Count | Pain Points | Status | Result | Notes |
|---|---:|---:|---:|---|---|---|
| prepare-change-space | skill | 1 | 0 | complete | success | Isolated task branch |
| draft-contract | skill | 1 | 1 | complete | partial | Scope corrected after human symptom clarification |
| proof-first-cycle | skill | 1 | 0 | complete | success | Focused red→green proof |
| implement-change | skill | 1 | 0 | complete | success | Exact vote-list invalidation |
| review-change | skill | 3 | 1 | complete | success | Contract re-reviewed; implementation approved |
| promote-learning | skill | 1 | 0 | complete | success | No new durable operating-model rule |
| open-reviewable-pr | skill | 1 | 1 | complete | success | Contract excluded and preserved locally |
| Codex | agent | 1 | 3 | complete | partial | Product proof green; unrelated root baseline red |

<details>
<summary>Detailed Agent Trace Ledger</summary>

```yaml
agent_trace:
  - step: 1
    event_type: intent
    stage: intent
    actor: human
    summary: Fix the stale Vote/Approve action after successful indexing.
    artifacts: []
    evidence:
      - User-provided reproduction and expected behavior.
    outcome: Task classified as a medium-risk bug.

  - step: 2
    event_type: skill_decision
    stage: intent
    actor: Codex
    summary: Prepare an isolated task branch before repository mutation.
    artifacts:
      - agent/vote-button-indexed-state
    evidence:
      - Git branch and working-tree preflight.
    outcome: Safe change space established.
    skill:
      name: prepare-change-space
      source: C:/dev/agent-framework/.agents/skills/prepare-change-space/SKILL.md
      trigger:
        type: operating_model_required
        evidence: Non-trivial repository mutation from raw intent.
      status: invoked
      announced: true
      read: true
      applied: true
      usefulness: required
      result: success

  - step: 3
    event_type: skill_decision
    stage: contract
    actor: Codex
    summary: Translate the reported bug into a technical and proof contract.
    artifacts:
      - Local contract excluded from this PR by user request.
    evidence:
      - Proposal breakdown uses proposal data while Vote/Approve uses useUserVote.
    outcome: Contract corrected to target only the connected-user vote cache.
    pain_points:
      - "rework: tried interpreting Approve as including the SPP result flow; blocker was the human-observed breakdown/button divergence; pivoted to the address-filtered useUserVote cache and removed all SPP changes"
    skill:
      name: draft-contract
      source: C:/dev/agent-framework/.agents/skills/draft-contract/SKILL.md
      trigger:
        type: user_named
        evidence: User explicitly requested contract-first implementation.
      status: invoked
      announced: true
      read: true
      applied: true
      usefulness: required
      result: partial

  - step: 4
    event_type: skill_decision
    stage: proof
    actor: Codex
    summary: Add focused proof before changing production behavior.
    artifacts:
      - apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.test.tsx
    evidence:
      - Red failure because onIndexed was undefined; green after exact invalidation.
    outcome: Stable red→green regression proof established.
    skill:
      name: proof-first-cycle
      source: C:/dev/agent-framework/.agents/skills/proof-first-cycle/SKILL.md
      trigger:
        type: contract_required
        evidence: Behaviorally precise cache-wiring regression with a stable oracle.
      status: invoked
      announced: true
      read: true
      applied: true
      usefulness: required
      result: success

  - step: 5
    event_type: skill_decision
    stage: change
    actor: Codex
    summary: Implement the smallest contract-authorized cache invalidation.
    artifacts:
      - apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
      - .changeset/refresh-vote-actions-after-indexing.md
    evidence:
      - Exact governanceServiceKeys.voteList invalidation on onIndexed.
    outcome: Token, lock-to-vote, and multisig action state refetches after indexing.
    skill:
      name: implement-change
      source: C:/dev/agent-framework/.agents/skills/implement-change/SKILL.md
      trigger:
        type: contract_required
        evidence: Approved connected-user vote/approval slice.
      status: invoked
      announced: true
      read: true
      applied: true
      usefulness: required
      result: success

  - step: 6
    event_type: skill_decision
    stage: review
    actor: contract reviewer
    summary: Review contract lifecycle, authority, scope, and proof mapping.
    artifacts:
      - Local contract excluded from this PR by user request.
    evidence:
      - First gate found mixed pre/post implementation statuses; second gate passed.
    outcome: Contract approved before final implementation review.
    pain_points:
      - "rework: tried reviewing a contract that still carried completed statuses and task-close evidence; blocker was mixed lifecycle state; pivoted to a pre-implementation contract and repeated the gate"
    skill:
      name: review-change
      source: C:/dev/agent-framework/.agents/skills/review-change/SKILL.md
      trigger:
        type: user_named
        evidence: User explicitly required contract review.
      status: invoked
      announced: true
      read: true
      applied: true
      usefulness: required
      result: partial

  - step: 7
    event_type: skill_decision
    stage: review
    actor: implementation reviewer
    summary: Review final implementation against scope, proof, and architecture.
    artifacts:
      - Three-file committed diff.
    evidence:
      - No SPP diff; focused Jest, Biome, changeset, and whitespace checks passed.
    outcome: No implementation blockers.
    skill:
      name: review-change
      source: C:/dev/agent-framework/.agents/skills/review-change/SKILL.md
      trigger:
        type: user_named
        evidence: User explicitly required implementation review.
      status: invoked
      announced: true
      read: true
      applied: true
      usefulness: required
      result: success

  - step: 8
    event_type: verification
    stage: review
    actor: Codex
    summary: Run focused and repository verification.
    artifacts:
      - Focused test, lint, type-check, and changeset outputs.
    evidence:
      - Focused checks green; unrelated root baselines disclosed.
    outcome: Product proof passed; repository-wide baseline remains red.
    pain_points:
      - "slowdown: tried direct Corepack execution; blocker was user-cache EPERM and Turbo package-manager lookup; pivoted to approved cache access and a temporary local pnpm shim"
      - "noise: tried an early app-only type-check; blocker was bypassing the documented Turbo dependency graph; pivoted to the root graph command"
      - "incomplete baseline: tried root type-check and lint; blocker was pre-existing assistant-chat type mismatches and checkout-wide CRLF formatting; pivoted to focused proof plus changed-file checks and explicit disclosure"

  - step: 9
    event_type: skill_decision
    stage: learning
    actor: Codex
    summary: Audit task friction and decide whether to promote durable memory.
    artifacts:
      - Pain-Point RCA and Learning Review in this PR body.
    evidence:
      - Human correction, review pivots, environment friction, and baseline failures.
    outcome: Regression test retained; no new operating-model rule promoted.
    skill:
      name: promote-learning
      source: C:/dev/agent-framework/.agents/skills/promote-learning/SKILL.md
      trigger:
        type: operating_model_required
        evidence: Implementation and review completed before publication.
      status: invoked
      announced: true
      read: true
      applied: true
      usefulness: required
      result: success

  - step: 10
    event_type: skill_decision
    stage: publication
    actor: Codex
    summary: Publish only the staged implementation files and exclude the contract.
    artifacts:
      - Commit e4c25fed
      - This PR
    evidence:
      - Cached diff contained exactly three files; post-commit worktree was clean.
    outcome: Reviewable PR prepared without the local contract.
    pain_points:
      - "slowdown: tried preserving the excluded contract under .agents/local; blocker was sandbox write protection; pivoted to the equivalent gitignored .claude/local area"
    skill:
      name: open-reviewable-pr
      source: C:/dev/app/.agents/skills/open-reviewable-pr/SKILL.md
      trigger:
        type: user_named
        evidence: User requested a PR containing only staged files.
      status: invoked
      announced: true
      read: true
      applied: true
      usefulness: required
      result: success
```

</details>

## Explicit Non-Changes

- No proposal-by-slug or SPP cache invalidation.
- No changes to voting eligibility, approval semantics, or transaction building.
- No changes to shared `TransactionDialog` behavior or query-key shapes.
- No auth, permissions, API, storage, CI, or release-workflow changes.
- The local operating-model contract is not included.

## Risk

Medium. The change is local and reversible, but it affects the post-transaction
state shown for governance actions. The exact query key and indexed-only timing
are covered by focused tests.

## Developer Checklist

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [x] Confirmed there are no new warnings on focused automated tests
- [x] Selected the correct base branch (`main`)
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed scope contains only the intended three files
- [ ] Confirmed the full pipeline checks are not failing

## Review Checklist

- [x] The implementation contains only the allowed change.
- [x] Required focused proof exists and passes.
- [x] Tests, lint, CI, and validation were not weakened.
- [x] The critical cache path received independent agent review.
- [ ] Human preview review completed.

## Learning

Context evaluated:

- Full task conversation, local trace, verification output, contract and
  implementation reviews, committed diff, and prior Learning (none).

Pain-Point RCA:

| ID | Grouped IDs | Evidence | Root Cause | Action Decision | Disposition |
|---|---|---|---|---|---|
| RCA-1 | PP-1, SR-1 | PP-1 and SR-1: initial SPP scope and partial contract result contradicted the progress-bar/button symptom | The first interpretation mapped “Approve” to another flow instead of tracing each UI consumer's cache owner | Remove SPP scope and preserve the exact distinction in the regression test and PR explanation | preserve |
| RCA-2 | PP-2, SR-2 | PP-2 and SR-2: contract review was partial and needed a second gate after lifecycle-state correction | Completion evidence was added before the revised contract re-entered its pre-implementation gate | Fix the artifact state and repeat review; existing review procedure caught the issue | no-op |
| PP-3 |  | PP-3: Corepack EPERM and Turbo lookup required a temporary shim | One-off Windows sandbox and package-manager path constraint prevented normal binary discovery | Use approved cache access and temporary shim; remove shim after checks | no-op |
| PP-4 |  | PP-4: early app-only type-check produced dependency noise | The documented root Turbo command was not followed initially, bypassing dependency ordering | Use root command; existing `AGENTS.md` guidance is sufficient | no-op |
| PP-5 |  | PP-5: root checks remain red on unrelated files | Pre-existing assistant-chat type drift and Windows CRLF checkout state are outside this diff | Disclose; keep separate from this bug fix | follow-up |
| PP-6 |  | PP-6: `.agents/local` archive move was blocked | Sandbox policy protects the shared `.agents` tree from writes even for ignored local paths | Preserve the excluded local artifact in gitignored `.claude/local` | no-op |

Auditor:

- [x] `node scripts/audit-learning-evidence.mjs --body <file>`
- Result: passed against the prepared PR body before publication.

Learning Review:

| Signal | Impact | Causal Analysis | Disposition |
|---|---|---|---|
| Proposal aggregates refreshed while the action stayed stale | The first scope included an unnecessary SPP path and required human correction | The two UI areas consume different cache owners; the focused test now preserves that task-specific boundary | preserve |
| Contract lifecycle evidence was mixed during re-review | Required another contract iteration | Existing review detected and corrected the artifact state, so no new rule is justified from one occurrence | no-op |
| Local package-manager and sandbox restrictions | Added verification and publication setup time | Environment-specific friction was resolved without changing repository behavior | no-op |
| Root graph checks expose unrelated baseline failures | Prevents a fully green local repository check | This is existing repository debt outside the authorized bug scope | follow-up |

Learning Decision:

- Preserved: exact post-index connected-user vote-query regression proof.
- Added: no new durable operating-model memory.
- Superseded: initial SPP interpretation.
- Durable action: focused component regression test.
- Follow-up: repair unrelated repository type/lint baselines under separate intent.
