### PR TITLE
feat(APP-1012): implement support for plugins with unresolved interface type

### DIFF
--- a/.agents/shared/metrics/hits.jsonl
+++ b/.agents/shared/metrics/hits.jsonl
@@ -155,3 +155,4 @@
 {"ts":"2026-08-03T14:29:17.284Z","tool":"Edit","file":"apps/app/src/actions/core/createProposal/createProposalActionDetails.tsx","rule":"core-action-decoded-input","bytes":948,"elapsed_ms":3,"adapter":"claude"}
 {"ts":"2026-08-03T14:29:22.784Z","tool":"Edit","file":"apps/app/src/actions/core/execute/executeActionDetails.tsx","rule":"core-action-decoded-input","bytes":948,"elapsed_ms":2,"adapter":"claude"}
 {"ts":"2026-08-04T10:56:30.749Z","tool":"Edit","file":"apps/app/src/shared/api/daoService/domain/pluginSettings.ts","rule":"query-and-cache","bytes":2385,"elapsed_ms":3,"adapter":"claude"}
+{"ts":"2026-08-10T03:51:44.869Z","tool":"Edit","file":"apps/app/src/shared/hooks/useDaoPlugins/useDaoPlugins.ts","rule":"plugin-visibility","bytes":2379,"elapsed_ms":1,"adapter":"claude"}

--- a/.agents/shared/skills/rules/plugin-visibility.md
+++ b/.agents/shared/skills/rules/plugin-visibility.md
@@ -1,24 +1,31 @@
 ---
 name: plugin-visibility
