### PR TITLE
ci(APP-1028): group the release summary by Linear tickets

### DIFF
--- a/.github/workflows/scripts/generateReleaseSummary.js
+++ b/.github/workflows/scripts/generateReleaseSummary.js
@@ -68,20 +68,38 @@ const commitMatchesPathFilter = (commit, patterns, git = runGit) => {
 // and would otherwise leak into the summary as "Other Changes".
 const RELEASE_COMMIT_RE = /^Release @aragon\/[^@\s]+@\d+\.\d+\.\d+/;
 
-// A PR landed as a merge commit carries its PR title in the commit body; the subject only says
-// "Merge pull request #N from org/branch". Surface the title so the entry reads like a squash.
-const resolveCommitTitle = (commit, subject, git = runGit) => {
-    const merge = subject.match(/^Merge pull request #(\d+)\b/);
-    if (!merge) {
+// Linear issue identifiers like "APP-1234" embedded in commit messages.
+const LINEAR_ID_RE = /\b[A-Za-z]{2,}-\d+\b/g;
+
+// A mainline commit that kept a merge-style title ("Merge pull request #N …") says nothing
+// in its subject — its real changes live in the body. This covers both PRs landed as merge
+// commits (GitHub puts the PR title into the body) and squashes that kept the merge title.
+const MERGE_TITLE_RE = /^Merge /i;
+
+// Body-harvesting cutoff: a squashed bulk-sync PR (e.g. a release back-merge) lists a whole
+// release worth of commits in its body, and harvesting tickets from it would resurface
+// already-released work. No genuine single PR references this many.
+const MAX_BODY_TICKETS = 8;
+
+// A merge-style subject carries no information: prefer the first real body line (the PR
+// title for a merge commit or single-commit squash, the first commit message for a
+// multi-commit squash), keeping the PR number visible.
+const resolveCommitTitle = (subject, body) => {
+    if (!MERGE_TITLE_RE.test(subject)) {
         return subject;
     }
 
-    const bodyTitle = git(['show', '-s', '--format=%b', commit])
+    const bodyTitle = (body ?? '')
         .split('\n')
-        .map((line) => line.trim())
+        .map((line) => line.replace(/^[\s*-]+/, '').trim())
         .find(Boolean);
 
-    return bodyTitle ? `${bodyTitle} (#${merge[1]})` : subject;
+    if (!bodyTitle) {
+        return subject;
+    }
+
+    const [pr] = subject.match(/#\d+\b/g) ?? [];
+    return /#\d+/.test(bodyTitle) || !pr ? bodyTitle : `${bodyTitle} (${pr})`;
 };
 
 // Mainline commits since the release boundary. The boundary is the previous release tag itself:
@@ -95,31 +113,38 @@ const collectScopedCommits = ({
     git = runGit,
 }) => {
     const range = baseRef ? `${baseRef}..${headRef}` : headRef;
+    // NUL-separated hash/subject/body per commit, record-separated so multiline bodies parse.
     const log = git([
         'log',
         '--first-parent',
         range,
-        '--pretty=format:%H%x00%s',
+        '--pretty=format:%H%x00%s%x00%b%x1e',
     ]);
 
     return (
         log
-            .split('\n')
+            .split('\x1e')
+            .map((record) => record.trim())
             .filter(Boolean)
-            .map((line) => {
-                const [commit, subject] = line.split('\0');
-                return { commit, subject };
+            .map((record) => {
+                const [commit = '', subject = '', body = ''] =
+                    record.split('\0');
+                return {
+                    commit: commit.trim(),
+                    subject: subject.trim(),
+                    body: body.trim(),
+                };
             })
             // Resolve titles before filtering: a release PR merged with GitHub's default
-            // merge subject only reveals its "Release @aragon/…" title after resolution,
-            // and RELEASE_COMMIT_RE must see that title to drop the commit.
-            .map(({ commit, subject }) => ({
-                commit,
-                subject: resolveCommitTitle(commit, subject, git),
+            // merge subject only reveals its "Release @aragon/…" title in its body, and
+            // RELEASE_COMMIT_RE must see that title to drop the commit.
+            .map((commit) => ({
+                ...commit,
+                title: resolveCommitTitle(commit.subject, commit.body),
             }))
             .filter(
-                ({ commit, subject }) =>
-                    !RELEASE_COMMIT_RE.test(subject) &&
+                ({ commit, title }) =>
+                    !RELEASE_COMMIT_RE.test(title) &&
                     commitMatchesPathFilter(commit, patterns, git),
             )
     );
@@ -168,6 +193,134 @@ const fetchLinearIssue = async (issueId, token) => {
     }
 };
 
+const SECTION_RANK = { features: 0, fixes: 1, others: 2 };
+
+// Section for a message: any feat/perf line wins over fix, fix over other. Lines are
+// stripped of list markers so squash bodies ("* feat: …") classify like subjects.
+const sectionOf = (text) => {
+    const lines = text.split('\n').map((line) => line.replace(/^[\s*-]+/, ''));
+    if (lines.some((line) => /^(feat|perf)[\s(:!]/i.test(line))) {
+        return 'features';
+    }
+    if (lines.some((line) => /^fix[\s(:!]/i.test(line))) {
+        return 'fixes';
+    }
+    return 'others';
+};
+
+// Groups commits by the Linear tickets they reference (subject always; body too for
+// merge-titled commits, capped): one entry per ticket regardless of how many commits
+// carry it, titled by the ticket itself and placed in the strongest section among its
+// commits. Commits with no resolvable ticket stay visible under their own title, so
+// missing Linear data can hide enrichment but never a change.
+const categorize = async (commits, { linearToken, repository }) => {
+    // Linear enrichment is optional: only attempted when a token is present, and each
+    // issue is fetched at most once across all commits. A failed fetch caches null, which
+    // degrades the commit to the title path — the release never fails on Linear.
+    const issueCache = new Map();
+    const resolveIssue = async (id) => {
+        if (!issueCache.has(id)) {
+            issueCache.set(
+                id,
+                linearToken ? await fetchLinearIssue(id, linearToken) : null,
+            );
+        }
+        return issueCache.get(id);
+    };
+
+    const prLink = (number) =>
+        `[#${number}](https://github.com/${repository}/pull/${number})`;
+
+    const tickets = new Map(); // id -> { issue, section, prs }
+    const titleEntries = [];
+    const seenTitles = new Set();
+
+    for (const { subject, body, title } of commits) {
+        const isMergeTitle = MERGE_TITLE_RE.test(subject);
+
+        const ids = new Set(
+            (subject.match(LINEAR_ID_RE) ?? []).map((id) => id.toUpperCase()),
+        );
+        if (isMergeTitle) {
+            const bodyIds = new Set(
+                (body.match(LINEAR_ID_RE) ?? []).map((id) => id.toUpperCase()),
+            );
+            if (bodyIds.size <= MAX_BODY_TICKETS) {
+                for (const id of bodyIds) {
+                    ids.add(id);
+                }
+            }
+        }
+
+        const section = sectionOf(
+            isMergeTitle ? `${subject}\n${body}` : subject,
+        );
+        const prs = (subject.match(/#\d+\b/g) ?? []).map((pr) => pr.slice(1));
+
+        const resolved = [];
+        for (const id of ids) {
+            const issue = await resolveIssue(id);
+            if (issue) {
+                resolved.push({ id, issue });
+            }
+        }
+
+        if (resolved.length > 0) {
+            for (const { id, issue } of resolved) {
+                const entry = tickets.get(id) ?? {
+                    issue,
+                    section,
+                    prs: new Set(),
+                };
+                if (SECTION_RANK[section] < SECTION_RANK[entry.section]) {
+                    entry.section = section;
+                }
+                for (const pr of prs) {
+                    entry.prs.add(pr);
+                }
+                tickets.set(id, entry);
+            }
+            continue;
+        }
+
+        // No resolvable ticket: keep the commit under its own (merge-resolved) title,
+        // deduplicating identical titles across commits.
+        if (seenTitles.has(title)) {
+            continue;
+        }
+        seenTitles.add(title);
+        titleEntries.push({
+            section,
+            text: title.replace(
+                /\(#(\d+)\)/g,
+                (_, number) => `(${prLink(number)})`,
+            ),
+        });
+    }
+
+    const sections = { features: [], fixes: [], others: [] };
+    for (const [id, { issue, section, prs }] of tickets) {
+        const refs =
+            prs.size > 0 ? ` (${[...prs].map(prLink).join(', ')})` : '';
+        sections[section].push(`[${id}: ${issue.title}](${issue.url})${refs}`);
+    }
+    for (const { section, text } of titleEntries) {
+        sections[section].push(text);
+    }
+
+    // Tickets referenced by this range that are not completed/canceled yet. Unresolved
+    // ids (false positives like "UTF-8", missing issues) are cached as null and never
+    // reach the warning.
+    const openIssues = [];
+    for (const [id, issue] of issueCache) {
+        if (issue?.state && !CLOSED_STATE_TYPES.has(issue.state.type)) {
+            openIssues.push({ ...issue, id });
+        }
+    }
+
+    return { ...sections, openIssues };
+};
+
 const generateSummary = async ({ core }) => {
     const linearToken = process.env.LINEAR_API_TOKEN;
     const packageName = process.env.PACKAGE_NAME;
@@ -208,73 +361,10 @@ const generateSummary = async ({ core }) => {
         `Generating ${packageName} release summary for range ${range} with path filter "${pathFilter}".`,
     );
 
-    const categories = {
-        features: [],
-        fixes: [],
-        others: [],
-    };
-
-    const linearRegex = /([a-zA-Z]{2,}-\d+)/g;
-    const issuesFound = new Set();
-    const openIssues = [];
-
-    for (const { subject: line } of commits) {
-        const lower = line.toLowerCase();
-        const linearMatches = line.match(linearRegex);
-
-        let category = 'others';
-        if (lower.startsWith('feat')) {
-            category = 'features';
-        } else if (lower.startsWith('fix')) {
-            category = 'fixes';
-        }
-
-        // Clean line prefix
-        let cleanLine = line
-            .replace(
-                /^(feat|fix|chore|docs|style|refactor|perf|test)(\(.*\))?:/,
-                '',
-            )
-            .trim();
-
-        // Linkify PR numbers (#123 -> [#123](url))
-        const repository = process.env.GITHUB_REPOSITORY || 'aragon/app';
-        cleanLine = cleanLine.replace(
-            /\(#(\d+)\)/g,
-            `([#$1](https://github.com/${repository}/pull/$1))`,
-        );
-
-        // Extract linear issues
-        let additionalInfo = '';
-        if (linearMatches && linearToken) {
-            const addedIssues = new Set();
-            for (const issueId of linearMatches) {
-                if (issuesFound.has(issueId) || addedIssues.has(issueId)) {
-                    continue;
-                }
-                issuesFound.add(issueId);
-                addedIssues.add(issueId);
-
-                const issue = await fetchLinearIssue(issueId, linearToken);
-                if (issue) {
-                    additionalInfo += ` [${issueId}: ${issue.title}](${issue.url})`;
-                    if (
-                        issue.state &&
-                        !CLOSED_STATE_TYPES.has(issue.state.type)
-                    ) {
-                        openIssues.push(issue);
-                    }
-                } else {
-                    additionalInfo += ` ${issueId}`;
-                }
-            }
-        }
-
-        const entry = additionalInfo
-            ? `${cleanLine} —${additionalInfo}`
-            : cleanLine;
-        categories[category].push(entry);
-    }
+    const { features, fixes, others, openIssues } = await categorize(commits, {
+        linearToken,
+        repository: process.env.GITHUB_REPOSITORY || 'aragon/app',
+    });
 
     // 2. Format Output
     let summary = '';
@@ -290,21 +380,21 @@ const generateSummary = async ({ core }) => {
         summary += '\n';
     }
 
-    if (categories.features.length > 0) {
+    if (features.length > 0) {
         summary += '## Features\n';
-        categories.features.forEach((item) => (summary += `- ${item}\n`));
+        features.forEach((item) => (summary += `- ${item}\n`));
         summary += '\n';
     }
 
-    if (categories.fixes.length > 0) {
+    if (fixes.length > 0) {
         summary += '## Fixes\n';
-        categories.fixes.forEach((item) => (summary += `- ${item}\n`));
+        fixes.forEach((item) => (summary += `- ${item}\n`));
         summary += '\n';
     }
 
-    if (categories.others.length > 0) {
+    if (others.length > 0) {
         summary += '## Other Changes\n';
-        categories.others.forEach((item) => (summary += `- ${item}\n`));
+        others.forEach((item) => (summary += `- ${item}\n`));
         summary += '\n';
     }
 

--- a/.github/workflows/scripts/generateReleaseSummary.test.js
+++ b/.github/workflows/scripts/generateReleaseSummary.test.js
@@ -53,12 +53,12 @@ const git = (repository, args) =>
         .toString()
         .trim();
 
-const commitFile = (repository, file, content, subject) => {
+const commitFile = (repository, file, content, subject, body) => {
     const target = path.join(repository, file);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, content);
     git(repository, ['add', file]);
-    git(repository, ['commit', '-m', subject]);
+    git(repository, ['commit', '-m', subject, ...(body ? ['-m', body] : [])]);
 };
 
 test('keeps release-window commits and excludes everything the tag already ships', () => {
@@ -188,7 +188,7 @@ test('keeps release-window commits and excludes everything the tag already ships
 
         assert.equal(packageTag, '@aragon/app@1.0.0');
         assert.deepEqual(
-            commits.map(({ subject }) => subject),
+            commits.map(({ title }) => title),
             [
                 'feat(APP-77): multi-commit feature (#43)',
                 'feat(APP-123): add app feature (#42)',
@@ -201,40 +201,33 @@ test('keeps release-window commits and excludes everything the tag already ships
     }
 });
 
-test('keeps the subject of a merge commit without a PR title in its body', () => {
-    const repository = createRepository();
-
-    try {
-        commitFile(repository, 'apps/app/a.txt', 'a', 'feat: base');
-        git(repository, ['checkout', '-b', 'feature/no-body']);
-        commitFile(repository, 'apps/app/b.txt', 'b', 'feat: branch work');
-        git(repository, ['checkout', 'main']);
-        git(repository, [
-            'merge',
-            '--no-ff',
-            'feature/no-body',
-            '-m',
-            'Merge pull request #7 from feature/no-body',
-        ]);
-
-        const repositoryGit = (args) => runGit(args, { cwd: repository });
-        const mergeCommit = repositoryGit(['rev-parse', 'HEAD']);
-
-        assert.equal(
-            resolveCommitTitle(
-                mergeCommit,
-                'Merge pull request #7 from feature/no-body',
-                repositoryGit,
-            ),
-            'Merge pull request #7 from feature/no-body',
-        );
-        assert.equal(
-            resolveCommitTitle('irrelevant', 'feat: squash subject (#8)'),
-            'feat: squash subject (#8)',
-        );
-    } finally {
-        fs.rmSync(repository, { recursive: true, force: true });
-    }
+test('resolves merge-style titles from the body and keeps the PR number visible', () => {
+    // No body to fall back to: the merge subject is all there is.
+    assert.equal(
+        resolveCommitTitle('Merge pull request #7 from feature/no-body', ''),
+        'Merge pull request #7 from feature/no-body',
+    );
+    // Non-merge subjects pass through untouched.
+    assert.equal(
+        resolveCommitTitle('feat: squash subject (#8)', 'ignored body'),
+        'feat: squash subject (#8)',
+    );
+    // The PR title from the body wins, with the PR number appended.
+    assert.equal(
+        resolveCommitTitle(
+            'Merge pull request #9 from aragon/feature',
+            'feat(APP-1): real title',
+        ),
+        'feat(APP-1): real title (#9)',
+    );
+    // A body line that already references a PR is not suffixed twice.
+    assert.equal(
+        resolveCommitTitle(
+            'Merge pull request #9 from aragon/feature',
+            '* feat: first commit (#9)\n* fix: second commit',
+        ),
+        'feat: first commit (#9)',
+    );
 });
 
 test('treats a workspace without package tags as a first release', () => {
@@ -277,7 +270,11 @@ test('treats a workspace without package tags as a first release', () => {
 
 // Runs generateSummary end-to-end inside a fixture repository with a mocked Linear API,
 // capturing the summary output. Restores cwd, env and global.fetch afterwards.
-const runGenerateSummary = async (repository, issuesById) => {
+const runGenerateSummary = async (
+    repository,
+    issuesById,
+    { linearToken = 'test-token' } = {},
+) => {
     const filterPath = path.join(repository, 'filters.yml');
     fs.writeFileSync(filterPath, 'app:\n  - "apps/app/**"\n');
 
@@ -291,9 +288,13 @@ const runGenerateSummary = async (repository, issuesById) => {
         process.env.PACKAGE_NAME = '@aragon/app';
         process.env.PATH_FILTER = 'app';
         process.env.FILTERS_PATH = filterPath;
-        process.env.LINEAR_API_TOKEN = 'test-token';
         process.env.GITHUB_REPOSITORY = 'aragon/app';
         delete process.env.BASE_REF;
+        if (linearToken) {
+            process.env.LINEAR_API_TOKEN = linearToken;
+        } else {
+            delete process.env.LINEAR_API_TOKEN;
+        }
 
         global.fetch = async (_url, options) => {
             const { variables } = JSON.parse(options.body);
@@ -405,6 +406,159 @@ test('omits the warning section when every ticket is finished', async () => {
         });
 
         assert.doesNotMatch(summary, /Open tickets/);
+    } finally {
+        fs.rmSync(repository, { recursive: true, force: true });
+    }
+});
+
+test('groups every commit of a ticket into a single linked entry', async () => {
+    const repository = createRepository();
+
+    try {
+        commitFile(
+            repository,
+            'apps/app/one.ts',
+            'one',
+            'feat(APP-500): part one (#10)',
+        );
+        commitFile(
+            repository,
+            'apps/app/two.ts',
+            'two',
+            'fix(APP-500): follow-up (#11)',
+        );
+
+        const summary = await runGenerateSummary(repository, {
+            'APP-500': {
+                title: 'Grouped feature',
+                url: 'https://linear.app/aragon/issue/APP-500',
+                state: { name: 'Done', type: 'completed' },
+            },
+        });
+
+        // One entry for the ticket, in the strongest section among its commits
+        // (feat > fix), carrying the PR links of every commit (newest first).
+        assert.match(
+            summary,
+            /## Features\n- \[APP-500: Grouped feature\]\(https:\/\/linear\.app\/aragon\/issue\/APP-500\) \(\[#11\]\(https:\/\/github\.com\/aragon\/app\/pull\/11\), \[#10\]\(https:\/\/github\.com\/aragon\/app\/pull\/10\)\)/,
+        );
+        assert.doesNotMatch(summary, /## Fixes/);
+        assert.equal(summary.match(/APP-500: Grouped feature/g).length, 1);
+    } finally {
+        fs.rmSync(repository, { recursive: true, force: true });
+    }
+});
+
+test('harvests tickets from the body of a merge-titled squash', async () => {
+    const repository = createRepository();
+
+    try {
+        // The v0.36.0 incident shape: a squash that kept the merge-style subject,
+        // its real changes only listed in the body.
+        commitFile(
+            repository,
+            'apps/app/squash.ts',
+            'squash',
+            'Merge pull request #1502 from aragon/feature-x',
+            '* feat(APP-600): the real feature\n* fix(APP-601): a follow-up fix',
+        );
+
+        const summary = await runGenerateSummary(repository, {
+            'APP-600': {
+                title: 'Squashed feature',
+                url: 'https://linear.app/aragon/issue/APP-600',
+                state: { name: 'Done', type: 'completed' },
+            },
+            'APP-601': {
+                title: 'Squashed fix',
+                url: 'https://linear.app/aragon/issue/APP-601',
+                state: { name: 'Done', type: 'completed' },
+            },
+        });
+
+        // Both tickets surface as their own entries, linked to the squash PR; the
+        // commit classifies as a feature (feat outranks fix within one message).
+        assert.match(
+            summary,
+            /- \[APP-600: Squashed feature\]\(https:\/\/linear\.app\/aragon\/issue\/APP-600\) \(\[#1502\]\(https:\/\/github\.com\/aragon\/app\/pull\/1502\)\)/,
+        );
+        assert.match(
+            summary,
+            /- \[APP-601: Squashed fix\]\(https:\/\/linear\.app\/aragon\/issue\/APP-601\) \(\[#1502\]\(https:\/\/github\.com\/aragon\/app\/pull\/1502\)\)/,
+        );
+        assert.doesNotMatch(summary, /Merge pull request/);
+    } finally {
+        fs.rmSync(repository, { recursive: true, force: true });
+    }
+});
+
+test('caps body ticket harvesting so bulk-sync squashes stay one entry', async () => {
+    const repository = createRepository();
+
+    try {
+        const bulkBody = Array.from(
+            { length: 9 },
+            (_, index) => `* feat(APP-${index + 1}): bulk change ${index + 1}`,
+        ).join('\n');
+        commitFile(
+            repository,
+            'apps/app/bulk.ts',
+            'bulk',
+            'Merge pull request #99 from aragon/bulk-sync',
+            bulkBody,
+        );
+
+        const summary = await runGenerateSummary(repository, {});
+
+        // Too many body tickets to be a genuine PR: no harvesting, the commit falls
+        // back to a single title entry built from the first body line.
+        assert.match(
+            summary,
+            /- feat\(APP-1\): bulk change 1 \(\[#99\]\(https:\/\/github\.com\/aragon\/app\/pull\/99\)\)/,
+        );
+        assert.doesNotMatch(summary, /APP-2/);
+    } finally {
+        fs.rmSync(repository, { recursive: true, force: true });
+    }
+});
+
+test('degrades to commit titles when no Linear token is provided', async () => {
+    const repository = createRepository();
+
+    try {
+        commitFile(
+            repository,
+            'apps/app/tokenless.ts',
+            'tokenless',
+            'feat(APP-700): tokenless work (#5)',
+        );
+
+        const summary = await runGenerateSummary(
+            repository,
+            {},
+            { linearToken: '' },
+        );
+
+        assert.match(
+            summary,
+            /## Features\n- feat\(APP-700\): tokenless work \(\[#5\]\(https:\/\/github\.com\/aragon\/app\/pull\/5\)\)/,
+        );
+        assert.doesNotMatch(summary, /linear\.app|Open tickets/);
+    } finally {
+        fs.rmSync(repository, { recursive: true, force: true });
+    }
+});
+
+test('deduplicates repeated titles without tickets', async () => {
+    const repository = createRepository();
+
+    try {
+        commitFile(repository, 'apps/app/dep-a.ts', 'a', 'chore: bump deps');
+        commitFile(repository, 'apps/app/dep-b.ts', 'b', 'chore: bump deps');
+
+        const summary = await runGenerateSummary(repository, {});
+
+        assert.equal(summary.match(/- chore: bump deps/g).length, 1);
     } finally {
         fs.rmSync(repository, { recursive: true, force: true });
     }


### PR DESCRIPTION
Ports the release-summary design shipped in app-backend (`release/0.36.0`, `33cf6073`) to the app's `generateReleaseSummary.js`. Previously the summary emitted one line per commit: a ticket spanning several commits produced several rows, the Linear link only attached to the first one (the `issuesFound` set suppressed repeat links but not repeat rows), and the remaining rows had their scope stripped and read as unrelated work.

## Changes

- **Ticket grouping** — commits are grouped by the Linear tickets they reference (`\b[A-Za-z]{2,}-\d+\b` in the subject always; in the body too for merge-titled squashes). One entry per ticket regardless of commit count, titled by the ticket itself: `[APP-123: Title](url)` plus links to every PR that carried it.
- **Body-harvest cap** — ticket ids are harvested from a merge-titled body only when it references ≤8 tickets, so a squashed bulk-sync PR cannot resurface a whole released changelog.
- **Section ranking** — a ticket lands in the strongest section among its commits: feat/perf > fix > other. Squash bodies (`* feat: …`) classify like subjects.
- **Title fallback** — commits without a resolvable ticket stay visible under their own title (deduplicated); a merge-style title falls back to the first real body line with the PR number appended. This closes the v0.36.0-backend class of incident where a squash that kept the merge subject dropped a feature from the summary.
- **Graceful degradation** — without a Linear token, or on any fetch failure, entries degrade to the title path; the release never fails on Linear. Open (not completed/canceled) tickets still surface in the leading warning section.
- `resolveCommitTitle` is now a pure `(subject, body)` function: bodies come along in one `git log --first-parent --pretty` pass (NUL/record-separated) instead of a `git show` per merge commit.

App specifics are untouched: mainline walk via `--first-parent`, workspace path filters (`readPathFilter`/`commitMatchesPathFilter`), `RELEASE_COMMIT_RE` dropping every workspace's release commits (still checked against the merge-resolved title), GitHub Markdown output.

Companion PR: aragon/github-templates#9 lands the same design in the canonical shared step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)