### PR TITLE
fix(APP-986): Revert excessive copy logic in objection plugin

### DIFF
--- a/apps/app/src/assets/locales/en.json
+++ b/apps/app/src/assets/locales/en.json
@@ -3485,10 +3485,7 @@
             "approveYesDescription": ", I approve",
             "label": "Do you want to {{label}} this proposal?",
             "no": "No",
-            "object": "Object",
-            "objectionDescription": ", I object",
-            "objectionHelpText": "During the objection phase you can only vote \"No\" to object to the proposal.",
-            "objectionLabel": "object to",
+            "objectionHelpText": "During the objection phase you can only vote No.",
             "vetoLabel": "veto",
             "vetoNoDescription": ", I don't veto",
             "vetoYesDescription": ", I veto",
@@ -3496,7 +3493,6 @@
           },
           "voteDescription": {
             "approve": "to approve",
-            "objection": "to object",
             "veto": "to veto"
           }
         },

--- a/apps/app/src/daos/alchemix/components/alchemixSubmitVote/alchemixSubmitVote.test.tsx
+++ b/apps/app/src/daos/alchemix/components/alchemixSubmitVote/alchemixSubmitVote.test.tsx
@@ -201,8 +201,10 @@ describe('<AlchemixSubmitVote /> component', () => {
         ).toBeInTheDocument();
     });
 
