### PR TITLE
fix(APP-999): Rename analytics transactionKind to transactionTypeEvent

### DIFF
--- a/.changeset/app-999-analytics-taxonomy-cleanup.md
+++ b/.changeset/app-999-analytics-taxonomy-cleanup.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Rename the Plausible analytics `transactionKind` prop to `transactionTypeEvent`, stop sending the backend `transactionType` enum on analytics events, and document event sources and dashboard goal registration

--- a/.changeset/app-999-analytics-taxonomy-cleanup.md
+++ b/.changeset/app-999-analytics-taxonomy-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Rename the Plausible analytics `transactionKind` prop to `transactionTypeEvent`, stop sending the backend `transactionType` enum on analytics events, and document event sources and dashboard goal registration

--- a/apps/app/docs/projectDocs/analyticsEvents.md
+++ b/apps/app/docs/projectDocs/analyticsEvents.md
@@ -61,7 +61,7 @@ Rationale:
 - event names are stable code IDs;
 - prefixes group related funnel events;
 - TypeScript unions catch typos;
-- dashboards can segment by event props such as `flow` and `transactionKind`;
+- dashboards can segment by event props such as `flow` and `transactionTypeEvent`;
 - Title Case click-goal names are too easy to attach to the wrong lifecycle point.
 
 Do not name a click after a later business outcome. For example, a submit-button click before wallet signing is not a DAO publish event. DAO creation success is represented by a transaction terminal event with DAO-specific props.
@@ -92,11 +92,12 @@ Use `analyticsUtils.trackEvent` directly only for shared pipeline tests or futur
 | Prop | Type before normalization | Meaning |
 | --- | --- | --- |
 | `flow` | string | Product flow that emitted the event. |
-| `transactionKind` | string | Low-cardinality transaction purpose inside a flow. |
-| `transactionType` | string | Backend transaction type when backend transaction status/indexing is used. |
+| `transactionTypeEvent` | string | Low-cardinality transaction purpose inside a product flow. This is the only transaction classification sent on analytics events. |
 | `network` | string | DAO or transaction network. |
 | `chainId` | number | Required EVM chain ID. |
 | `pluginInterfaceType` | string | Governance plugin interface type when relevant. |
+
+`transactionType` is a separate backend enum used by the pending-transaction manager for resume, duplicate detection, and indexing. It is intentionally not included in Plausible payloads; do not add it as a second analytics dimension.
 
 Known `flow` values:
 
@@ -109,7 +110,7 @@ Known `flow` values:
 | `proposal_execution` | Execute existing proposal. |
 | `proposal_vote` | Vote on existing proposal. |
 
-Known `transactionKind` values:
+Known `transactionTypeEvent` values:
 
 | Value | Flow |
 | --- | --- |
@@ -230,7 +231,7 @@ Required props:
 | Prop | Notes |
 | --- | --- |
 | `flow` | Product flow. |
-| `transactionKind` | Low-cardinality transaction purpose. |
+| `transactionTypeEvent` | Low-cardinality transaction purpose. |
 | `network` | Transaction network. |
 | `chainId` | Required chain ID. |
 | `attemptKind` | `new` or `resume`. |
@@ -239,10 +240,9 @@ Optional props:
 
 | Prop | Notes |
 | --- | --- |
-| `transactionType` | Present when backend transaction status/indexing is used. |
 | `actionCount` | Present for direct execute-actions. |
 
-DAO publish/create attempt is `transaction_start` with `flow: 'create_dao'` and `transactionKind: 'dao_create'`.
+DAO publish/create attempt is `transaction_start` with `flow: 'create_dao'` and `transactionTypeEvent: 'dao_create'`.
 
 ### `transaction_stage`
 
@@ -253,7 +253,7 @@ Required props:
 | Prop | Notes |
 | --- | --- |
 | `flow` | Product flow. |
