### PR TITLE
Release @aragon/app@1.36.0

### DIFF
--- a/.changeset/app-1001-filter-osx-related-actions-from-action-builder.md
+++ b/.changeset/app-1001-filter-osx-related-actions-from-action-builder.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Filter OSx-related actions from the action builder when the DAO lacks the required permission

--- a/.changeset/app-1016-assistant-chat-assistant-ui.md
+++ b/.changeset/app-1016-assistant-chat-assistant-ui.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant-chat": minor
----
-
-Rebuild the assistant-chat widget on assistant-ui with the agentic backend: streamed transcript and a `createLinearTicket` approval card (draft → Create/Dismiss → success or retry), a greeting screen with intake shortcuts and request history, and our own composer.

--- a/.changeset/app-1023-stuck-transaction-recovery.md
+++ b/.changeset/app-1023-stuck-transaction-recovery.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Surface a warning with an explicitly confirmed retry when a transaction stays unconfirmed past 90 seconds, expire stale persisted pending-transaction records, pin receipt polling to the transaction chain, and show an actionable error for underpriced replacement transactions

--- a/.changeset/app-1025-add-link-to-safe-address.md
+++ b/.changeset/app-1025-add-link-to-safe-address.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Add link to block explorer for external Safe address in proposal creation eligibility

--- a/.changeset/app-984-alchemix-delegate-vote-overrides.md
+++ b/.changeset/app-984-alchemix-delegate-vote-overrides.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Support delegate vote overrides for Alchemix Token Voting: eligible delegators can override their delegate's vote (or vote and override atomically) from the voting terminal, and overridden votes are reflected in the votes list

--- a/.changeset/app-985-mixed-approving-vetoing-bodies.md
+++ b/.changeset/app-985-mixed-approving-vetoing-bodies.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Support mixed approving and vetoing bodies within a single SPP stage

--- a/.changeset/app-985-mixed-body-ui-feedback.md
+++ b/.changeset/app-985-mixed-body-ui-feedback.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Revise mixed-body UI: remove approve/veto decision tags, move the governance-type field to its own setup-body wizard step, display stage thresholds in the stage settings list and update governance copy

--- a/.changeset/app-999-analytics-taxonomy-cleanup.md
+++ b/.changeset/app-999-analytics-taxonomy-cleanup.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Rename the Plausible analytics `transactionKind` prop to `transactionTypeEvent`, stop sending the backend `transactionType` enum on analytics events, and document event sources and dashboard goal registration

--- a/.changeset/app-999-analytics-taxonomy-cleanup.md
+++ b/.changeset/app-999-analytics-taxonomy-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Rename the Plausible analytics `transactionKind` prop to `transactionTypeEvent`, stop sending the backend `transactionType` enum on analytics events, and document event sources and dashboard goal registration

--- a/.changeset/app-999-plausible-analytics-event-hooks.md
+++ b/.changeset/app-999-plausible-analytics-event-hooks.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Instrument privacy-safe Plausible custom events across the wizard, transaction and proposal-action flows, sent through the shared analytics pipeline

--- a/.changeset/design-sync-claude-design.md
+++ b/.changeset/design-sync-claude-design.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Add design-sync setup for the "Aragon App Design System" Claude Design project to enable future re-syncs.

--- a/.changeset/objection-stage-voting.md
+++ b/.changeset/objection-stage-voting.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": minor
----
-
-Restrict voting to an "Object" option on objection-stage proposals

--- a/apps/app/CHANGELOG.md
+++ b/apps/app/CHANGELOG.md
@@ -1,5 +1,32 @@
 # @aragon/app
 