-description: Plugin visibility (CMS pluginsToHide) is presentation-only — never filter a list you then look up by address/slug/type.
-globs: apps/app/src/shared/hooks/useDaoPlugins/**, apps/app/src/shared/utils/daoVisibilityUtils/**, apps/app/src/plugins/*/hooks/*NormalizeActions/**, apps/app/src/modules/governance/dialogs/selectPluginDialog/**
+description: Two filters sit on the plugin list — CMS visibility (opt-in, presentation-only) and unknown interface type (opt-out, applied by default). Never filter a list you then look up by address/slug/type.
+globs: apps/app/src/shared/hooks/useDaoPlugins/**, apps/app/src/shared/utils/daoVisibilityUtils/**, apps/app/src/shared/utils/daoUtils/**, apps/app/src/plugins/*/hooks/*NormalizeActions/**, apps/app/src/modules/governance/dialogs/selectPluginDialog/**
 kind: rule
 ---
 
 # plugin-visibility
 
-CMS "hidden" plugins (`IDaoOverride.pluginsToHide`) are a **presentation** concern, not a data concern. The canonical plugin list is always complete.
+Two independent filters sit on the plugin list, and their defaults point in **opposite** directions. Get the axis right before reaching for a flag.
+
+| Axis | Flag | Default | Why |
+| --- | --- | --- | --- |
+| CMS hidden (`pluginsToHide`) | `visibleOnly: true` | off — list is complete | A hidden plugin still works; only its presentation is suppressed, so lookups must resolve it. |
+| Unknown interface type | `includeUnsupported: true` | **on — unknowns are dropped** | The app has no UI to render an unclassified plugin with, so it is never a valid target. |
 
 ## Canon
 
 - `src/shared/hooks/useDaoPlugins/useDaoPlugins.ts` — `visibleOnly?: boolean` gates `filterHiddenPlugins`. Default `false` = full canonical list.
 - `src/shared/utils/daoVisibilityUtils/daoVisibilityUtils.ts` — the only place that removes hidden plugins.
+- `src/shared/utils/daoUtils/daoUtils.ts` — `isSupportedPlugin` is the single predicate for the unknown axis, and `getDaoPlugins` applies it unless `includeUnsupported` is set. Deliberately an interface-type check, never a plugin-registry lookup: the registry populates on demand, so a registry check would mark every plugin unsupported during server rendering.
 
 ## The invariant
 
 - **Lookups use the full list.** Resolving a plugin by `pluginAddress`, `slug`, `interfaceType`, or `type` to read its `.settings`/metadata, render an existing proposal/action, run a guard, submit a vote, or count plugins → call `useDaoPlugins` WITHOUT `visibleOnly`. A hidden plugin must still resolve.
 - **Listings & create-pickers use `visibleOnly: true`.** Rendering a set of plugins to the user — plugin filter tabs (any `useDaoPluginFilterUrlParam` consumer feeding `PluginFilterComponent`), a body/process selector for the aside, or a picker for CREATING new proposals/actions (action composer, process picker, `selectPluginDialog`) → pass `visibleOnly: true`. `useDaoPluginFilterUrlParam` forwards params straight to `useDaoPlugins`, so it inherits the same `false` default — every filter-tab caller must opt in explicitly. Hidden plugins must not be offered for new work.
 - **Never filter-then-find.** If you filter by visibility (`visibleOnly: true` or `filterHiddenPlugins(list)`) and then `list.find(byAddress)`, a hidden target resolves to `undefined` and reading `.settings` crashes with `TypeError: Cannot read properties of undefined (reading 'settings')`. This was a real production bug in the normalize hooks (APP-793).
+- **`includeUnsupported: true` is for on-chain inventory only.** Surfaces that describe what is *installed* rather than what you can *govern with* — the permissions view, contract versions — must pass it, otherwise a contract holding permissions over the DAO silently disappears from the screen an admin uses to audit exactly that. Everywhere else leaves it unset.
 
 ## Null-safety
 

--- a/.changeset/app-1012-unknown-plugins.md
+++ b/.changeset/app-1012-unknown-plugins.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Handle plugins with an unresolved interface type consistently: they are now dropped from the plugin list everywhere instead of only from process lookups, so they no longer surface as unselectable entries. The permissions view and contract versions keep showing them, since those describe what is installed on-chain. Contract updates also no longer offer plugins whose interface type cannot be matched to a known repository, which previously crashed the update dialog

--- a/apps/app/src/modules/application/components/navigations/navigationDao/navigationDao.test.tsx
+++ b/apps/app/src/modules/application/components/navigations/navigationDao/navigationDao.test.tsx
@@ -5,6 +5,7 @@ import { userEvent } from '@testing-library/user-event';
 import * as NextNavigation from 'next/navigation';
 import * as wagmi from 'wagmi';
 import * as UseWalletConnected from '@/modules/application/hooks/useWalletConnected';
+import { PluginInterfaceType } from '@/shared/api/daoService';
 import * as useDialogContext from '@/shared/components/dialogProvider';
 import type * as Navigation from '@/shared/components/navigation';
 import {
@@ -105,6 +106,7 @@ describe('<NavigationDao /> component', () => {
         hasSupportedPluginsSpy.mockReturnValue(true);
 
         const plugin = generateDaoPlugin({
+            interfaceType: PluginInterfaceType.MULTISIG,
             isBody: true,
         });
         const dao = generateDao({ id: 'test', plugins: [plugin] });

--- a/apps/app/src/modules/governance/dialogs/executeDialog/executeDialog.test.tsx
+++ b/apps/app/src/modules/governance/dialogs/executeDialog/executeDialog.test.tsx
@@ -7,6 +7,7 @@ import { render, screen } from '@testing-library/react';
 import { act, type ReactNode } from 'react';
 import * as Wagmi from 'wagmi';
 import * as DaoService from '@/shared/api/daoService';
+import { PluginInterfaceType } from '@/shared/api/daoService';
 import type { IDialogLocation } from '@/shared/components/dialogProvider';
 import {
     type ITransactionDialogProps,
@@ -130,7 +131,13 @@ describe('<ExecuteDialog /> proposal card status after indexing', () => {
         // so proposalUtils.getProposalSlug resolves to SLUG-1.
         useDaoSpy.mockReturnValue(
             generateReactQueryResultSuccess({
-                data: generateDao({ plugins: [generateDaoPlugin()] }),
+                data: generateDao({
+                    plugins: [
+                        generateDaoPlugin({
+                            interfaceType: PluginInterfaceType.MULTISIG,
+                        }),
+                    ],
+                }),
             }),
         );
         const indexedProposal = generateProposal({ id: 'executed-1' });

--- a/apps/app/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPage.test.tsx
+++ b/apps/app/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPage.test.tsx
@@ -2,7 +2,11 @@ import type * as ReactQuery from '@tanstack/react-query';
 import { QueryClient } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { daoService, Network } from '@/shared/api/daoService';
+import {
+    daoService,
+    Network,
+    PluginInterfaceType,
+} from '@/shared/api/daoService';
 import { generateDao, generateDaoPlugin } from '@/shared/testUtils';
 import { daoUtils } from '@/shared/utils/daoUtils';
 import { memberOptions } from '../../api/governanceService';
@@ -39,7 +43,12 @@ describe('<DaoMemberDetailsPage /> component', () => {
         resolveDaoIdSpy.mockResolvedValue('test-dao-id');
         getDaoSpy.mockResolvedValue(
             generateDao({
-                plugins: [generateDaoPlugin({ isBody: true })],
+                plugins: [
+                    generateDaoPlugin({
+                        interfaceType: PluginInterfaceType.MULTISIG,
+                        isBody: true,
+                    }),
+                ],
             }),
         );
     });
@@ -74,6 +83,7 @@ describe('<DaoMemberDetailsPage /> component', () => {
             plugins: [
                 generateDaoPlugin({
                     address: 'test-plugin-address',
+                    interfaceType: PluginInterfaceType.MULTISIG,
                     isBody: true,
                 }),
             ],

--- a/apps/app/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
+++ b/apps/app/src/modules/governance/pages/daoMemberDetailsPage/daoMemberDetailsPageClient.test.tsx
@@ -15,6 +15,7 @@ import { ensRecordKeys } from '@/modules/ens';
 import { DaoList } from '@/modules/explore/components/daoList';
 import * as efpService from '@/modules/governance/api/efpService';
 import * as daoService from '@/shared/api/daoService';
+import { PluginInterfaceType } from '@/shared/api/daoService';
 import { FeatureFlagsProvider } from '@/shared/components/featureFlagsProvider';
 import {
     generateDao,
@@ -63,7 +64,10 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
         'useEnsProfileRecords',
     );
 
-    const defaultPlugin = generateDaoPlugin({ isBody: true });
+    const defaultPlugin = generateDaoPlugin({
+        interfaceType: PluginInterfaceType.MULTISIG,
+        isBody: true,
+    });
 
     beforeEach(() => {
         useDaoSpy.mockReturnValue(
@@ -128,6 +132,7 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
     it('fetches and renders the member ens and avatar', () => {
         const plugin = generateDaoPlugin({
             address: 'plugin-address',
+            interfaceType: PluginInterfaceType.MULTISIG,
             isBody: true,
         });
         const dao = generateDao({
@@ -351,6 +356,7 @@ describe('<DaoMemberDetailsPageClient /> component', () => {
     it('passes the correct params to the DaoList component', () => {
         const plugin = generateDaoPlugin({
             address: 'plugin-address',
+            interfaceType: PluginInterfaceType.MULTISIG,
             isBody: true,
         });
         const dao = generateDao({

--- a/apps/app/src/modules/settings/components/daoVersionInfo/daoVersionInfo.tsx
+++ b/apps/app/src/modules/settings/components/daoVersionInfo/daoVersionInfo.tsx
@@ -26,11 +26,14 @@ export const DaoVersionInfo: React.FC<IDaoVersionInfoProps> = (props) => {
         type: ChainEntityType.ADDRESS,
         id: dao.address,
     });
+    // Lists the installed contracts and their versions, so plugins we cannot
+    // classify belong here too — they are still deployed and upgradeable.
     const processPlugins = useDaoPlugins({
         daoId: dao.id,
         includeSubPlugins: true,
         includeLinkedAccounts: true,
         visibleOnly: true,
+        includeUnsupported: true,
     });
 
     return (

--- a/apps/app/src/modules/settings/dialogs/prepareDaoContractsUpdateDialog/prepareDaoContractsUpdateDialogUtils.ts
+++ b/apps/app/src/modules/settings/dialogs/prepareDaoContractsUpdateDialog/prepareDaoContractsUpdateDialogUtils.ts
@@ -66,7 +66,13 @@ class PrepareDaoContractsUpdateDialogUtils {
     ) => {
         const pluginInfo = pluginRegistryUtils.getPlugin(
             plugin.interfaceType,
-        ) as IPluginInfo;
+        ) as IPluginInfo | undefined;
+
+        // Never encode an update transaction against a plugin we cannot identify.
+        invariant(
+            pluginInfo != null,
+            `PrepareDaoContractsUpdateDialogUtils: no plugin info registered for interface type "${plugin.interfaceType}".`,
+        );
 
         const currentVersionTag =
             versionComparatorUtils.normaliseComparatorInput(plugin)!;
@@ -236,6 +242,8 @@ class PrepareDaoContractsUpdateDialogUtils {
             release: currentRelease,
             build: currentBuild,
         } = plugin;
+        // getAvailablePluginUpdates only returns plugins whose interfaceType
+        // resolves, so this lookup cannot miss.
         const { release, build, description, releaseNotes } = (
             pluginRegistryUtils.getPlugin(interfaceType) as IPluginInfo
         ).installVersion;

--- a/apps/app/src/modules/settings/hooks/usePermissionsData/usePermissionsData.ts
+++ b/apps/app/src/modules/settings/hooks/usePermissionsData/usePermissionsData.ts
@@ -50,10 +50,13 @@ export const usePermissionsData = (
     const { isEnabled } = useFeatureFlags();
 
     const { data: dao } = useDao({ urlParams: { id: daoId } });
+    // Permissions describe what is installed on-chain, so plugins we cannot
+    // classify must still show up here.
     const daoPluginsData = useDaoPlugins({
         daoId,
         includeSubPlugins: true,
         includeLinkedAccounts: true,
+        includeUnsupported: true,
     });
 
     const accounts = useMemo<IPermissionsDataAccount[]>(() => {

--- a/apps/app/src/plugins/sppPlugin/components/sppProposalListItem/sppProposalListItem.test.tsx
+++ b/apps/app/src/plugins/sppPlugin/components/sppProposalListItem/sppProposalListItem.test.tsx
@@ -1,5 +1,6 @@
 import { GukModulesProvider, ProposalStatus } from '@aragon/gov-ui-kit';
 import { render, screen } from '@testing-library/react';
+import { PluginInterfaceType } from '@/shared/api/daoService';
 import { generateDao, generateDaoPlugin } from '@/shared/testUtils';
 import {
     generateSppPluginSettings,
@@ -22,7 +23,10 @@ describe('<SppProposalListItem /> component', () => {
         getProposalStatusSpy.mockReset();
     });
 
-    const defaultPlugin = generateDaoPlugin({ slug: 'spp' });
+    const defaultPlugin = generateDaoPlugin({
+        slug: 'spp',
+        interfaceType: PluginInterfaceType.SPP,
+    });
     const defaultDao = generateDao({
         address: '0x123',
         plugins: [defaultPlugin],

--- a/apps/app/src/plugins/sppPlugin/dialogs/sppAdvanceStageDialog/sppAdvanceStageDialog.test.tsx
+++ b/apps/app/src/plugins/sppPlugin/dialogs/sppAdvanceStageDialog/sppAdvanceStageDialog.test.tsx
@@ -9,6 +9,7 @@ import * as Wagmi from 'wagmi';
 import * as governanceService from '@/modules/governance/api/governanceService';
 import { generateProposal } from '@/modules/governance/testUtils';
 import * as DaoService from '@/shared/api/daoService';
+import { PluginInterfaceType } from '@/shared/api/daoService';
 import type { IDialogLocation } from '@/shared/components/dialogProvider';
 import {
     type ITransactionDialogProps,
@@ -142,7 +143,13 @@ describe('<SppAdvanceStageDialog /> proposal card status after indexing', () => 
         // so proposalUtils.getProposalSlug resolves to SLUG-1.
         useDaoSpy.mockReturnValue(
             generateReactQueryResultSuccess({
-                data: generateDao({ plugins: [generateDaoPlugin()] }),
+                data: generateDao({
+                    plugins: [
+                        generateDaoPlugin({
+                            interfaceType: PluginInterfaceType.SPP,
+                        }),
+                    ],
+                }),
             }),
         );
         const indexedProposal = generateProposal({ id: 'advanced-1' });

--- a/apps/app/src/shared/hooks/useDaoPlugins/useDaoPlugins.test.ts
+++ b/apps/app/src/shared/hooks/useDaoPlugins/useDaoPlugins.test.ts
@@ -96,6 +96,27 @@ describe('useDaoPlugins hook', () => {
         });
     });
 
+    it('forwards includeUnsupported to the plugin filters', () => {
+        const dao = generateDao({
+            plugins: [
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.UNKNOWN,
+                }),
+            ],
+        });
+        useDaoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: dao }),
+        );
+
+        renderHook(
+            () => useDaoPlugins({ daoId: dao.id, includeUnsupported: true }),
+            { wrapper: FeatureFlagsProvider },
+        );
+        expect(getDaoPluginsSpy).toHaveBeenCalledWith(dao, {
+            includeUnsupported: true,
+        });
+    });
+
     it('hides plugins listed in the DAO override when visibleOnly is true', () => {
         const hiddenPlugin = generateDaoPlugin({
             interfaceType: PluginInterfaceType.TOKEN_VOTING,

--- a/apps/app/src/shared/hooks/useDaoPlugins/useDaoPlugins.ts
+++ b/apps/app/src/shared/hooks/useDaoPlugins/useDaoPlugins.ts
@@ -57,6 +57,14 @@ export interface IUseDaoPluginsParams {
      * @default false
      */
     visibleOnly?: boolean;