-    it('disables the option the delegate voted on and opens the vote dialog with the override vote type', async () => {
+    it('uses normal confirmation copy for an objection override', async () => {
         const open = jest.fn();
+        const proposal = generateTokenProposal();
+        proposal.settings.isObjection = true;
         useDialogContextSpy.mockReturnValue(generateDialogContext({ open }));
         useAlchemixOverrideStatusSpy.mockReturnValue(
             buildOverrideStatus({
@@ -216,7 +218,7 @@ describe('<AlchemixSubmitVote /> component', () => {
             }),
         );
 
-        render(createTestComponent());
+        render(createTestComponent({ isVeto: true, proposal }));
 
         await userEvent.click(
             screen.getByRole('button', {
@@ -245,6 +247,8 @@ describe('<AlchemixSubmitVote /> component', () => {
             expect.objectContaining({
                 params: expect.objectContaining({
                     vote: expect.objectContaining({
+                        labelDescription:
+                            'app.plugins.token.tokenSubmitVote.voteDescription.veto',
                         value: VoteOption.NO,
                         voteType: 'override',
                     }),

--- a/apps/app/src/daos/alchemix/components/alchemixSubmitVote/alchemixSubmitVote.tsx
+++ b/apps/app/src/daos/alchemix/components/alchemixSubmitVote/alchemixSubmitVote.tsx
@@ -210,7 +210,7 @@ export const AlchemixSubmitVote: React.FC<IAlchemixSubmitVoteProps> = (
             voteLabel === 'abstain'
                 ? undefined
                 : t(
-                      `app.plugins.token.tokenSubmitVote.voteDescription.${settings.isObjection ? 'objection' : isVeto ? 'veto' : 'approve'}`,
+                      `app.plugins.token.tokenSubmitVote.voteDescription.${isVeto ? 'veto' : 'approve'}`,
                   );
         // Without override permission the delegated power cannot be moved: leave the vote type unset so that the
         // DAO-level build-vote-data slot falls back to the plain vote of the token plugin.

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenSubmitVoteDefault.test.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenSubmitVoteDefault.test.tsx
@@ -98,11 +98,13 @@ describe('<TokenSubmitVoteDefault /> component', () => {
         expect(check).toHaveBeenCalled();
     });
 
-    it('shows the vote options and opens the vote dialog with the selected option', async () => {
+    it('uses normal confirmation copy when selecting No during objection', async () => {
         const open = jest.fn();
+        const proposal = generateTokenProposal();
+        proposal.settings.isObjection = true;
         useDialogContextSpy.mockReturnValue(generateDialogContext({ open }));
 
-        render(createTestComponent());
+        render(createTestComponent({ isVeto: true, proposal }));
 
         await userEvent.click(
             screen.getByRole('button', {
@@ -116,7 +118,7 @@ describe('<TokenSubmitVoteDefault /> component', () => {
         expect(submitButton).toBeDisabled();
 
         await userEvent.click(
-            screen.getByRole('radio', { name: /tokenSubmitVote.options.yes/ }),
+            screen.getByRole('radio', { name: /tokenSubmitVote.options.no/ }),
         );
         await userEvent.click(submitButton);
 
@@ -124,7 +126,11 @@ describe('<TokenSubmitVoteDefault /> component', () => {
             GovernanceDialogId.VOTE,
             expect.objectContaining({
                 params: expect.objectContaining({
-                    vote: expect.objectContaining({ value: VoteOption.YES }),
+                    vote: expect.objectContaining({
+                        labelDescription:
+                            'app.plugins.token.tokenSubmitVote.voteDescription.veto',
+                        value: VoteOption.NO,
+                    }),
                 }),
             }),
         );

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenSubmitVoteDefault.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenSubmitVoteDefault.tsx
@@ -82,7 +82,7 @@ export const TokenSubmitVoteDefault: React.FC<ITokenSubmitVoteDefaultProps> = (
             voteLabel === 'abstain'
                 ? undefined
                 : t(
-                      `app.plugins.token.tokenSubmitVote.voteDescription.${proposal.settings.isObjection ? 'objection' : isVeto ? 'veto' : 'approve'}`,
+                      `app.plugins.token.tokenSubmitVote.voteDescription.${isVeto ? 'veto' : 'approve'}`,
                   );
         const vote = {
             value: Number(selectedOption),

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.test.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.test.tsx
@@ -5,6 +5,10 @@ import {
 } from './tokenVotingOptions';
 
 describe('<TokenVotingOptions /> component', () => {
+    const optionKey = 'app.plugins.token.tokenSubmitVote.options';
+    const getOptionText = (key: string) =>
+        screen.getByText(`${optionKey}.${key}`);
+
     const createTestComponent = (props?: Partial<ITokenVotingOptionsProps>) => {
         const completeProps: ITokenVotingOptionsProps = {
             onChange: jest.fn(),
@@ -16,43 +20,29 @@ describe('<TokenVotingOptions /> component', () => {
 
     it('renders the yes, abstain and no vote options', () => {
         render(createTestComponent());
-        expect(
-            screen.getByText('app.plugins.token.tokenSubmitVote.options.yes'),
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(
-                'app.plugins.token.tokenSubmitVote.options.abstain',
-            ),
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText('app.plugins.token.tokenSubmitVote.options.no'),
-        ).toBeInTheDocument();
+        ['yes', 'abstain', 'no'].forEach((key) =>
+            expect(getOptionText(key)).toBeInTheDocument(),
+        );
     });
 
-    it('disables all options but object and renders a help text when the isObjection property is set', () => {
-        render(createTestComponent({ isObjection: true }));
-
-        const objectOption = screen.getByText(
-            'app.plugins.token.tokenSubmitVote.options.object',
-        );
-        expect(objectOption).toBeInTheDocument();
-        expect(objectOption.closest('button')).toBeEnabled();
-
-        expect(
-            screen
-                .getByText('app.plugins.token.tokenSubmitVote.options.yes')
-                .closest('button'),
-        ).toBeDisabled();
-        expect(
-            screen
-                .getByText('app.plugins.token.tokenSubmitVote.options.abstain')
-                .closest('button'),
-        ).toBeDisabled();
+    it('uses approval copy and only enables No for objection proposals', () => {
+        render(createTestComponent({ isObjection: true, isVeto: true }));
 
         expect(
             screen.getByText(
-                'app.plugins.token.tokenSubmitVote.options.objectionHelpText',
+                `${optionKey}.label (label=${optionKey}.vetoLabel)`,
             ),
         ).toBeInTheDocument();
+
+        const noOption = getOptionText('no').closest('button');
+        expect(noOption).toBeEnabled();
+        expect(noOption).toHaveClass('active:border-success-500');
+        expect(getOptionText('vetoNoDescription')).toBeInTheDocument();
+        const yesOption = getOptionText('yes').closest('button');
+        expect(yesOption).toBeDisabled();
+        expect(yesOption).toHaveClass('active:border-critical-500');
+        expect(getOptionText('vetoYesDescription')).toBeInTheDocument();
+        expect(getOptionText('abstain').closest('button')).toBeDisabled();
+        expect(getOptionText('objectionHelpText')).toBeInTheDocument();
     });
 });

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.tsx
@@ -71,18 +71,12 @@ export const TokenVotingOptions: React.FC<ITokenVotingOptionsProps> = (
             description: undefined,
         },
         {
-            label: t(
-                `app.plugins.token.tokenSubmitVote.options.${isObjection ? 'object' : 'no'}`,
-            ),
+            label: t('app.plugins.token.tokenSubmitVote.options.no'),
             value: VoteOption.NO.toString(),
-            variant: isVeto && !isObjection ? 'success' : 'critical',
-            description: isObjection
-                ? t(
-                      'app.plugins.token.tokenSubmitVote.options.objectionDescription',
-                  )
-                : t(
-                      `app.plugins.token.tokenSubmitVote.options.${isVeto ? 'vetoNoDescription' : 'approveNoDescription'}`,
-                  ),
+            variant: isVeto ? 'success' : 'critical',
+            description: t(
+                `app.plugins.token.tokenSubmitVote.options.${isVeto ? 'vetoNoDescription' : 'approveNoDescription'}`,
+            ),
         },
     ] as const;
 
@@ -97,15 +91,11 @@ export const TokenVotingOptions: React.FC<ITokenVotingOptionsProps> = (
             }
             id={id}
             label={t('app.plugins.token.tokenSubmitVote.options.label', {
-                label: isObjection
-                    ? t(
-                          'app.plugins.token.tokenSubmitVote.options.objectionLabel',
-                      )
-                    : isVeto
-                      ? t('app.plugins.token.tokenSubmitVote.options.vetoLabel')
-                      : t(
-                            'app.plugins.token.tokenSubmitVote.options.approveLabel',
-                        ),
+                label: isVeto
+                    ? t('app.plugins.token.tokenSubmitVote.options.vetoLabel')
+                    : t(
+                          'app.plugins.token.tokenSubmitVote.options.approveLabel',
+                      ),
             })}
             useCustomWrapper={true}
         >


### PR DESCRIPTION
## Summary

- Preserve standard approval/veto prompts, option copy, styling, and confirmation copy during objection voting.
- Keep objection-specific UI behavior limited to disabling Yes/Abstain and showing the requested No-only help text.
- Remove unused objection presentation strings and cover both default and Alchemix voting paths.

BLOCKED BY:
- We need clarity on whether there should be any changes in the token voting non-DAO slot code.
- We need clarity on whether or not we can call a view function on the contract to see if they already voted in stage 1 (and then change button to "Change vote").

## Why

The objection flag had been treated as a presentation mode, replacing normal voting copy in the selector and confirmation dialog. Objection should only restrict the available vote to No; it should not alter how a normal approval or veto vote is presented.

## User impact

Members see the standard voting experience and confirmation wording. During an objection phase, Yes and Abstain are disabled, No remains enabled, and the help text explains the restriction.

## Verification

- `pnpm --filter @aragon/app test -- --runInBand tokenVotingOptions.test.tsx tokenSubmitVoteDefault.test.tsx alchemixSubmitVote.test.tsx` — 3 suites, 26 tests passed.
- Biome check on the seven changed files — passed.
- Broader app type-check remains blocked by unrelated existing workspace errors; no error referenced the modified voting-options component.