+## 1.36.0
+
+### Minor Changes
+
+- [#1266](https://github.com/aragon/app/pull/1266) [`8091efb`](https://github.com/aragon/app/commit/8091efb8bf88dfeb9001589f23ed7c7789963edd) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Support delegate vote overrides for Alchemix Token Voting: eligible delegators can override their delegate's vote (or vote and override atomically) from the voting terminal, and overridden votes are reflected in the votes list
+
+- [#1256](https://github.com/aragon/app/pull/1256) [`4119b3c`](https://github.com/aragon/app/commit/4119b3cb25d5260ad6899d5f9d2e993a99262c55) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Support mixed approving and vetoing bodies within a single SPP stage
+
+- [#1258](https://github.com/aragon/app/pull/1258) [`93154db`](https://github.com/aragon/app/commit/93154db76fd714caef1a2cb01a6c350fa0935bcf) Thanks [@thekidnamedkd](https://github.com/thekidnamedkd)! - Instrument privacy-safe Plausible custom events across the wizard, transaction and proposal-action flows, sent through the shared analytics pipeline
+
+- [#1259](https://github.com/aragon/app/pull/1259) [`c4f3a60`](https://github.com/aragon/app/commit/c4f3a609eeb53b7b1b6107b15d5182f4ffd2c1c7) Thanks [@harryburger](https://github.com/harryburger)! - Restrict voting to an "Object" option on objection-stage proposals
+
+### Patch Changes
+
+- [#1253](https://github.com/aragon/app/pull/1253) [`ae5dd8f`](https://github.com/aragon/app/commit/ae5dd8ffa3a0bc8df73f561e6fef3770d9f6da10) Thanks [@milosh86](https://github.com/milosh86)! - Filter OSx-related actions from the action builder when the DAO lacks the required permission
+
+- [#1262](https://github.com/aragon/app/pull/1262) [`3e2b8c5`](https://github.com/aragon/app/commit/3e2b8c54213fafbf50ce493e871a6d5d0b821a19) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Surface a warning with an explicitly confirmed retry when a transaction stays unconfirmed past 90 seconds, expire stale persisted pending-transaction records, pin receipt polling to the transaction chain, and show an actionable error for underpriced replacement transactions
+
+- [#1267](https://github.com/aragon/app/pull/1267) [`fef1057`](https://github.com/aragon/app/commit/fef10573f2d153eb76bd5f0fee3a6927a5f5eeb5) Thanks [@milosh86](https://github.com/milosh86)! - Add link to block explorer for external Safe address in proposal creation eligibility
+
+- [#1268](https://github.com/aragon/app/pull/1268) [`302cdda`](https://github.com/aragon/app/commit/302cdda59317a1e5647b4ee26a3b8e1de16f75a1) Thanks [@evanaronson](https://github.com/evanaronson)! - Revise mixed-body UI: remove approve/veto decision tags, move the governance-type field to its own setup-body wizard step, display stage thresholds in the stage settings list and update governance copy
+
+- [#1243](https://github.com/aragon/app/pull/1243) [`cc1a6a2`](https://github.com/aragon/app/commit/cc1a6a2ccf1df0c4d4ffc7304a6648d2fd150d02) Thanks [@evanaronson](https://github.com/evanaronson)! - Add design-sync setup for the "Aragon App Design System" Claude Design project to enable future re-syncs.
+
+- Updated dependencies [[`3e7c9fd`](https://github.com/aragon/app/commit/3e7c9fd62afdfd79616e98e319b1baf2b303a037)]:
+    - @aragon/assistant-chat@0.3.0
+
 ## 1.35.0
 
 ### Minor Changes

--- a/apps/app/docs/projectDocs/analyticsEvents.md
+++ b/apps/app/docs/projectDocs/analyticsEvents.md
@@ -61,7 +61,7 @@ Rationale:
 - event names are stable code IDs;
 - prefixes group related funnel events;
 - TypeScript unions catch typos;
-- dashboards can segment by event props such as `flow` and `transactionKind`;
+- dashboards can segment by event props such as `flow` and `transactionTypeEvent`;
 - Title Case click-goal names are too easy to attach to the wrong lifecycle point.
 
 Do not name a click after a later business outcome. For example, a submit-button click before wallet signing is not a DAO publish event. DAO creation success is represented by a transaction terminal event with DAO-specific props.
@@ -92,11 +92,12 @@ Use `analyticsUtils.trackEvent` directly only for shared pipeline tests or futur
 | Prop | Type before normalization | Meaning |
 | --- | --- | --- |
 | `flow` | string | Product flow that emitted the event. |
-| `transactionKind` | string | Low-cardinality transaction purpose inside a flow. |
-| `transactionType` | string | Backend transaction type when backend transaction status/indexing is used. |
+| `transactionTypeEvent` | string | Low-cardinality transaction purpose inside a product flow. This is the only transaction classification sent on analytics events. |
 | `network` | string | DAO or transaction network. |
 | `chainId` | number | Required EVM chain ID. |
 | `pluginInterfaceType` | string | Governance plugin interface type when relevant. |
+
+`transactionType` is a separate backend enum used by the pending-transaction manager for resume, duplicate detection, and indexing. It is intentionally not included in Plausible payloads; do not add it as a second analytics dimension.
 
 Known `flow` values:
 
@@ -109,7 +110,7 @@ Known `flow` values:
 | `proposal_execution` | Execute existing proposal. |
 | `proposal_vote` | Vote on existing proposal. |
 
-Known `transactionKind` values:
+Known `transactionTypeEvent` values:
 
 | Value | Flow |
 | --- | --- |
@@ -230,7 +231,7 @@ Required props:
 | Prop | Notes |
 | --- | --- |
 | `flow` | Product flow. |
-| `transactionKind` | Low-cardinality transaction purpose. |
+| `transactionTypeEvent` | Low-cardinality transaction purpose. |
 | `network` | Transaction network. |
 | `chainId` | Required chain ID. |
 | `attemptKind` | `new` or `resume`. |
@@ -239,10 +240,9 @@ Optional props:
 
 | Prop | Notes |
 | --- | --- |
-| `transactionType` | Present when backend transaction status/indexing is used. |
 | `actionCount` | Present for direct execute-actions. |
 
-DAO publish/create attempt is `transaction_start` with `flow: 'create_dao'` and `transactionKind: 'dao_create'`.
+DAO publish/create attempt is `transaction_start` with `flow: 'create_dao'` and `transactionTypeEvent: 'dao_create'`.
 
 ### `transaction_stage`
 
@@ -253,7 +253,7 @@ Required props:
 | Prop | Notes |
 | --- | --- |
 | `flow` | Product flow. |
-| `transactionKind` | Low-cardinality transaction purpose. |
+| `transactionTypeEvent` | Low-cardinality transaction purpose. |
 | `network` | Transaction network. |
 | `chainId` | Required chain ID. |
 | `status` | Currently `submitted` or `confirmed`. |
@@ -267,12 +267,12 @@ Required props:
 | Prop | Notes |
 | --- | --- |
 | `flow` | Product flow. |
-| `transactionKind` | Low-cardinality transaction purpose. |
+| `transactionTypeEvent` | Low-cardinality transaction purpose. |
 | `network` | Transaction network. |
 | `chainId` | Required chain ID. |
 | `status` | `confirmed` or `indexed`. |
 
-DAO creation success is `transaction_end` with `flow: 'create_dao'`, `transactionKind: 'dao_create'`, and a success `status`.
+DAO creation success is `transaction_end` with `flow: 'create_dao'`, `transactionTypeEvent: 'dao_create'`, and a success `status`.
 
 ### `transaction_failed`
 
@@ -283,7 +283,7 @@ Required props:
 | Prop | Notes |
 | --- | --- |
 | `flow` | Product flow. |
-| `transactionKind` | Low-cardinality transaction purpose. |
+| `transactionTypeEvent` | Low-cardinality transaction purpose. |
 | `network` | Transaction network. |
 | `chainId` | Required chain ID. |
 | `errorClass` | Error class name only, or `unknown`. |
@@ -293,8 +293,43 @@ Optional props:
 | Prop | Notes |
 | --- | --- |
 | `step` | Step where failure happened, e.g. `PREPARE`, `APPROVE`, `CONFIRM`, `INDEXING`. |
+| `status` | Present as `send_error` for direct execute-actions failures. |
 
 Never send raw error messages, stacks, revert reasons, provider payloads, calldata, addresses, hashes, or proposal metadata.
+
+## Where each event fires
+
+Each event is fired by exactly one place in the app: a page, dialog, or hook. These are code paths, not the Plausible dashboard Goals covered in the next section. The wizard and transaction events are opt-in, so their component fires them only when it is given analytics metadata.
+
+| Events | Fired by | Current application surfaces |
+| --- | --- | --- |
+| `wizard_start`, `wizard_step` | `WizardRoot` | `createDaoPageClient` (`create_dao`), `createProcessPageClient` (`governance_designer`), `createProposalPageClient` (`create_proposal`), and `createExecuteActionsPageClient` (`direct_execute_actions`) |
+| `wizard_validation_blocked` | `WizardForm` | The same four analytics-enabled wizards |
+| `wizard_submit` | Flow page client | `createDaoPageClient`, `createProcessPageClient`, `createProposalPageClient`, and `createExecuteActionsPageClient` |
+| `transaction_start`, `transaction_stage`, `transaction_end`, `transaction_failed` | `TransactionDialog` | `publishDaoDialog`, `publishProposalDialog`, `executeDialog`, and `voteDialog`, when passed an `analytics` prop |
+| `transaction_start`, `transaction_stage`, `transaction_failed` | `ExecuteActionsDialog` | Direct admin action execution (`direct_execute_actions`) |
+| `action_added`, `action_added_batch` | `useProposalActionsField` | Proposal and direct-execute action forms |
+
+## Plausible dashboard declarations
+
+Plausible is a passive receiver. It has no registry of the app's event names; it only learns an event exists once the tracker sends it to `/api/event`. Both steps are required, in order: the app emits the event, and a matching Custom event Goal exists for the count to appear. A Goal with no matching event sits at zero forever, and an event with no Goal is received but never shown. Past events are not backfilled, so a Goal counts only from when you create it.
+
+In the development site (`dev.app.aragon.org`) and production site (`app.aragon.org`), create one Custom event Goal for each exact event name the app emits:
+
+- `wizard_start`
+- `wizard_step`
+- `wizard_submit`
+- `wizard_validation_blocked`
+- `action_added`
+- `action_added_batch`
+- `transaction_start`
+- `transaction_stage`
+- `transaction_end`
+- `transaction_failed`
+
+Create property-filtered Goals only when a funnel needs a specific segment, using `flow` and/or `transactionTypeEvent` (Plausible allows up to three property constraints per Goal). Do not register Goals for names the app does not emit, such as the backend `transactionType` or Title Case labels; a Goal for a non-emitted name is a permanent zero. When a new surface ships, add its name to `PlausibleAnalyticsEventName`, emit it from that UI, then register the Goal.
+
+Renaming an emitted property key does not require rebuilding event Goals. The ten event names above are unchanged, so unfiltered Goals and their funnels keep working. Only update Goals, funnels, and saved filters that constrain on `transactionKind`: edit those in place to `transactionTypeEvent`. Historical events keep the old key, so segmented data splits at the rename boundary; do not dual-send both keys to paper over it.
 
 ## Adding a new event
 

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/app",
-    "version": "1.35.0",
+    "version": "1.36.0",
     "description": "Human-centered DAO infrastructure",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",

--- a/apps/app/src/modules/createDao/dialogs/publishDaoDialog/publishDaoDialog.tsx
+++ b/apps/app/src/modules/createDao/dialogs/publishDaoDialog/publishDaoDialog.tsx
@@ -172,7 +172,7 @@ export const PublishDaoDialog: React.FC<IPublishDaoDialogProps> = (props) => {
         <TransactionDialog<PublishDaoStep>
             analytics={{
                 flow: 'create_dao',
-                transactionKind: 'dao_create',
+                transactionTypeEvent: 'dao_create',
             }}
             customSteps={customSteps}
             description={t('app.createDao.publishDaoDialog.description')}

--- a/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.test.tsx
+++ b/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.test.tsx
@@ -156,14 +156,14 @@ describe('<ExecuteActionsDialog /> component', () => {
         );
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_start', {
             flow: 'direct_execute_actions',
-            transactionKind: 'admin_instant_execute',
+            transactionTypeEvent: 'admin_instant_execute',
             network,
             chainId: networkDefinitions[network].id,
             actionCount: 0,
         });
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_stage', {
             flow: 'direct_execute_actions',
-            transactionKind: 'admin_instant_execute',
+            transactionTypeEvent: 'admin_instant_execute',
             network,
             chainId: networkDefinitions[network].id,
             status: 'submitted',
@@ -200,7 +200,7 @@ describe('<ExecuteActionsDialog /> component', () => {
 
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_failed', {
             flow: 'direct_execute_actions',
-            transactionKind: 'admin_instant_execute',
+            transactionTypeEvent: 'admin_instant_execute',
             network,
             chainId: networkDefinitions[network].id,
             status: 'send_error',

--- a/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
@@ -87,7 +87,7 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
     const analyticsProps = useMemo(
         () => ({
             flow: 'direct_execute_actions',
-            transactionKind: 'admin_instant_execute',
+            transactionTypeEvent: 'admin_instant_execute',
             network,
             chainId: requiredChainId,
             actionCount: actions.length,

--- a/apps/app/src/modules/governance/dialogs/executeDialog/executeDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/executeDialog/executeDialog.tsx
@@ -89,7 +89,7 @@ export const ExecuteDialog: React.FC<IExecuteDialogProps> = (props) => {
         <TransactionDialog
             analytics={{
                 flow: 'proposal_execution',
-                transactionKind: 'governance_proposal_execute',
+                transactionTypeEvent: 'governance_proposal_execute',
             }}
             description={t('app.governance.executeDialog.description')}
             indexingFallbackUrl={daoUtils.getDaoUrl(dao, `proposals/${slug}`)}

--- a/apps/app/src/modules/governance/dialogs/publishProposalDialog/publishProposalDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/publishProposalDialog/publishProposalDialog.tsx
@@ -186,7 +186,7 @@ export const PublishProposalDialog: React.FC<IPublishProposalDialogProps> = (
         <TransactionDialog<PublishProposalStep>
             analytics={{
                 flow: 'create_proposal',
-                transactionKind: 'governance_proposal_create',
+                transactionTypeEvent: 'governance_proposal_create',
             }}
             customSteps={customSteps}
             description={t(`${namespace}.description`)}

--- a/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
@@ -123,7 +123,7 @@ export const VoteDialog: React.FC<IVoteDialogProps> = (props) => {
         <TransactionDialog
             analytics={{
                 flow: 'proposal_vote',
-                transactionKind: 'governance_proposal_vote',
+                transactionTypeEvent: 'governance_proposal_vote',
             }}
             description={t('app.governance.voteDialog.description')}
             indexingFallbackUrl={

--- a/apps/app/src/shared/components/transactionDialog/transactionDialog.api.ts
+++ b/apps/app/src/shared/components/transactionDialog/transactionDialog.api.ts
@@ -76,9 +76,11 @@ export interface ITransactionDialogAnalytics {
      */
     flow?: string;
     /**
-     * Low-cardinality transaction kind within the product flow.
+     * Low-cardinality analytics classification of the transaction within the product flow. Emitted
+     * on `transaction_*` events as `transactionTypeEvent`. Distinct from the backend
+     * `transactionType` enum prop, which is intentionally not sent to analytics.
      */
-    transactionKind?: string;
+    transactionTypeEvent?: string;
 }
 
 export interface ITransactionDialogProps<

--- a/apps/app/src/shared/components/transactionDialog/transactionDialog.test.tsx
+++ b/apps/app/src/shared/components/transactionDialog/transactionDialog.test.tsx
@@ -435,7 +435,7 @@ describe('<TransactionDialog /> component', () => {
             createTestComponent({
                 analytics: {
                     flow: 'create_proposal',
-                    transactionKind: 'governance_proposal_create',
+                    transactionTypeEvent: 'governance_proposal_create',
                 },
                 stepper,
                 network,
@@ -450,8 +450,7 @@ describe('<TransactionDialog /> component', () => {
 
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_start', {
             flow: 'create_proposal',
-            transactionKind: 'governance_proposal_create',
-            transactionType: TransactionType.PROPOSAL_CREATE,
+            transactionTypeEvent: 'governance_proposal_create',
             network,
             chainId: networkDefinitions[network].id,
             attemptKind: 'new',
@@ -765,7 +764,7 @@ describe('<TransactionDialog /> component', () => {
             createTestComponent({
                 analytics: {
                     flow: 'create_proposal',
-                    transactionKind: 'governance_proposal_create',
+                    transactionTypeEvent: 'governance_proposal_create',
                 },
                 transactionType: TransactionType.PROPOSAL_CREATE,
             }),
@@ -773,8 +772,7 @@ describe('<TransactionDialog /> component', () => {
 
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_failed', {
             flow: 'create_proposal',
-            transactionKind: 'governance_proposal_create',
-            transactionType: TransactionType.PROPOSAL_CREATE,
+            transactionTypeEvent: 'governance_proposal_create',
             network: Network.ETHEREUM_MAINNET,
             chainId: networkDefinitions[Network.ETHEREUM_MAINNET].id,
             step: TransactionDialogStep.CONFIRM,
@@ -1048,7 +1046,7 @@ describe('<TransactionDialog /> onIndexed callback', () => {
         const propsWithCallback: Partial<ITransactionDialogProps> = {
             analytics: {
                 flow: 'create_proposal',
-                transactionKind: 'governance_proposal_create',
+                transactionTypeEvent: 'governance_proposal_create',
             },
             onIndexed,
         };
@@ -1073,8 +1071,7 @@ describe('<TransactionDialog /> onIndexed callback', () => {
         expect(onIndexed).toHaveBeenCalledWith({ slug: 'abc' });
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_end', {
             flow: 'create_proposal',
-            transactionKind: 'governance_proposal_create',
-            transactionType: TransactionType.PROPOSAL_CREATE,
+            transactionTypeEvent: 'governance_proposal_create',
             chainId: networkDefinitions[Network.ETHEREUM_MAINNET].id,
             network: Network.ETHEREUM_MAINNET,
             status: 'indexed',

--- a/apps/app/src/shared/components/transactionDialog/transactionDialog.tsx
+++ b/apps/app/src/shared/components/transactionDialog/transactionDialog.tsx
@@ -107,11 +107,10 @@ export const TransactionDialog = <TCustomStepId extends string>(
     const getTransactionAnalyticsProps = useCallback(
         () => ({
             ...analyticsRef.current,
-            transactionType,
             network,
             chainId: requiredChainId,
         }),
-        [transactionType, network, requiredChainId],
+        [network, requiredChainId],
     );
 
     const trackTransactionAnalytics = useCallback(

--- a/packages/assistant-chat/CHANGELOG.md
+++ b/packages/assistant-chat/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aragon/assistant-chat
 
+## 0.3.0
+
+### Minor Changes
+
+- [#1255](https://github.com/aragon/app/pull/1255) [`3e7c9fd`](https://github.com/aragon/app/commit/3e7c9fd62afdfd79616e98e319b1baf2b303a037) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Rebuild the assistant-chat widget on assistant-ui with the agentic backend: streamed transcript and a `createLinearTicket` approval card (draft → Create/Dismiss → success or retry), a greeting screen with intake shortcuts and request history, and our own composer.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/assistant-chat/package.json
+++ b/packages/assistant-chat/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/assistant-chat",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Support-chat widget for the Aragon App, backed by the Aragon assistant service",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",


### PR DESCRIPTION
## Features
- support chat on assistant-ui with an agentic backend ([#1255](https://github.com/aragon/app/pull/1255)) — [APP-1016: Support chat on assistant-ui with an agentic backend](https://linear.app/aragon/issue/APP-1016/support-chat-on-assistant-ui-with-an-agentic-backend)
- support voting on objection-stage proposals ([#1259](https://github.com/aragon/app/pull/1259)) — [APP-1022: App: voting on the objection stage](https://linear.app/aragon/issue/APP-1022/app-voting-on-the-objection-stage)
- support delegate vote overrides for Alchemix Token Voting ([#1266](https://github.com/aragon/app/pull/1266)) — [APP-984: Support delegate vote overrides for Alchemix Token Voting](https://linear.app/aragon/issue/APP-984/support-delegate-vote-overrides-for-alchemix-token-voting)
- add Plausible analytics event hooks ([#1258](https://github.com/aragon/app/pull/1258))
- Filter plugin actions in action composer by DAO permissions ([#1253](https://github.com/aragon/app/pull/1253)) — [APP-1001: Filter OSx-related actions from action builder when the DAO lacks the permission](https://linear.app/aragon/issue/APP-1001/filter-osx-related-actions-from-action-builder-when-the-dao-lacks-the)
- support mixed approving and vetoing bodies within an SPP stage ([#1256](https://github.com/aragon/app/pull/1256))

## Fixes
- Rename analytics transactionKind to transactionTypeEvent ([#1302](https://github.com/aragon/app/pull/1302)) — [APP-999: Add Plausible analytics event hooks to the app](https://linear.app/aragon/issue/APP-999/add-plausible-analytics-event-hooks-to-the-app)
- Feedback about mixed body support ([#1268](https://github.com/aragon/app/pull/1268)) — [APP-985: Support mixed approving and vetoing bodies within an SPP stage](https://linear.app/aragon/issue/APP-985/support-mixed-approving-and-vetoing-bodies-within-an-spp-stage)
- Add stuck-transaction recovery to the transaction dialog ([#1262](https://github.com/aragon/app/pull/1262)) — [APP-1023: TransactionDialog: stuck transaction confirmation has no escape](https://linear.app/aragon/issue/APP-1023/transactiondialog-stuck-transaction-confirmation-has-no-escape)
- Add link to block explorer for external Safe address ([#1267](https://github.com/aragon/app/pull/1267)) — [APP-1025: Add link to Safe address](https://linear.app/aragon/issue/APP-1025/add-link-to-safe-address)

## Other Changes
- Bump 1password/load-secrets-action ([#1265](https://github.com/aragon/app/pull/1265))
- add design-sync setup for the Aragon App Design System (claude.ai/design) ([#1243](https://github.com/aragon/app/pull/1243))



<!-- slack_ts: 1785772789.648489 -->
