### PR TITLE
fix(APP-1035): keep uploaded transfer action amount when token data is already cached

### DIFF
--- a/.changeset/app-1035-imported-transfer-action-amount.md
+++ b/.changeset/app-1035-imported-transfer-action-amount.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix uploaded transfer actions losing their amount and calldata when the token details are already cached

--- a/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.test.tsx
+++ b/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.test.tsx
@@ -1,0 +1,231 @@
+import { GukModulesProvider } from '@aragon/gov-ui-kit';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { encodeFunctionData, erc20Abi, parseUnits } from 'viem';
+import * as wagmi from 'wagmi';
+import * as daoService from '@/shared/api/daoService';
+import * as DialogProvider from '@/shared/components/dialogProvider';
+import * as useTokenModule from '@/shared/hooks/useToken/useToken';
+import {
+    generateDao,
+    generateDialogContext,
+    generateReactQueryResultSuccess,
+} from '@/shared/testUtils';
+import type { IProposalActionData } from '../../../createProposalFormDefinitions';
+import { TransferAssetAction } from './transferAssetAction';
+
+describe('<TransferAssetAction /> component', () => {
+    const useDaoSpy = jest.spyOn(daoService, 'useDao');
+    const useTokenSpy = jest.spyOn(useTokenModule, 'useToken');
+    const useReadContractSpy = jest.spyOn(wagmi, 'useReadContract');
+    const useBalanceSpy = jest.spyOn(wagmi, 'useBalance');
+    const useDialogContextSpy = jest.spyOn(DialogProvider, 'useDialogContext');
+
+    const tokenAddress = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238';
+    const receiverAddress = '0x2222222222222222222222222222222222222222';
+    const rawAmount = '1234000000'; // 1234 tokens with 6 decimals
+
+    const originalData = encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: [receiverAddress, BigInt(rawAmount)],
+    });
+
+    const resolvedToken = {
+        name: 'USDC',
+        symbol: 'USDC',
+        decimals: 6,
+        totalSupply: '1000000000000',
+    };
+
+    // Action shape produced by uploading a JSON file with an ERC20 transfer
+    // (see normalizeTransferAction): placeholder 18-decimals token, amount '0'
+    // and the real wei amount stored in rawAmount until decimals are fetched.
+    const generateImportedAction = () => ({
+        type: 'TRANSFER',
+        to: tokenAddress,
+        value: BigInt(0),
+        data: originalData,
+        inputData: {
+            function: 'transfer',
+            contract: 'USDC',
+            parameters: [
+                { name: '_to', type: 'address', value: receiverAddress },
+                { name: '_value', type: 'uint256', value: rawAmount },
+            ],
+        },
+        receiver: { address: receiverAddress },
+        amount: '0',
+        asset: {
+            token: {
+                address: tokenAddress,
+                network: 'ethereum-mainnet',
+                symbol: '',
+                name: 'USDC',
+                logo: '',
+                decimals: 18,
+                priceUsd: '0',
+                totalSupply: null,
+            },
+            amount: undefined,
+        },
+        rawAmount,
+        daoId: 'dao-test',
+        meta: undefined,
+    });
+
+    beforeEach(() => {
+        useDaoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({
+                data: generateDao({ id: 'dao-test' }),
+            }),
+        );
+        useTokenSpy.mockReturnValue({
+            data: null,
+            isLoading: true,
+            isError: false,
+        });
+        useReadContractSpy.mockReturnValue({
+            data: BigInt(0),
+        } as unknown as wagmi.UseReadContractReturnType);
+        useBalanceSpy.mockReturnValue({
+            data: undefined,
+        } as unknown as wagmi.UseBalanceReturnType);
+        useDialogContextSpy.mockReturnValue(generateDialogContext());
+    });
+
+    afterEach(() => {
+        useDaoSpy.mockReset();
+        useTokenSpy.mockReset();
+        useReadContractSpy.mockReset();
+        useBalanceSpy.mockReset();
+        useDialogContextSpy.mockReset();
+    });
+
+    // Mimics useProposalActionsField's actionsMerged: the action prop is the
+    // live watched form value, as on the real create-proposal page.
+    const WatchedAction = (props: {
+        initialAction: Record<string, unknown>;
+    }) => {
+        const watched = useWatch({ name: 'actions.0' });
+        const action = { ...props.initialAction, ...(watched as object) };
+        return (
+            <TransferAssetAction
+                action={action as unknown as IProposalActionData}
+                index={0}
+            />
+        );
+    };
+
+    // biome-ignore lint/suspicious/noExplicitAny: test probe for form values
+    let getFormValues: any;
+
+    const Host = (props: { initialAction: Record<string, unknown> }) => {
+        const methods = useForm({
+            defaultValues: { actions: [props.initialAction] },
+        });
+        getFormValues = methods.getValues;
+        return (
+            <GukModulesProvider>
+                <FormProvider {...methods}>
+                    <WatchedAction initialAction={props.initialAction} />
+                </FormProvider>
+            </GukModulesProvider>
+        );
+    };
+
+    const createTestComponent = (initialAction: Record<string, unknown>) => (
+        <Host initialAction={initialAction} />
+    );
+
+    it('initializes an imported action when token data is cached at mount', () => {
+        useTokenSpy.mockReturnValue({
+            data: resolvedToken,
+            isLoading: false,
+            isError: false,
+        });
+
+        render(createTestComponent(generateImportedAction()));
+
+        const action = getFormValues('actions.0');
+        expect(action.amount).toEqual('1234');
+        expect(action.data).toEqual(originalData);
+        expect(action.asset.token.decimals).toEqual(6);
+        expect(action.rawAmount).toBeUndefined();
+        expect(action.inputData.parameters[1].value).toEqual(rawAmount);
+    });
+
+    it('keeps the uploaded calldata untouched while token data is loading and initializes the amount once it resolves', () => {
+        const { rerender } = render(
+            createTestComponent(generateImportedAction()),
+        );
+
+        // Token details not fetched yet: nothing may be derived from the
+        // placeholder values, so the uploaded calldata must stay untouched.
+        const loadingAction = getFormValues('actions.0');
+        expect(loadingAction.data).toEqual(originalData);
+        expect(loadingAction.rawAmount).toEqual(rawAmount);
+
+        act(() => {
+            useTokenSpy.mockReturnValue({
+                data: resolvedToken,
+                isLoading: false,
+                isError: false,
+            });
+        });
+        rerender(createTestComponent(generateImportedAction()));
+
+        const action = getFormValues('actions.0');
+        expect(action.amount).toEqual('1234');
+        expect(action.data).toEqual(originalData);
+        expect(action.asset.token.decimals).toEqual(6);
+        expect(action.rawAmount).toBeUndefined();
+    });
+
+    it('encodes the transfer data for actions composed in the app', async () => {
+        // Composer-created action: asset selected, amount typed in by the user after mount.
+        const composedAmount = '5';
+        const composedAction = {
+            type: 'TRANSFER',
+            to: tokenAddress,
+            value: BigInt(0),
+            data: '0x',
+            inputData: undefined,
+            receiver: { address: receiverAddress },
+            amount: undefined,
+            asset: {
+                token: {
+                    address: tokenAddress,
+                    network: 'ethereum-mainnet',
+                    symbol: 'TEST',
+                    name: 'Test token',
+                    logo: '',
+                    decimals: 18,
+                    priceUsd: '0',
+                    totalSupply: null,
+                },
+                amount: '100',
+            },
+            daoId: 'dao-test',
+            meta: undefined,
+        };
+
+        render(createTestComponent(composedAction));
+
+        const user = userEvent.setup();
+        await user.type(screen.getByRole('spinbutton'), composedAmount);
+
+        const expectedData = encodeFunctionData({
+            abi: erc20Abi,
+            functionName: 'transfer',
+            args: [receiverAddress, parseUnits(composedAmount, 18)],
+        });
+
+        const action = getFormValues('actions.0');
+        expect(action.data).toEqual(expectedData);
+        expect(action.amount).toEqual(composedAmount);
+        expect(action.value).toEqual('0');
+        expect(action.to).toEqual(tokenAddress);
+    });
+});

