### PR TITLE
feat(APP-1035): show token logo for uploaded transfer actions

### DIFF
--- a/.changeset/app-1035-imported-transfer-token-logo.md
+++ b/.changeset/app-1035-imported-transfer-token-logo.md
@@ -2,4 +2,4 @@
 "@aragon/app": patch
 ---
 
-Show the token logo for uploaded transfer actions
+Show the token logo for uploaded transfer actions and assets added by address

--- a/.changeset/app-1035-imported-transfer-token-logo.md
+++ b/.changeset/app-1035-imported-transfer-token-logo.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Show the token logo for uploaded transfer actions

--- a/apps/app/src/modules/finance/api/financeService/financeService.api.ts
+++ b/apps/app/src/modules/finance/api/financeService/financeService.api.ts
@@ -66,3 +66,17 @@ export interface IGetTransactionActionsUrlParams {
 
 export interface IGetTransactionActionsParams
     extends IRequestUrlParams<IGetTransactionActionsUrlParams> {}
+
+export interface IGetTokenInfoUrlParams {
+    /**
+     * Network of the token.
+     */
+    network: Network;
+    /**
+     * Address of the token.
+     */
+    address: string;
+}
+
+export interface IGetTokenInfoParams
+    extends IRequestUrlParams<IGetTokenInfoUrlParams> {}

--- a/apps/app/src/modules/finance/api/financeService/financeService.ts
+++ b/apps/app/src/modules/finance/api/financeService/financeService.ts
@@ -6,9 +6,10 @@ import {
     AragonBackendService,
     type IPaginatedResponse,
 } from '@/shared/api/aragonBackendService';
-import type { IAsset } from './domain';
+import type { IAsset, IToken } from './domain';
 import type {
     IGetAssetListParams,
+    IGetTokenInfoParams,
     IGetTransactionActionsParams,
     IGetTransactionListParams,
 } from './financeService.api';
@@ -16,8 +17,15 @@ import type {
 class FinanceService extends AragonBackendService {
     private urls = {
         assets: '/v2/assets',
+        token: '/v2/tokens/:network/:address',
         transactions: '/v2/transactions',
         transactionActions: '/v2/transactions/:network/:id/actions',
+    };
+
+    getTokenInfo = async (params: IGetTokenInfoParams): Promise<IToken> => {
+        const result = await this.request<IToken>(this.urls.token, params);
+
+        return result;
     };
 
     getAssetList = async (

--- a/apps/app/src/modules/finance/api/financeService/financeServiceKeys.ts
+++ b/apps/app/src/modules/finance/api/financeService/financeServiceKeys.ts
@@ -1,11 +1,13 @@
 import type {
     IGetAssetListParams,
+    IGetTokenInfoParams,
     IGetTransactionActionsParams,
     IGetTransactionListParams,
 } from './financeService.api';
 
 export enum FinanceServiceKey {
     ASSET_LIST = 'ASSET_LIST',
+    TOKEN_INFO = 'TOKEN_INFO',
     TRANSACTION_ACTIONS = 'TRANSACTION_ACTIONS',
     TRANSACTION_LIST = 'TRANSACTION_LIST',
 }
@@ -13,6 +15,10 @@ export enum FinanceServiceKey {
 export const financeServiceKeys = {
     assetList: (params: IGetAssetListParams) => [
         FinanceServiceKey.ASSET_LIST,
+        params,
+    ],
+    tokenInfo: (params: IGetTokenInfoParams) => [
+        FinanceServiceKey.TOKEN_INFO,
         params,
     ],
     transactionList: (params: IGetTransactionListParams) => [

--- a/apps/app/src/modules/finance/api/financeService/queries/index.ts
+++ b/apps/app/src/modules/finance/api/financeService/queries/index.ts
@@ -1,3 +1,4 @@
 export * from './useAssetList';
+export * from './useTokenInfo';
 export * from './useTransactionActions';
 export * from './useTransactionList';

--- a/apps/app/src/modules/finance/api/financeService/queries/useTokenInfo/index.ts
+++ b/apps/app/src/modules/finance/api/financeService/queries/useTokenInfo/index.ts
@@ -1,0 +1,1 @@
+export { tokenInfoOptions, useTokenInfo } from './useTokenInfo';

--- a/apps/app/src/modules/finance/api/financeService/queries/useTokenInfo/useTokenInfo.test.ts
+++ b/apps/app/src/modules/finance/api/financeService/queries/useTokenInfo/useTokenInfo.test.ts
@@ -1,0 +1,30 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { generateToken } from '@/modules/finance/testUtils';
+import { Network } from '@/shared/api/daoService';
+import { ReactQueryWrapper } from '@/shared/testUtils';
+import { financeService } from '../../financeService';
+import { useTokenInfo } from './useTokenInfo';
+
+describe('useTokenInfo query', () => {
+    const financeServiceSpy = jest.spyOn(financeService, 'getTokenInfo');
+
+    afterEach(() => {
+        financeServiceSpy.mockReset();
+    });
+
+    it('fetches the token info for the specified network and address', async () => {
+        const params = {
+            network: Network.ETHEREUM_SEPOLIA,
+            address: '0x8115B4F2aC13FC3444Ca88b448a1c8092793b569',
+        };
+        const token = generateToken({ address: params.address });
+        financeServiceSpy.mockResolvedValue(token);
+        const { result } = renderHook(
+            () => useTokenInfo({ urlParams: params }),
+            {
+                wrapper: ReactQueryWrapper,
+            },
+        );
+        await waitFor(() => expect(result.current.data).toEqual(token));
+    });
+});

--- a/apps/app/src/modules/finance/api/financeService/queries/useTokenInfo/useTokenInfo.ts
+++ b/apps/app/src/modules/finance/api/financeService/queries/useTokenInfo/useTokenInfo.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import type { QueryOptions, SharedQueryOptions } from '@/shared/types';
+import type { IToken } from '../../domain';
+import { financeService } from '../../financeService';
+import type { IGetTokenInfoParams } from '../../financeService.api';
+import { financeServiceKeys } from '../../financeServiceKeys';
+
+export const tokenInfoOptions = (
+    params: IGetTokenInfoParams,
+    options?: QueryOptions<IToken>,
+): SharedQueryOptions<IToken> => ({
+    queryKey: financeServiceKeys.tokenInfo(params),
+    queryFn: () => financeService.getTokenInfo(params),
+    ...options,
+});
+
+export const useTokenInfo = (
+    params: IGetTokenInfoParams,
+    options?: QueryOptions<IToken>,
+) => useQuery(tokenInfoOptions(params, options));

--- a/apps/app/src/modules/finance/components/assetAddressSelect/assetAddressSelectAddAddressView.test.tsx
+++ b/apps/app/src/modules/finance/components/assetAddressSelect/assetAddressSelectAddAddressView.test.tsx
@@ -1,8 +1,14 @@
 import { GukModulesProvider } from '@aragon/gov-ui-kit';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import * as financeService from '@/modules/finance/api/financeService';
+import { generateToken } from '@/modules/finance/testUtils';
 import { Network } from '@/shared/api/daoService';
 import * as useTokenModule from '@/shared/hooks/useToken/useToken';
+import {
+    generateReactQueryResultLoading,
+    generateReactQueryResultSuccess,
+} from '@/shared/testUtils';
 import {
     AssetAddressSelectAddAddressView,
     type IAssetAddressSelectAddAddressViewProps,
@@ -10,6 +16,7 @@ import {
 
 describe('<AssetAddressSelectAddAddressView /> component', () => {
     const useTokenSpy = jest.spyOn(useTokenModule, 'useToken');
+    const useTokenInfoSpy = jest.spyOn(financeService, 'useTokenInfo');
 
     beforeEach(() => {
         useTokenSpy.mockReturnValue({
@@ -17,10 +24,16 @@ describe('<AssetAddressSelectAddAddressView /> component', () => {
             isLoading: false,
             isError: false,
         });
+        useTokenInfoSpy.mockReturnValue(
+            generateReactQueryResultLoading() as ReturnType<
+                typeof financeService.useTokenInfo
+            >,
+        );
     });
 
     afterEach(() => {
         useTokenSpy.mockReset();
+        useTokenInfoSpy.mockReset();
     });
 
     const createTestComponent = (
@@ -115,6 +128,40 @@ describe('<AssetAddressSelectAddAddressView /> component', () => {
         );
 
         expect(screen.getByText('Wrapped stETH')).toBeInTheDocument();
+    });
+
+    it('builds the asset with the logo fetched from the backend token info', async () => {
+        useTokenSpy.mockReturnValue({
+            data: {
+                name: 'Wrapped stETH',
+                symbol: 'wstETH',
+                decimals: 18,
+                totalSupply: '0',
+            },
+            isLoading: false,
+            isError: false,
+        });
+        useTokenInfoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({
+                data: generateToken({ logo: 'wsteth-logo.png' }),
+            }),
+        );
+        const onAssetClick = jest.fn();
+
+        render(createTestComponent({ onAssetClick }));
+
+        const user = userEvent.setup();
+        await user.type(
+            screen.getByRole('searchbox'),
+            '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
+        );
+        await user.click(screen.getByText('Wrapped stETH'));
+
+        expect(onAssetClick).toHaveBeenCalledWith(
+            expect.objectContaining({
+                token: expect.objectContaining({ logo: 'wsteth-logo.png' }),
+            }),
+        );
     });
 
     it('renders the not-a-token empty state when useToken resolves with no data', async () => {

--- a/apps/app/src/modules/finance/components/assetAddressSelect/assetAddressSelectAddAddressView.tsx
+++ b/apps/app/src/modules/finance/components/assetAddressSelect/assetAddressSelectAddAddressView.tsx
@@ -9,7 +9,10 @@ import {
 } from '@aragon/gov-ui-kit';
 import { useState } from 'react';
 import type { Hex } from 'viem';
-import type { IAsset } from '@/modules/finance/api/financeService';
+import {
+    type IAsset,
+    useTokenInfo,
+} from '@/modules/finance/api/financeService';
 import type { Network } from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
 import { useToken } from '@/shared/hooks/useToken';
@@ -70,6 +73,11 @@ export const AssetAddressSelectAddAddressView: React.FC<
         chainId,
     });
 
+    const { data: tokenInfo } = useTokenInfo(
+        { urlParams: { network, address: resolvedAddress ?? '' } },
+        { enabled: resolvedAddress != null },
+    );
+
     const asset: IAsset | undefined =
         resolvedAddress != null && tokenData != null
             ? {
@@ -80,7 +88,7 @@ export const AssetAddressSelectAddAddressView: React.FC<
                       name: tokenData.name || 'Unknown',
                       symbol: tokenData.symbol || 'UNKNOWN',
                       decimals: tokenData.decimals,
-                      logo: '',
+                      logo: tokenInfo?.logo ?? '',
                       priceUsd: '0',
                       totalSupply: tokenData.totalSupply,
                   },

--- a/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.test.tsx
+++ b/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.test.tsx
@@ -4,12 +4,15 @@ import userEvent from '@testing-library/user-event';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { encodeFunctionData, erc20Abi, parseUnits } from 'viem';
 import * as wagmi from 'wagmi';
+import * as financeService from '@/modules/finance/api/financeService';
+import { generateToken } from '@/modules/finance/testUtils';
 import * as daoService from '@/shared/api/daoService';
 import * as DialogProvider from '@/shared/components/dialogProvider';
 import * as useTokenModule from '@/shared/hooks/useToken/useToken';
 import {
     generateDao,
     generateDialogContext,
+    generateReactQueryResultLoading,
     generateReactQueryResultSuccess,
 } from '@/shared/testUtils';
 import type { IProposalActionData } from '../../../createProposalFormDefinitions';
@@ -18,6 +21,7 @@ import { TransferAssetAction } from './transferAssetAction';
 describe('<TransferAssetAction /> component', () => {
     const useDaoSpy = jest.spyOn(daoService, 'useDao');
     const useTokenSpy = jest.spyOn(useTokenModule, 'useToken');
+    const useTokenInfoSpy = jest.spyOn(financeService, 'useTokenInfo');
     const useReadContractSpy = jest.spyOn(wagmi, 'useReadContract');
     const useBalanceSpy = jest.spyOn(wagmi, 'useBalance');
     const useDialogContextSpy = jest.spyOn(DialogProvider, 'useDialogContext');
@@ -86,6 +90,11 @@ describe('<TransferAssetAction /> component', () => {
             isLoading: true,
             isError: false,
         });
+        useTokenInfoSpy.mockReturnValue(
+            generateReactQueryResultLoading() as ReturnType<
+                typeof financeService.useTokenInfo
+            >,
+        );
         useReadContractSpy.mockReturnValue({
             data: BigInt(0),
         } as unknown as wagmi.UseReadContractReturnType);
@@ -98,6 +107,7 @@ describe('<TransferAssetAction /> component', () => {
     afterEach(() => {
         useDaoSpy.mockReset();
         useTokenSpy.mockReset();
+        useTokenInfoSpy.mockReset();
         useReadContractSpy.mockReset();
         useBalanceSpy.mockReset();
         useDialogContextSpy.mockReset();
@@ -181,6 +191,27 @@ describe('<TransferAssetAction /> component', () => {
         expect(action.data).toEqual(originalData);
         expect(action.asset.token.decimals).toEqual(6);
         expect(action.rawAmount).toBeUndefined();
+    });
+
+    it('sets the token logo fetched from the backend token info', () => {
+        useTokenSpy.mockReturnValue({
+            data: resolvedToken,
+            isLoading: false,
+            isError: false,
+        });
+        useTokenInfoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({
+                data: generateToken({
+                    address: tokenAddress,
+                    logo: 'usdc-logo.png',
+                }),
+            }),
+        );
+
+        render(createTestComponent(generateImportedAction()));
+
+        const action = getFormValues('actions.0');
+        expect(action.asset.token.logo).toEqual('usdc-logo.png');
     });
 
     it('re-encodes the calldata from user edits when the token query fails for an imported action', async () => {

--- a/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.test.tsx
+++ b/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.test.tsx
@@ -214,6 +214,41 @@ describe('<TransferAssetAction /> component', () => {
         expect(action.asset.token.logo).toEqual('usdc-logo.png');
     });
 
+    it('does not apply the fetched logo when the selected asset no longer matches the action token', () => {
+        useTokenSpy.mockReturnValue({
+            data: resolvedToken,
+            isLoading: false,
+            isError: false,
+        });
+        useTokenInfoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({
+                data: generateToken({
+                    address: tokenAddress,
+                    logo: 'usdc-logo.png',
+                }),
+            }),
+        );
+
+        // Already initialized action where the user picked another asset in the meantime.
+        const importedAction = generateImportedAction();
+        const otherAssetAction = {
+            ...importedAction,
+            rawAmount: undefined,
+            asset: {
+                ...importedAction.asset,
+                token: {
+                    ...importedAction.asset.token,
+                    address: '0x3333333333333333333333333333333333333333',
+                },
+            },
+        };
+
+        render(createTestComponent(otherAssetAction));
+
+        const action = getFormValues('actions.0');
+        expect(action.asset.token.logo).toEqual('');
+    });
+
     it('re-encodes the calldata from user edits when the token query fails for an imported action', async () => {
         useTokenSpy.mockReturnValue({
             data: null,

--- a/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
+++ b/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
@@ -14,7 +14,10 @@ import {
     zeroAddress,
 } from 'viem';
 import { useBalance, useReadContract } from 'wagmi';
-import type { IAsset } from '@/modules/finance/api/financeService';
+import {
+    type IAsset,
+    useTokenInfo,
+} from '@/modules/finance/api/financeService';
 import {
     type ITransferAssetFormData,
     TransferAssetForm,
@@ -92,6 +95,14 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
         enabled: disableTokenSelection || isImportedErc20Action,
     });
     const isImportPending = isImportedErc20Action && !isTokenError;
+
+    // The token logo is not available on-chain, fetch it from the backend. Best effort:
+    // the backend might not know the token, so on-chain data stays the source of truth.
+    const { data: tokenInfo } = useTokenInfo(
+        { urlParams: { network: dao!.network, address: action.to } },
+        { enabled: disableTokenSelection || isImportedErc20Action },
+    );
+    const importedTokenLogo = tokenInfo?.logo ?? '';
     const { data: balance } = useReadContract({
         abi: erc20Abi,
         address: action.to as Hex,
@@ -158,7 +169,7 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
             ...token,
             address: tokenAddress,
             network: dao!.network,
-            logo: '',
+            logo: importedTokenLogo,
             priceUsd: '0',
         };
         const tokenBalance = formatUnits(balance, tokenDecimals);
@@ -171,6 +182,7 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
         balance,
         tokenAddress,
         tokenDecimals,
+        importedTokenLogo,
         setValue,
         fieldName,
         dao,
@@ -190,7 +202,7 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
             ...token,
             address: tokenAddress,
             network: dao!.network,
-            logo: '',
+            logo: importedTokenLogo,
             priceUsd: '0',
         };
 
@@ -214,10 +226,28 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
         token,
         action.rawAmount,
         tokenAddress,
+        importedTokenLogo,
         dao,
         setValue,
         fieldName,
     ]);
+
+    // The asset list can resolve after the imported action was already initialized with an
+    // empty logo, so patch the asset once the logo is known.
+    useEffect(() => {
+        if (
+            !importedTokenLogo ||
+            asset == null ||
+            asset.token.logo === importedTokenLogo
+        ) {
+            return;
+        }
+
+        setValue(`${fieldName}.asset`, {
+            ...asset,
+            token: { ...asset.token, logo: importedTokenLogo },
+        });
+    }, [importedTokenLogo, asset, fieldName, setValue]);
 
     // Update asset balance for imported actions. Uploaded and decoded transfer actions have token info, but don't have max available balance for the given DAO.
     useEffect(() => {

--- a/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
+++ b/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
@@ -96,8 +96,6 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
     });
     const isImportPending = isImportedErc20Action && !isTokenError;
 
-    // The token logo is not available on-chain, fetch it from the backend. Best effort:
-    // the backend might not know the token, so on-chain data stays the source of truth.
     const { data: tokenInfo } = useTokenInfo(
         { urlParams: { network: dao!.network, address: action.to } },
         { enabled: disableTokenSelection || isImportedErc20Action },
@@ -232,8 +230,8 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
         fieldName,
     ]);
 
-    // The asset list can resolve after the imported action was already initialized with an
-    // empty logo, so patch the asset once the logo is known.
+    // The backend token info can resolve after the imported action was already initialized
+    // with an empty logo, so patch the asset once the logo is known.
     useEffect(() => {
         if (
             !importedTokenLogo ||

--- a/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
+++ b/apps/app/src/modules/governance/components/createProposalForm/createProposalFormActions/proposalActions/transferAssetAction/transferAssetAction.tsx
@@ -231,21 +231,27 @@ export const TransferAssetAction: React.FC<ITransferAssetActionProps> = (
     ]);
 
     // The backend token info can resolve after the imported action was already initialized
-    // with an empty logo, so patch the asset once the logo is known.
+    // with an empty logo, so patch the asset once the logo is known. The address check makes
+    // sure the logo is not applied to another asset the user selected in the meantime.
     useEffect(() => {
         if (
-            !importedTokenLogo ||
+            tokenInfo == null ||
+            !tokenInfo.logo ||
             asset == null ||
-            asset.token.logo === importedTokenLogo
+            !addressUtils.isAddressEqual(
+                asset.token.address,
+                tokenInfo.address,
+            ) ||
+            asset.token.logo === tokenInfo.logo
         ) {
             return;
         }
 
         setValue(`${fieldName}.asset`, {
             ...asset,
-            token: { ...asset.token, logo: importedTokenLogo },
+            token: { ...asset.token, logo: tokenInfo.logo },
         });
-    }, [importedTokenLogo, asset, fieldName, setValue]);
+    }, [tokenInfo, asset, fieldName, setValue]);
 
     // Update asset balance for imported actions. Uploaded and decoded transfer actions have token info, but don't have max available balance for the given DAO.
     useEffect(() => {


### PR DESCRIPTION
# Description

Stacked on #1301.

Uploaded transfer actions and assets added by address were rendered without the token logo, the logo is not available on-chain so we were always setting an empty string.

Added a `useTokenInfo` query in financeService using the backend api `/v2/tokens/:network/:address` and use it to fill the logo when initializing the imported action and when resolving an asset by address in the asset selection dialog. Best effort, if the backend does not know the token the logo stays empty.

## Type of Change

- [x] Patch: Enhancement (non-breaking change to an existing feature)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes