### PR TITLE
fix: Fix stale watched action data overwriting proposal actions after remove/add

### DIFF
--- a/.changeset/fix-actions-state-management.md
+++ b/.changeset/fix-actions-state-management.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Fix stale watched action data overwriting proposal actions after remove/add

--- a/apps/app/src/modules/governance/hooks/useProposalActionsField/useProposalActionsField.test.ts
+++ b/apps/app/src/modules/governance/hooks/useProposalActionsField/useProposalActionsField.test.ts
@@ -2,7 +2,78 @@ import { act, renderHook } from '@testing-library/react';
 import { FormWrapper } from '@/shared/testUtils';
 import { plausibleAnalyticsUtils } from '@/shared/utils/plausibleAnalyticsUtils';
 import type { IProposalActionData } from '../../components/createProposalForm';
-import { useProposalActionsField } from './useProposalActionsField';
+import {
+    mergeWatchedAction,
+    useProposalActionsField,
+} from './useProposalActionsField';
+
+describe('mergeWatchedAction', () => {
+    const generateAction = (
+        action?: Partial<IProposalActionData>,
+    ): IProposalActionData =>
+        ({
+            type: 'transfer',
+            daoId: 'test',
+            meta: undefined,
+            ...action,
+        }) as IProposalActionData;
+
+    it('merges the watched values when they belong to the same action', () => {
+        const field = generateAction({
+            type: 'transfer',
+            fieldId: 'action-1',
+            id: 'rhf-1',
+        });
+        const watchedAction = generateAction({
+            type: 'transfer',
+            fieldId: 'action-1',
+            amount: '100',
+        } as Partial<IProposalActionData>);
+
+        expect(mergeWatchedAction(field, watchedAction)).toEqual({
+            ...field,
+            ...watchedAction,
+            fieldId: 'action-1',
+        });
+    });
+
+    it('ignores a watched action left over from a deleted action at the same index', () => {
+        // Reproduces deleting an action and adding a different one: `useFieldArray`'s `fields`
+        // already reflect the new action, but `useWatch` can still be one render behind and hand
+        // back data describing the action that used to sit at this index.
+        const field = generateAction({
+            type: 'gaugeRegistrarRegisterGauge',
+            fieldId: 'action-2',
+            id: 'rhf-2',
+        });
+        const staleWatchedAction = generateAction({
+            type: 'transfer',
+            fieldId: 'action-1',
+            amount: '100',
+        } as Partial<IProposalActionData>);
+
+        const result = mergeWatchedAction(field, staleWatchedAction);
+
+        expect(result.type).toEqual('gaugeRegistrarRegisterGauge');
+        expect(result).not.toHaveProperty('amount');
+        expect(result.fieldId).toEqual('action-2');
+    });
+
+    it('falls back to the field id when neither the field nor the watched action carry a fieldId', () => {
+        const field = generateAction({ fieldId: undefined, id: 'rhf-3' });
+
+        expect(mergeWatchedAction(field, undefined).fieldId).toEqual('rhf-3');
+    });
+
+    it('does not merge when there is no watched action yet at this index', () => {
+        const field = generateAction({ fieldId: 'action-4', id: 'rhf-4' });
+
+        expect(mergeWatchedAction(field, undefined)).toEqual({
+            ...field,
+            fieldId: 'action-4',
+        });
+    });
+});
 
 describe('useProposalActionsField hook', () => {
     const trackAnalyticsSpy = jest.spyOn(plausibleAnalyticsUtils, 'track');

--- a/apps/app/src/modules/governance/hooks/useProposalActionsField/useProposalActionsField.ts
+++ b/apps/app/src/modules/governance/hooks/useProposalActionsField/useProposalActionsField.ts
@@ -40,6 +40,32 @@ const resolveActionCategory = (action: IProposalActionData) => {
     return 'unknown_native';
 };
 
+/**
+ * Merges a field-array entry with its watched form value.
+ *
+ * `useFieldArray`'s `fields` update synchronously inside `remove()`/`append()`, but `useWatch` only
+ * catches up a render later, through react-hook-form's own internal broadcast. Comparing array
+ * length alone is not enough to detect that lag: deleting one action and adding a different one
+ * leaves the array length unchanged, so a `watchedAction` that still describes the just-deleted
+ * action can slip through - overwriting not just stale field values but the new action's `type`,
+ * which silently mounts the wrong view populated with the previous action's data. Comparing
+ * `fieldId` (unique per action instance) catches the lag even when the length coincidentally
+ * matches again.
+ */
+export const mergeWatchedAction = (
+    field: IProposalActionData,
+    watchedAction: IProposalActionData | undefined,
+): IProposalActionData => {
+    const fieldId = field.fieldId ?? field.id;
+    const isWatchedActionCurrent = watchedAction?.fieldId === fieldId;
+
+    return {
+        ...field,
+        ...(isWatchedActionCurrent ? watchedAction : undefined),
+        fieldId,
+    };
+};
+
 export const useProposalActionsField = () => {
     const { t } = useTranslations();
 
@@ -57,19 +83,9 @@ export const useProposalActionsField = () => {
     const watchActions = useWatch<
         Record<string, ICreateProposalFormData['actions']>
     >({ name: 'actions' });
-    // Skip stale watch data when lengths diverge after remove() to avoid index corruption.
-    const stableWatchActions =
-        watchActions?.length === actions.length ? watchActions : undefined;
-    const actionsMerged = actions.map((field, index) => ({
-        ...field,
-        ...stableWatchActions?.[index],
-        // `fieldId` is our own stable id (assigned in handleAddAction) and is the React key for the
-        // item. It lives in the form values, so it survives RHF regenerating the field array `id`
-        // when the decoder re-encodes calldata on each keystroke. Every action enters the array via
-        // handleAddAction (which assigns a `fieldId`), so the `field.id` fallback is purely defensive
-        // — it just guarantees a key if some future path adds an action without going through it.
-        fieldId: field.fieldId ?? field.id,
-    }));
+    const actionsMerged = actions.map((field, index) =>
+        mergeWatchedAction(field, watchActions?.[index]),
+    );
 
     /**
      * Note: We don't use useFieldArray.swap() or .move() because they create empty slots


### PR DESCRIPTION
# Description

`useFieldArray`'s `fields` update synchronously inside `remove()`/`append()`, but `useWatch` only catches up a render later. Comparing array length alone isn't enough to detect that lag: deleting one action and adding a different one leaves the array length unchanged, so a stale `watchedAction` describing the just-deleted action can slip through — overwriting the new action's `type` and silently mounting the wrong view populated with the previous action's data.

This replaces the length-based staleness check with a `fieldId` comparison (unique per action instance), which catches the lag even when the length coincidentally matches again.

## Type of Change

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project