--- a/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.test.tsx
+++ b/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.test.tsx
@@ -183,6 +183,34 @@ describe('<TransferAssetAction /> component', () => {
         expect(action.rawAmount).toBeUndefined();
     });
 
+    it('re-encodes the calldata from user edits when the token query fails for an imported action', async () => {
+        useTokenSpy.mockReturnValue({
+            data: null,
+            isLoading: false,
+            isError: true,
+        });
+
+        render(createTestComponent(generateImportedAction()));
+
+        const user = userEvent.setup();
+        const amountInput = screen.getByRole('spinbutton');
+        await user.clear(amountInput);
+        await user.type(amountInput, '7');
+
+        // Decimals could not be fetched, so encoding falls back to the
+        // placeholder 18 decimals — but the calldata must follow the visible
+        // amount instead of silently keeping the uploaded one.
+        const expectedData = encodeFunctionData({
+            abi: erc20Abi,
+            functionName: 'transfer',
+            args: [receiverAddress, parseUnits('7', 18)],
+        });
+
+        const action = getFormValues('actions.0');
+        expect(action.amount).toEqual('7');
+        expect(action.data).toEqual(expectedData);
+    });
+
     it('encodes the transfer data for actions composed in the app', async () => {
         // Composer-created action: asset selected, amount typed in by the user after mount.
         const composedAmount = '5';

--- a/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
+++ b/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
@@ -3,7 +3,7 @@ import {
     type IProposalActionComponentProps,
     invariant,
 } from '@aragon/gov-ui-kit';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import {
     encodeFunctionData,
@@ -86,14 +86,12 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
     // For imported ERC20 actions, we need to fetch token details to get correct decimals
     const isImportedErc20Action =
         action.rawAmount != null && action.to !== zeroAddress;
-    const [isImportPending, setIsImportPending] = useState(
-        isImportedErc20Action,
-    );
-    const { data: token } = useToken({
+    const { data: token, isError: isTokenError } = useToken({
         address: action.to as Hex,
         chainId,
         enabled: disableTokenSelection || isImportedErc20Action,
     });
+    const isImportPending = isImportedErc20Action && !isTokenError;
     const { data: balance } = useReadContract({
         abi: erc20Abi,
         address: action.to as Hex,
@@ -211,7 +209,6 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
 
         // Clear rawAmount after initialization
         setValue(`${fieldName}.rawAmount`, undefined);
-        setIsImportPending(false);
     }, [
         isImportedErc20Action,
         token,

--- a/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
+++ b/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
@@ -3,7 +3,7 @@ import {
     type IProposalActionComponentProps,
     invariant,
 } from '@aragon/gov-ui-kit';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import {
     encodeFunctionData,
@@ -86,6 +86,9 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
     // For imported ERC20 actions, we need to fetch token details to get correct decimals
     const isImportedErc20Action =
         action.rawAmount != null && action.to !== zeroAddress;
+    const [isImportPending, setIsImportPending] = useState(
+        isImportedErc20Action,
+    );
     const { data: token } = useToken({
         address: action.to as Hex,
         chainId,
@@ -149,7 +152,7 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
 
     // Initialize asset field for transferActionLocked case
     useEffect(() => {
-        if (token == null || balance == null) {
+        if (!disableTokenSelection || token == null || balance == null) {
             return;
         }
 
@@ -164,7 +167,16 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
         const asset: IAsset = { token: tokenAsset, amount: tokenBalance };
 
         setValue(`${fieldName}.asset`, asset);
-    }, [token, balance, tokenAddress, tokenDecimals, setValue, fieldName, dao]);
+    }, [
+        disableTokenSelection,
+        token,
+        balance,
+        tokenAddress,
+        tokenDecimals,
+        setValue,
+        fieldName,
+        dao,
+    ]);
 
     // Initialize imported ERC20 action with fetched token details and formatted amount
     useEffect(() => {
@@ -199,6 +211,7 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
 
         // Clear rawAmount after initialization
         setValue(`${fieldName}.rawAmount`, undefined);
+        setIsImportPending(false);
     }, [
         isImportedErc20Action,
         token,
@@ -211,7 +224,7 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
 
     // Update asset balance for imported actions. Uploaded and decoded transfer actions have token info, but don't have max available balance for the given DAO.
     useEffect(() => {
-        if (!shouldFetchImportedTokenBalance) {
+        if (isImportPending || !shouldFetchImportedTokenBalance) {
             return;
         }
 
@@ -238,6 +251,7 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
             });
         }
     }, [
+        isImportPending,
         shouldFetchImportedTokenBalance,
         isNativeToken,
         nativeBalance,
@@ -249,6 +263,10 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
     ]);
 
     useEffect(() => {
+        if (isImportPending) {
+            return;
+        }
+
         let newData: string | undefined = '0x';
 
         if (!isNativeToken) {
@@ -265,28 +283,6 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
             }
         }
 
-        setValue(`${fieldName}.data`, newData);
-    }, [isNativeToken, receiverAddress, weiAmount, fieldName, setValue]);
-
-    useEffect(() => {
-        const newTarget = isNativeToken ? receiverAddress : tokenAddress;
-
-        setValue(`${fieldName}.to`, newTarget);
-    }, [isNativeToken, receiverAddress, tokenAddress, fieldName, setValue]);
-
-    useEffect(() => {
-        const newAmount = formatUnits(weiAmount, tokenDecimals);
-
-        setValue(`${fieldName}.amount`, newAmount);
-    }, [weiAmount, tokenDecimals, fieldName, setValue]);
-
-    useEffect(() => {
-        const newValue = isNativeToken ? weiAmount.toString() : '0';
-
-        setValue(`${fieldName}.value`, newValue);
-    }, [isNativeToken, weiAmount, fieldName, setValue]);
-
-    useEffect(() => {
         // Get current inputData to preserve function and stateMutability
         const currentAction = getValues(`actions.${index.toString()}`) as
             | IProposalActionData
@@ -299,6 +295,16 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
         ];
         const processedParameters = isNativeToken ? [] : newContractParameters;
 
+        setValue(`${fieldName}.data`, newData);
+        setValue(
+            `${fieldName}.to`,
+            isNativeToken ? receiverAddress : tokenAddress,
+        );
+        setValue(`${fieldName}.amount`, formatUnits(weiAmount, tokenDecimals));
+        setValue(
+            `${fieldName}.value`,
+            isNativeToken ? weiAmount.toString() : '0',
+        );
         // Preserve all inputData fields while updating specific ones
         setValue(`${fieldName}.inputData`, {
             ...currentInputData,
@@ -306,13 +312,16 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
             parameters: processedParameters,
         });
     }, [
+        isImportPending,
         isNativeToken,
         receiverAddress,
-        weiAmount,
-        setValue,
-        fieldName,
+        tokenAddress,
+        tokenDecimals,
         tokenName,
+        weiAmount,
+        fieldName,
         index,
+        setValue,
         getValues,
     ]);
 


### PR DESCRIPTION
# Description

Uploading a transfer action JSON was losing the amount when the asset is not in the DAO. The amount field ended up empty and the decoded view showed the transfer value as 0, so the action user uploads is not the action that would execute.

The cause is a race on mount. When the token details are already cached (which happens exactly in this flow, importing the asset via the composer warms the cache), the effects that re-encode calldata from the form values run in the same pass as the initializer, but still with the placeholder values (amount 0, 18 decimals). They overwrite the amount and the calldata right after the initializer set the real ones, and since rawAmount is cleared there is no retry.

Key changes:

- TransferAssetAction: added an isImportPending flag, the derive/re-encode effects are skipped until the imported action is initialized with the real token decimals. Once initialized they re-run and produce calldata identical to the uploaded file.
- Consolidated the five separate derive effects (data, to, amount, value, inputData) into one effect with a single guard.
- The locked-transfer initializer now only runs for locked transfers, it was also writing the asset field for imported actions.
- Added tests for the component (there were none), covering the cached-token upload, the fresh-fetch upload and the normal composer flow.

Related: [APP-1035](https://linear.app/aragon/issue/APP-1035)

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
