### PR TITLE
Release @aragon/assistant@0.2.0

### DIFF
--- a/.changeset/app-1016-assistant-agentic-backend.md
+++ b/.changeset/app-1016-assistant-agentic-backend.md
@@ -1,6 +1,0 @@
----
-"@aragon/assistant": minor
-"@aragon/assistant-contracts": minor
----
-
-Rework the assistant backend into a tool-calling agent: one streamed `/chat` turn with an approval-gated `createLinearTicket` tool, replacing the classify/extract/preview pipeline and the `/issues` endpoints.

--- a/.changeset/app-998-assistant-issue-texts.md
+++ b/.changeset/app-998-assistant-issue-texts.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant": patch
----
-
-Move the static Linear ticket texts into chat/prompts/issueTexts.ts so all service copy lives under chat/prompts/

--- a/.changeset/app-998-fixed-replies-prepare-ticket.md
+++ b/.changeset/app-998-fixed-replies-prepare-ticket.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant": patch
----
-
-Turn/size-limit fixed replies point users to the actual "Prepare ticket" button instead of the removed "Create ticket"

--- a/.changeset/assistant-contracts-package-build.md
+++ b/.changeset/assistant-contracts-package-build.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant-contracts": patch
----
-
-Build the package to `dist/` (tsup CJS/ESM/types) so Node runtimes such as Vercel can require it; TypeScript source under `src/` is no longer the package entrypoint

--- a/.changeset/assistant-contracts-scaffold.md
+++ b/.changeset/assistant-contracts-scaffold.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant-contracts": minor
----
-
-Scaffold the assistant contracts package: shared zod schemas between the assistant service and the assistant-chat widget, starting with the /health response contract

--- a/.changeset/assistant-contracts-support-intake.md
+++ b/.changeset/assistant-contracts-support-intake.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant-contracts": minor
----
-
-Add the support-chat contracts: chat request/message schemas, collected-fields data part (required fields: summary and description — email is optional), issue create request/response, file confirm/delete requests and upload response, shared error shape, hard limits and the pinned Phase-2 docs-search result shape

--- a/.changeset/assistant-scaffold.md
+++ b/.changeset/assistant-scaffold.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant": minor
----
-
-Scaffold the assistant service: Hono app with /health endpoint and CORS allowlist, per-environment config, Vercel project wiring (preview/dev/production deploys) and the Version-PR release flow

--- a/.changeset/assistant-support-intake.md
+++ b/.changeset/assistant-support-intake.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant": minor
----
-
-Add the support-chat intake feature: streaming /chat pipeline (intent classification, field extraction, live collected-fields summary, optional email), idempotent /issues creation in Linear with attachment transfer at creation time, client-direct file uploads to Vercel Blob (token/confirm/delete endpoints, server-side magic-byte validation at confirm, daily orphan-cleanup cron), per-IP rate limiting via Upstash, structured step logs with Sentry, runtime env delivery for Vercel deployments and preview CORS narrowed to the aragon-app scope

--- a/apps/assistant/CHANGELOG.md
+++ b/apps/assistant/CHANGELOG.md
@@ -1,0 +1,20 @@
+# @aragon/assistant
+
+## 0.2.0
+
+### Minor Changes
+
+- [#1255](https://github.com/aragon/app/pull/1255) [`3e7c9fd`](https://github.com/aragon/app/commit/3e7c9fd62afdfd79616e98e319b1baf2b303a037) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Rework the assistant backend into a tool-calling agent: one streamed `/chat` turn with an approval-gated `createLinearTicket` tool, replacing the classify/extract/preview pipeline and the `/issues` endpoints.
+
+- [#1222](https://github.com/aragon/app/pull/1222) [`36c1fc4`](https://github.com/aragon/app/commit/36c1fc44d7a3ca3759d8f7d1c4c4fc1046287c0b) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Scaffold the assistant service: Hono app with /health endpoint and CORS allowlist, per-environment config, Vercel project wiring (preview/dev/production deploys) and the Version-PR release flow
+
+- [#1224](https://github.com/aragon/app/pull/1224) [`0c52e23`](https://github.com/aragon/app/commit/0c52e2351022a4a99ef2d3045dcec234179efb9d) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Add the support-chat intake feature: streaming /chat pipeline (intent classification, field extraction, live collected-fields summary, optional email), idempotent /issues creation in Linear with attachment transfer at creation time, client-direct file uploads to Vercel Blob (token/confirm/delete endpoints, server-side magic-byte validation at confirm, daily orphan-cleanup cron), per-IP rate limiting via Upstash, structured step logs with Sentry, runtime env delivery for Vercel deployments and preview CORS narrowed to the aragon-app scope
+
+### Patch Changes
+
+- [#1242](https://github.com/aragon/app/pull/1242) [`4977e3e`](https://github.com/aragon/app/commit/4977e3e565c58842853835796a0a040e28cb5b75) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Move the static Linear ticket texts into chat/prompts/issueTexts.ts so all service copy lives under chat/prompts/
+
+- [#1242](https://github.com/aragon/app/pull/1242) [`4977e3e`](https://github.com/aragon/app/commit/4977e3e565c58842853835796a0a040e28cb5b75) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Turn/size-limit fixed replies point users to the actual "Prepare ticket" button instead of the removed "Create ticket"
+
+- Updated dependencies [[`3e7c9fd`](https://github.com/aragon/app/commit/3e7c9fd62afdfd79616e98e319b1baf2b303a037), [`0c52e23`](https://github.com/aragon/app/commit/0c52e2351022a4a99ef2d3045dcec234179efb9d), [`36c1fc4`](https://github.com/aragon/app/commit/36c1fc44d7a3ca3759d8f7d1c4c4fc1046287c0b), [`0c52e23`](https://github.com/aragon/app/commit/0c52e2351022a4a99ef2d3045dcec234179efb9d)]:
+    - @aragon/assistant-contracts@0.2.0

--- a/apps/assistant/package.json
+++ b/apps/assistant/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/assistant",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Aragon assistant service: support-chat intake API",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",

--- a/packages/assistant-contracts/CHANGELOG.md
+++ b/packages/assistant-contracts/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @aragon/assistant-contracts
+
+## 0.2.0
+
+### Minor Changes
+
+- [#1255](https://github.com/aragon/app/pull/1255) [`3e7c9fd`](https://github.com/aragon/app/commit/3e7c9fd62afdfd79616e98e319b1baf2b303a037) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Rework the assistant backend into a tool-calling agent: one streamed `/chat` turn with an approval-gated `createLinearTicket` tool, replacing the classify/extract/preview pipeline and the `/issues` endpoints.
+
+- [#1222](https://github.com/aragon/app/pull/1222) [`36c1fc4`](https://github.com/aragon/app/commit/36c1fc44d7a3ca3759d8f7d1c4c4fc1046287c0b) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Scaffold the assistant contracts package: shared zod schemas between the assistant service and the assistant-chat widget, starting with the /health response contract
+
+- [#1224](https://github.com/aragon/app/pull/1224) [`0c52e23`](https://github.com/aragon/app/commit/0c52e2351022a4a99ef2d3045dcec234179efb9d) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Add the support-chat contracts: chat request/message schemas, collected-fields data part (required fields: summary and description — email is optional), issue create request/response, file confirm/delete requests and upload response, shared error shape, hard limits and the pinned Phase-2 docs-search result shape
+
+### Patch Changes
+
+- [#1224](https://github.com/aragon/app/pull/1224) [`0c52e23`](https://github.com/aragon/app/commit/0c52e2351022a4a99ef2d3045dcec234179efb9d) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Build the package to `dist/` (tsup CJS/ESM/types) so Node runtimes such as Vercel can require it; TypeScript source under `src/` is no longer the package entrypoint

--- a/packages/assistant-contracts/package.json
+++ b/packages/assistant-contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/assistant-contracts",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Shared zod contracts between the Aragon assistant service and the assistant-chat widget",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",


### PR DESCRIPTION
Merging this PR releases `@aragon/assistant@0.2.0`: the merge commit is
tagged and the tag triggers the production deploy to assistant.aragon.org. The
version-only packages below ship inside their consumers and get no tag of their own.

## @aragon/assistant@0.2.0

### Minor Changes

- [#1255](https://github.com/aragon/app/pull/1255) [`3e7c9fd`](https://github.com/aragon/app/commit/3e7c9fd62afdfd79616e98e319b1baf2b303a037) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Rework the assistant backend into a tool-calling agent: one streamed `/chat` turn with an approval-gated `createLinearTicket` tool, replacing the classify/extract/preview pipeline and the `/issues` endpoints.

- [#1222](https://github.com/aragon/app/pull/1222) [`36c1fc4`](https://github.com/aragon/app/commit/36c1fc44d7a3ca3759d8f7d1c4c4fc1046287c0b) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Scaffold the assistant service: Hono app with /health endpoint and CORS allowlist, per-environment config, Vercel project wiring (preview/dev/production deploys) and the Version-PR release flow

- [#1224](https://github.com/aragon/app/pull/1224) [`0c52e23`](https://github.com/aragon/app/commit/0c52e2351022a4a99ef2d3045dcec234179efb9d) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Add the support-chat intake feature: streaming /chat pipeline (intent classification, field extraction, live collected-fields summary, optional email), idempotent /issues creation in Linear with attachment transfer at creation time, client-direct file uploads to Vercel Blob (token/confirm/delete endpoints, server-side magic-byte validation at confirm, daily orphan-cleanup cron), per-IP rate limiting via Upstash, structured step logs with Sentry, runtime env delivery for Vercel deployments and preview CORS narrowed to the aragon-app scope

### Patch Changes

- [#1242](https://github.com/aragon/app/pull/1242) [`4977e3e`](https://github.com/aragon/app/commit/4977e3e565c58842853835796a0a040e28cb5b75) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Move the static Linear ticket texts into chat/prompts/issueTexts.ts so all service copy lives under chat/prompts/

- [#1242](https://github.com/aragon/app/pull/1242) [`4977e3e`](https://github.com/aragon/app/commit/4977e3e565c58842853835796a0a040e28cb5b75) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Turn/size-limit fixed replies point users to the actual "Prepare ticket" button instead of the removed "Create ticket"

- Updated dependencies [[`3e7c9fd`](https://github.com/aragon/app/commit/3e7c9fd62afdfd79616e98e319b1baf2b303a037), [`0c52e23`](https://github.com/aragon/app/commit/0c52e2351022a4a99ef2d3045dcec234179efb9d), [`36c1fc4`](https://github.com/aragon/app/commit/36c1fc44d7a3ca3759d8f7d1c4c4fc1046287c0b), [`0c52e23`](https://github.com/aragon/app/commit/0c52e2351022a4a99ef2d3045dcec234179efb9d)]:
    - @aragon/assistant-contracts@0.2.0

## @aragon/assistant-contracts@0.2.0

### Minor Changes

- [#1255](https://github.com/aragon/app/pull/1255) [`3e7c9fd`](https://github.com/aragon/app/commit/3e7c9fd62afdfd79616e98e319b1baf2b303a037) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Rework the assistant backend into a tool-calling agent: one streamed `/chat` turn with an approval-gated `createLinearTicket` tool, replacing the classify/extract/preview pipeline and the `/issues` endpoints.

- [#1222](https://github.com/aragon/app/pull/1222) [`36c1fc4`](https://github.com/aragon/app/commit/36c1fc44d7a3ca3759d8f7d1c4c4fc1046287c0b) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Scaffold the assistant contracts package: shared zod schemas between the assistant service and the assistant-chat widget, starting with the /health response contract

- [#1224](https://github.com/aragon/app/pull/1224) [`0c52e23`](https://github.com/aragon/app/commit/0c52e2351022a4a99ef2d3045dcec234179efb9d) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Add the support-chat contracts: chat request/message schemas, collected-fields data part (required fields: summary and description — email is optional), issue create request/response, file confirm/delete requests and upload response, shared error shape, hard limits and the pinned Phase-2 docs-search result shape

### Patch Changes

- [#1224](https://github.com/aragon/app/pull/1224) [`0c52e23`](https://github.com/aragon/app/commit/0c52e2351022a4a99ef2d3045dcec234179efb9d) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Build the package to `dist/` (tsup CJS/ESM/types) so Node runtimes such as Vercel can require it; TypeScript source under `src/` is no longer the package entrypoint