+    /**
+     * Keeps plugins whose interface type could not be resolved. They are
+     * dropped by default because the app has no UI to render them with. Set
+     * this to `true` ONLY for surfaces describing what is installed on-chain
+     * (permissions, contract versions).
+     * @default false
+     */
+    includeUnsupported?: boolean;
 }
 
 export const pluginGroupFilter: IFilterComponentPlugin<IDaoPlugin> = {
@@ -142,6 +150,7 @@ export const useDaoPlugins = (
         slug,
         hasExecute,
         visibleOnly,
+        includeUnsupported,
     } = params;
 
     const { isEnabled } = useFeatureFlags();
@@ -156,6 +165,7 @@ export const useDaoPlugins = (
         interfaceType,
         slug,
         hasExecute,
+        includeUnsupported,
     });
 
     const daoOverride = daoOverrides?.[daoId];

--- a/apps/app/src/shared/utils/daoUtils/daoUtils.test.ts
+++ b/apps/app/src/shared/utils/daoUtils/daoUtils.test.ts
@@ -35,6 +35,41 @@ describe('dao utils', () => {
         getPluginsSpy.mockReset();
     });
 
+    describe('hasPluginBody', () => {
+        it('returns true when dao has a body the app can render', () => {
+            const dao = generateDao({
+                plugins: [
+                    generateDaoPlugin({
+                        interfaceType: PluginInterfaceType.MULTISIG,
+                        isBody: true,
+                    }),
+                ],
+            });
+            expect(daoUtils.hasPluginBody(dao)).toBeTruthy();
+        });
+
+        it('returns false when the only bodies have an unknown interface type', () => {
+            const dao = generateDao({
+                plugins: [
+                    generateDaoPlugin({
+                        interfaceType: PluginInterfaceType.MULTISIG,
+                        isProcess: true,
+                        isBody: false,
+                    }),
+                    generateDaoPlugin({
+                        interfaceType: PluginInterfaceType.UNKNOWN,
+                        isBody: true,
+                    }),
+                ],
+            });
+            expect(daoUtils.hasPluginBody(dao)).toBeFalsy();
+        });
+
+        it('returns false when dao is not defined', () => {
+            expect(daoUtils.hasPluginBody()).toBeFalsy();
+        });
+    });
+
     describe('hasSupportedPlugins', () => {
         it('returns true when dao has supported plugins', () => {
             listContainsRegisteredPluginsSpy.mockReturnValue(true);
@@ -62,6 +97,30 @@ describe('dao utils', () => {
         it('returns false when dao parameter is not defined', () => {
             listContainsRegisteredPluginsSpy.mockReturnValue(false);
             expect(daoUtils.hasSupportedPlugins()).toBeFalsy();
+        });
+    });
+
+    describe('isSupportedPlugin', () => {
+        it('returns true when the interface type could be resolved', () => {
+            const plugin = generateDaoPlugin({
+                interfaceType: PluginInterfaceType.MULTISIG,
+            });
+            expect(daoUtils.isSupportedPlugin(plugin)).toBeTruthy();
+        });
+
+        it('returns false for plugins with unknown interface type', () => {
+            const plugin = generateDaoPlugin({
+                interfaceType: PluginInterfaceType.UNKNOWN,
+            });
+            expect(daoUtils.isSupportedPlugin(plugin)).toBeFalsy();
+        });
+
+        it('does not use the plugin registry to resolve support', () => {
+            const plugin = generateDaoPlugin({
+                interfaceType: PluginInterfaceType.MULTISIG,
+            });
+            daoUtils.isSupportedPlugin(plugin);
+            expect(listContainsRegisteredPluginsSpy).not.toHaveBeenCalled();
         });
     });
 
@@ -219,7 +278,14 @@ describe('dao utils', () => {
 
     describe('getDaoPlugins', () => {
         it('returns all dao plugins by default', () => {
-            const plugins = [generateDaoPlugin(), generateDaoPlugin()];
+            const plugins = [
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.MULTISIG,
+                }),
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.TOKEN_VOTING,
+                }),
+            ];
             const dao = generateDao({ plugins });
             expect(daoUtils.getDaoPlugins(dao)).toEqual(plugins);
         });
@@ -227,8 +293,14 @@ describe('dao utils', () => {
         it('only returns the plugin with the specified address', () => {
             const pluginAddress = '0x7249387';
             const plugins = [
-                generateDaoPlugin({ address: '0x123' }),
-                generateDaoPlugin({ address: pluginAddress }),
+                generateDaoPlugin({
+                    address: '0x123',
+                    interfaceType: PluginInterfaceType.MULTISIG,
+                }),
+                generateDaoPlugin({
+                    address: pluginAddress,
+                    interfaceType: PluginInterfaceType.TOKEN_VOTING,
+                }),
             ];
             const dao = generateDao({ plugins });
             isAddressEqualSpy
@@ -302,6 +374,7 @@ describe('dao utils', () => {
                 }),
                 generateDaoPlugin({
                     subdomain: 'sub-plugin',
+                    interfaceType: PluginInterfaceType.ADMIN,
                     isProcess: true,
                     isSubPlugin: true,
                 }),
@@ -414,6 +487,7 @@ describe('dao utils', () => {
                 }),
                 generateDaoPlugin({
                     subdomain: 'sub-body',
+                    interfaceType: PluginInterfaceType.ADMIN,
                     isBody: true,
                     isSubPlugin: true,
                 }),
@@ -529,6 +603,51 @@ describe('dao utils', () => {
             expect(daoUtils.getDaoPlugins(dao)).toEqual(plugins);
         });
 
+        it('drops plugins with unknown interface type by default', () => {
+            const plugins = [
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.UNKNOWN,
+                }),
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.MULTISIG,
+                }),
+            ];
+            const dao = generateDao({ plugins });
+            expect(daoUtils.getDaoPlugins(dao)).toEqual([plugins[1]]);
+        });
+
+        it('keeps plugins with unknown interface type when includeUnsupported is true', () => {
+            const plugins = [
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.UNKNOWN,
+                }),
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.MULTISIG,
+                }),
+            ];
+            const dao = generateDao({ plugins });
+            expect(
+                daoUtils.getDaoPlugins(dao, { includeUnsupported: true }),
+            ).toEqual(plugins);
+        });
+
+        it('drops unknown plugins for every plugin type, not only processes', () => {
+            const plugins = [
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.UNKNOWN,
+                    isBody: true,
+                }),
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.MULTISIG,
+                    isBody: true,
+                }),
+            ];
+            const dao = generateDao({ plugins });
+            expect(
+                daoUtils.getDaoPlugins(dao, { type: PluginType.BODY }),
+            ).toEqual([plugins[1]]);
+        });
+
         it('returns undefined when dao parameter is not defined', () => {
             expect(daoUtils.getDaoPlugins(undefined)).toBeUndefined();
         });
@@ -630,14 +749,17 @@ describe('dao utils', () => {
             ];
             const dao = generateDao({ plugins });
             const multisigPluginInfo = {
+                id: PluginInterfaceType.MULTISIG,
                 subdomain: 'multisig',
                 installVersion: { release: 1, build: 2 },
             } as IPluginInfo;
             const adminPluginInfo = {
+                id: PluginInterfaceType.ADMIN,
                 subdomain: 'admin',
                 installVersion: { release: 1, build: 1 },
             } as IPluginInfo;
             const tokenPluginInfo = {
+                id: PluginInterfaceType.TOKEN_VOTING,
                 subdomain: 'token-voting',
                 installVersion: { release: 3, build: 0 },
             } as IPluginInfo;
@@ -650,6 +772,53 @@ describe('dao utils', () => {
             const result = daoUtils.getAvailablePluginUpdates(dao);
 
             expect(result).toEqual([plugins[0], plugins[2]]);
+        });
+
+        it('excludes plugins with an interface type that resolves to no registered plugin', () => {
+            const plugins = [
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.UNKNOWN,
+                    subdomain: 'multisig',
+                    release: '1',
+                    build: '1',
+                }),
+            ];
+            const dao = generateDao({ plugins });
+            getPluginsSpy.mockReturnValue([
+                {
+                    id: PluginInterfaceType.MULTISIG,
+                    subdomain: 'multisig',
+                    installVersion: { release: 1, build: 2 },
+                } as IPluginInfo,
+            ]);
+
+            expect(daoUtils.getAvailablePluginUpdates(dao)).toEqual([]);
+        });
+
+        it('excludes plugins whose subdomain and interface type resolve to different registered plugins', () => {
+            const plugins = [
+                generateDaoPlugin({
+                    interfaceType: PluginInterfaceType.ADMIN,
+                    subdomain: 'multisig',
+                    release: '1',
+                    build: '1',
+                }),
+            ];
+            const dao = generateDao({ plugins });
+            getPluginsSpy.mockReturnValue([
+                {
+                    id: PluginInterfaceType.MULTISIG,
+                    subdomain: 'multisig',
+                    installVersion: { release: 1, build: 2 },
+                } as IPluginInfo,
+                {
+                    id: PluginInterfaceType.ADMIN,
+                    subdomain: 'admin',
+                    installVersion: { release: 1, build: 2 },
+                } as IPluginInfo,
+            ]);
+
+            expect(daoUtils.getAvailablePluginUpdates(dao)).toEqual([]);
         });
 
         it('returns empty array when dao is not defined', () => {

--- a/apps/app/src/shared/utils/daoUtils/daoUtils.ts
+++ b/apps/app/src/shared/utils/daoUtils/daoUtils.ts
@@ -47,6 +47,15 @@ export interface IGetDaoPluginsParams {
      * Only returns plugins with full execute permissions when set to true.
      */
     hasExecute?: boolean;
+    /**
+     * Keeps plugins whose interface type could not be resolved. They are
+     * dropped by default because the app has no UI to render them with. Set
+     * this to `true` ONLY for surfaces describing what is installed on-chain
+     * (permissions, contract versions), where omitting a contract would give a
+     * wrong picture of the DAO.
+     * @default false
+     */
+    includeUnsupported?: boolean;
 }
 
 export interface IDaoAvailableUpdates {
@@ -62,7 +71,8 @@ export interface IDaoAvailableUpdates {
 
 class DaoUtils {
     hasPluginBody = (dao?: IDao): boolean =>
-        dao?.plugins?.some((p) => p.isBody) ?? false;
+        dao?.plugins?.some((p) => p.isBody && this.isSupportedPlugin(p)) ??
+        false;
 
     hasSupportedPlugins = (dao?: IDao): boolean => {
         const pluginIds =
@@ -70,6 +80,15 @@ class DaoUtils {
 
         return pluginRegistryUtils.listContainsRegisteredPlugins(pluginIds);
     };
+
+    /**
+     * Checks if the backend could resolve the interface type of the plugin.
+     * Deliberately based on the interface type and not on the plugin registry:
+     * the registry is populated on demand, so a registry lookup here would
+     * report every plugin as unsupported during server rendering.
+     */
+    isSupportedPlugin = (plugin: Pick<IDaoPlugin, 'interfaceType'>): boolean =>
+        plugin.interfaceType !== PluginInterfaceType.UNKNOWN;
 
     getDaoEns = (dao?: IDao): string | undefined =>
         dao?.ens != null && dao.ens !== '' ? dao.ens : undefined;
@@ -106,6 +125,7 @@ class DaoUtils {
             interfaceType,
             hasExecute,
             slug,
+            includeUnsupported = false,
         } = params ?? {};
 
         return dao?.plugins?.filter(
@@ -120,7 +140,8 @@ class DaoUtils {
                 ) &&
                 this.filterByInterfaceType(plugin, interfaceType) &&
                 this.filterByHasExecute(plugin, hasExecute) &&
-                this.filterBySlug(plugin, slug),
+                this.filterBySlug(plugin, slug) &&
+                this.filterBySupported(plugin, includeUnsupported),
         );
     };
 
@@ -185,9 +206,17 @@ class DaoUtils {
                     registeredPlugin.subdomain === plugin.subdomain,
             );
 
+            // Skip plugins that do not pin down to a single registered entry.
+            // Preparing the update looks the plugin info up by interfaceType, so
+            // both lookups have to agree, otherwise we would prepare the update
+            // against the wrong repository.
+            if (target == null || target.id !== plugin.interfaceType) {
+                return false;
+            }
+
             return versionComparatorUtils.isLessThan(
                 plugin,
-                target?.installVersion,
+                target.installVersion,
             );
         });
 
@@ -267,10 +296,7 @@ class DaoUtils {
     private filterPluginByType = (plugin: IDaoPlugin, type?: PluginType) =>
         type == null ||
         (type === PluginType.BODY && plugin.isBody) ||
-        (type === PluginType.PROCESS &&
-            plugin.isProcess &&
-            // TODO (APP-1012): just a temp solution to fix regression in SelectPluginDialog. Implement a consistent way to handle unknowns across the app!
-            plugin.interfaceType !== PluginInterfaceType.UNKNOWN);
+        (type === PluginType.PROCESS && plugin.isProcess);
 
     private filterBySubPlugin = (
         plugin: IDaoPlugin,
@@ -299,6 +325,11 @@ class DaoUtils {
 
     private filterByHasExecute = (plugin: IDaoPlugin, hasExecute?: boolean) =>
         !hasExecute || plugin.conditionAddress == null;
+
+    private filterBySupported = (
+        plugin: IDaoPlugin,
+        includeUnsupported: boolean,
+    ) => includeUnsupported || this.isSupportedPlugin(plugin);
 }
 
 export const daoUtils = new DaoUtils();


### PR DESCRIPTION
# Description

Plugins with unresolved interface type were handled inconsistently. They were filtered out only from process lookups, everywhere else they were still returned, so they showed up as tabs and list entries that render nothing.

Now `getDaoPlugins` drops them at the source so every caller gets the same list. Two places opt back in with `includeUnsupported: true`, the permissions view and the contracts version list, because those describe what is actually installed on chain. An unknown plugin can hold EXECUTE_PERMISSION over the DAO, hiding it there would be wrong.

Key changes:

- `daoUtils.isSupportedPlugin` is the single check and `getDaoPlugins` applies it unless `includeUnsupported` is set. Removed the temp PROCESS only filter and its TODO.
- `hasPluginBody` uses the same check, so the members nav link matches what the members page lists. Before it could show the link for a DAO whose only body is unknown, and clicking it just redirects back to dashboard.
- `getAvailablePluginUpdates` now needs the subdomain match and the interfaceType lookup to resolve to the same registered plugin. Before, a plugin with a known subdomain but unresolved interfaceType passed the filter and then crashed the update dialog on `getPlugin(...).installVersion`.
- Updated the `plugin-visibility` rule, there are two filters on the plugin list now and their defaults are opposite.
- Some tests were relying on `generateDaoPlugin()` defaulting interfaceType to unknown, set it explicitly there.

Smoke tested on ethereum-sepolia `0x1770F7e9E22CB5914c5d254093b4174465dB2566`, it has an unknown plugin installed. It is gone from the governance list and the member tabs, still listed under Contracts and still shows its EXECUTE_PERMISSION row in Permissions.

Related: [APP-1012](https://linear.app/aragon/issue/APP-1012)

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes

## Review Checklist:

- [x] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