-| `transactionKind` | Low-cardinality transaction purpose. |
+| `transactionTypeEvent` | Low-cardinality transaction purpose. |
 | `network` | Transaction network. |
 | `chainId` | Required chain ID. |
 | `status` | Currently `submitted` or `confirmed`. |
@@ -267,12 +267,12 @@ Required props:
 | Prop | Notes |
 | --- | --- |
 | `flow` | Product flow. |
-| `transactionKind` | Low-cardinality transaction purpose. |
+| `transactionTypeEvent` | Low-cardinality transaction purpose. |
 | `network` | Transaction network. |
 | `chainId` | Required chain ID. |
 | `status` | `confirmed` or `indexed`. |
 
-DAO creation success is `transaction_end` with `flow: 'create_dao'`, `transactionKind: 'dao_create'`, and a success `status`.
+DAO creation success is `transaction_end` with `flow: 'create_dao'`, `transactionTypeEvent: 'dao_create'`, and a success `status`.
 
 ### `transaction_failed`
 
@@ -283,7 +283,7 @@ Required props:
 | Prop | Notes |
 | --- | --- |
 | `flow` | Product flow. |
-| `transactionKind` | Low-cardinality transaction purpose. |
+| `transactionTypeEvent` | Low-cardinality transaction purpose. |
 | `network` | Transaction network. |
 | `chainId` | Required chain ID. |
 | `errorClass` | Error class name only, or `unknown`. |
@@ -293,8 +293,43 @@ Optional props:
 | Prop | Notes |
 | --- | --- |
 | `step` | Step where failure happened, e.g. `PREPARE`, `APPROVE`, `CONFIRM`, `INDEXING`. |
+| `status` | Present as `send_error` for direct execute-actions failures. |
 
 Never send raw error messages, stacks, revert reasons, provider payloads, calldata, addresses, hashes, or proposal metadata.
+
+## Where each event fires
+
+Each event is fired by exactly one place in the app: a page, dialog, or hook. These are code paths, not the Plausible dashboard Goals covered in the next section. The wizard and transaction events are opt-in, so their component fires them only when it is given analytics metadata.
+
+| Events | Fired by | Current application surfaces |
+| --- | --- | --- |
+| `wizard_start`, `wizard_step` | `WizardRoot` | `createDaoPageClient` (`create_dao`), `createProcessPageClient` (`governance_designer`), `createProposalPageClient` (`create_proposal`), and `createExecuteActionsPageClient` (`direct_execute_actions`) |
+| `wizard_validation_blocked` | `WizardForm` | The same four analytics-enabled wizards |
+| `wizard_submit` | Flow page client | `createDaoPageClient`, `createProcessPageClient`, `createProposalPageClient`, and `createExecuteActionsPageClient` |
+| `transaction_start`, `transaction_stage`, `transaction_end`, `transaction_failed` | `TransactionDialog` | `publishDaoDialog`, `publishProposalDialog`, `executeDialog`, and `voteDialog`, when passed an `analytics` prop |
+| `transaction_start`, `transaction_stage`, `transaction_failed` | `ExecuteActionsDialog` | Direct admin action execution (`direct_execute_actions`) |
+| `action_added`, `action_added_batch` | `useProposalActionsField` | Proposal and direct-execute action forms |
+
+## Plausible dashboard declarations
+
+Plausible is a passive receiver. It has no registry of the app's event names; it only learns an event exists once the tracker sends it to `/api/event`. Both steps are required, in order: the app emits the event, and a matching Custom event Goal exists for the count to appear. A Goal with no matching event sits at zero forever, and an event with no Goal is received but never shown. Past events are not backfilled, so a Goal counts only from when you create it.
+
+In the development site (`dev.app.aragon.org`) and production site (`app.aragon.org`), create one Custom event Goal for each exact event name the app emits:
+
+- `wizard_start`
+- `wizard_step`
+- `wizard_submit`
+- `wizard_validation_blocked`
+- `action_added`
+- `action_added_batch`
+- `transaction_start`
+- `transaction_stage`
+- `transaction_end`
+- `transaction_failed`
+
+Create property-filtered Goals only when a funnel needs a specific segment, using `flow` and/or `transactionTypeEvent` (Plausible allows up to three property constraints per Goal). Do not register Goals for names the app does not emit, such as the backend `transactionType` or Title Case labels; a Goal for a non-emitted name is a permanent zero. When a new surface ships, add its name to `PlausibleAnalyticsEventName`, emit it from that UI, then register the Goal.
+
+Renaming an emitted property key does not require rebuilding event Goals. The ten event names above are unchanged, so unfiltered Goals and their funnels keep working. Only update Goals, funnels, and saved filters that constrain on `transactionKind`: edit those in place to `transactionTypeEvent`. Historical events keep the old key, so segmented data splits at the rename boundary; do not dual-send both keys to paper over it.
 
 ## Adding a new event
 

--- a/apps/app/src/modules/createDao/dialogs/publishDaoDialog/publishDaoDialog.tsx
+++ b/apps/app/src/modules/createDao/dialogs/publishDaoDialog/publishDaoDialog.tsx
@@ -172,7 +172,7 @@ export const PublishDaoDialog: React.FC<IPublishDaoDialogProps> = (props) => {
         <TransactionDialog<PublishDaoStep>
             analytics={{
                 flow: 'create_dao',
-                transactionKind: 'dao_create',
+                transactionTypeEvent: 'dao_create',
             }}
             customSteps={customSteps}
             description={t('app.createDao.publishDaoDialog.description')}

--- a/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.test.tsx
+++ b/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.test.tsx
@@ -156,14 +156,14 @@ describe('<ExecuteActionsDialog /> component', () => {
         );
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_start', {
             flow: 'direct_execute_actions',
-            transactionKind: 'admin_instant_execute',
+            transactionTypeEvent: 'admin_instant_execute',
             network,
             chainId: networkDefinitions[network].id,
             actionCount: 0,
         });
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_stage', {
             flow: 'direct_execute_actions',
-            transactionKind: 'admin_instant_execute',
+            transactionTypeEvent: 'admin_instant_execute',
             network,
             chainId: networkDefinitions[network].id,
             status: 'submitted',
@@ -200,7 +200,7 @@ describe('<ExecuteActionsDialog /> component', () => {
 
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_failed', {
             flow: 'direct_execute_actions',
-            transactionKind: 'admin_instant_execute',
+            transactionTypeEvent: 'admin_instant_execute',
             network,
             chainId: networkDefinitions[network].id,
             status: 'send_error',

--- a/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/executeActionsDialog/executeActionsDialog.tsx
@@ -87,7 +87,7 @@ export const ExecuteActionsDialog: React.FC<IExecuteActionsDialogProps> = (
     const analyticsProps = useMemo(
         () => ({
             flow: 'direct_execute_actions',
-            transactionKind: 'admin_instant_execute',
+            transactionTypeEvent: 'admin_instant_execute',
             network,
             chainId: requiredChainId,
             actionCount: actions.length,

--- a/apps/app/src/modules/governance/dialogs/executeDialog/executeDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/executeDialog/executeDialog.tsx
@@ -89,7 +89,7 @@ export const ExecuteDialog: React.FC<IExecuteDialogProps> = (props) => {
         <TransactionDialog
             analytics={{
                 flow: 'proposal_execution',
-                transactionKind: 'governance_proposal_execute',
+                transactionTypeEvent: 'governance_proposal_execute',
             }}
             description={t('app.governance.executeDialog.description')}
             indexingFallbackUrl={daoUtils.getDaoUrl(dao, `proposals/${slug}`)}

--- a/apps/app/src/modules/governance/dialogs/publishProposalDialog/publishProposalDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/publishProposalDialog/publishProposalDialog.tsx
@@ -186,7 +186,7 @@ export const PublishProposalDialog: React.FC<IPublishProposalDialogProps> = (
         <TransactionDialog<PublishProposalStep>
             analytics={{
                 flow: 'create_proposal',
-                transactionKind: 'governance_proposal_create',
+                transactionTypeEvent: 'governance_proposal_create',
             }}
             customSteps={customSteps}
             description={t(`${namespace}.description`)}

--- a/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
@@ -123,7 +123,7 @@ export const VoteDialog: React.FC<IVoteDialogProps> = (props) => {
         <TransactionDialog
             analytics={{
                 flow: 'proposal_vote',
-                transactionKind: 'governance_proposal_vote',
+                transactionTypeEvent: 'governance_proposal_vote',
             }}
             description={t('app.governance.voteDialog.description')}
             indexingFallbackUrl={

--- a/apps/app/src/shared/components/transactionDialog/transactionDialog.api.ts
+++ b/apps/app/src/shared/components/transactionDialog/transactionDialog.api.ts
@@ -76,9 +76,11 @@ export interface ITransactionDialogAnalytics {
      */
     flow?: string;
     /**
-     * Low-cardinality transaction kind within the product flow.
+     * Low-cardinality analytics classification of the transaction within the product flow. Emitted
+     * on `transaction_*` events as `transactionTypeEvent`. Distinct from the backend
+     * `transactionType` enum prop, which is intentionally not sent to analytics.
      */
-    transactionKind?: string;
+    transactionTypeEvent?: string;
 }
 
 export interface ITransactionDialogProps<

--- a/apps/app/src/shared/components/transactionDialog/transactionDialog.test.tsx
+++ b/apps/app/src/shared/components/transactionDialog/transactionDialog.test.tsx
@@ -435,7 +435,7 @@ describe('<TransactionDialog /> component', () => {
             createTestComponent({
                 analytics: {
                     flow: 'create_proposal',
-                    transactionKind: 'governance_proposal_create',
+                    transactionTypeEvent: 'governance_proposal_create',
                 },
                 stepper,
                 network,
@@ -450,8 +450,7 @@ describe('<TransactionDialog /> component', () => {
 
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_start', {
             flow: 'create_proposal',
-            transactionKind: 'governance_proposal_create',
-            transactionType: TransactionType.PROPOSAL_CREATE,
+            transactionTypeEvent: 'governance_proposal_create',
             network,
             chainId: networkDefinitions[network].id,
             attemptKind: 'new',
@@ -765,7 +764,7 @@ describe('<TransactionDialog /> component', () => {
             createTestComponent({
                 analytics: {
                     flow: 'create_proposal',
-                    transactionKind: 'governance_proposal_create',
+                    transactionTypeEvent: 'governance_proposal_create',
                 },
                 transactionType: TransactionType.PROPOSAL_CREATE,
             }),
@@ -773,8 +772,7 @@ describe('<TransactionDialog /> component', () => {
 
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_failed', {
             flow: 'create_proposal',
-            transactionKind: 'governance_proposal_create',
-            transactionType: TransactionType.PROPOSAL_CREATE,
+            transactionTypeEvent: 'governance_proposal_create',
             network: Network.ETHEREUM_MAINNET,
             chainId: networkDefinitions[Network.ETHEREUM_MAINNET].id,
             step: TransactionDialogStep.CONFIRM,
@@ -1048,7 +1046,7 @@ describe('<TransactionDialog /> onIndexed callback', () => {
         const propsWithCallback: Partial<ITransactionDialogProps> = {
             analytics: {
                 flow: 'create_proposal',
-                transactionKind: 'governance_proposal_create',
+                transactionTypeEvent: 'governance_proposal_create',
             },
             onIndexed,
         };
@@ -1073,8 +1071,7 @@ describe('<TransactionDialog /> onIndexed callback', () => {
         expect(onIndexed).toHaveBeenCalledWith({ slug: 'abc' });
         expect(trackAnalyticsSpy).toHaveBeenCalledWith('transaction_end', {
             flow: 'create_proposal',
-            transactionKind: 'governance_proposal_create',
-            transactionType: TransactionType.PROPOSAL_CREATE,
+            transactionTypeEvent: 'governance_proposal_create',
             chainId: networkDefinitions[Network.ETHEREUM_MAINNET].id,
             network: Network.ETHEREUM_MAINNET,
             status: 'indexed',

--- a/apps/app/src/shared/components/transactionDialog/transactionDialog.tsx
+++ b/apps/app/src/shared/components/transactionDialog/transactionDialog.tsx
@@ -107,11 +107,10 @@ export const TransactionDialog = <TCustomStepId extends string>(
     const getTransactionAnalyticsProps = useCallback(
         () => ({
             ...analyticsRef.current,
-            transactionType,
             network,
             chainId: requiredChainId,
         }),
-        [transactionType, network, requiredChainId],
+        [network, requiredChainId],
     );
 
     const trackTransactionAnalytics = useCallback(


### PR DESCRIPTION
## Summary

Follow-up to #1258. Fixes one real defect from the initial implementation (the `transactionKind`/`transactionType` overlap) and clears two spec/doc items product raised while reviewing the original proposal. The transport pipeline is unchanged; the analytics payload keys change (one rename, one field dropped).

## Changes

- Rename the analytics prop `transactionKind` to `transactionTypeEvent` across `transactionDialog` and the five emitting dialogs (`publishDaoDialog`, `publishProposalDialog`, `executeDialog`, `voteDialog`, `executeActionsDialog`). It is the single low-cardinality transaction classification on `transaction_*` events; values stay snake_case (`dao_create`, `governance_proposal_create`, ...).
- Stop sending the backend `transactionType` enum on analytics events. It stays on `TransactionDialog` for the pending-transaction manager (resume, duplicate detection, indexing) but is no longer copied into the payload.
- Update `analyticsEvents.md`: rename the "Emitters" section to "Where each event fires", drop the internal "emitter" term (not used in code), map every event to the component that fires it, and document emit-first ordering plus per-site Custom event Goal registration.

## QA items

- **`transactionKind` vs `transactionType` (real defect, fixed here).** The initial implementation put two near-synonym keys on the same event, and the DAO case was actively wrong: `transactionKind: dao_create` next to `transactionType: pluginCreate`. Now there is one analytics label (`transactionTypeEvent`); the backend enum is no longer sent to analytics.
- **`deposit_address_copied` (in the reviewed spec, never in code).** Never emitted. `deposit` in the app only names the inbound treasury ledger tab, so the event would clash with that meaning and describe a flow we do not have. Not added until a real receive/fund surface ships.
- **"what are emitters?" (doc jargon).** Internal term that leaked into a product-facing section; removed, section renamed, each event mapped to its component.

## Dashboard migration (manual, not code)

Plausible reports an event only after the app emits it and a matching Custom event Goal exists per site; past events are not backfilled, so a Goal counts from its creation time. Goal setup is a manual per-site step in `dev.app.aragon.org` and `app.aragon.org`.

The rename has dashboard blast radius: any existing Goal or saved filter constraining on `transactionKind` (there is already at least one property-filtered Goal live in dev) stops matching once this deploys, and must be edited in place to `transactionTypeEvent` with values unchanged, in lockstep with the release. Any of the 10 base event Goals not yet created still need adding by hand. The list and migration note are in `analyticsEvents.md`.

## Verification

- Affected Jest suites pass (`transactionDialog`, `executeActionsDialog`, `executeDialog`, `publishProposalDialog`, `voteDialog`, analytics utils).
- `pnpm type-check` clean.
- Biome clean on changed files; pre-push Turbo run green (lint, type-check, 15 suites / 125 tests).
