### PR TITLE
fix(ci): restore the preview deployment URL and fail loudly when it is lost

### DIFF
--- a/.github/workflows/shared-deploy.yml
+++ b/.github/workflows/shared-deploy.yml
@@ -74,7 +74,7 @@ jobs:
       deploymentUrl: ${{ steps.set-deployment-url.outputs.deploymentUrl }}
     steps:
       - name: Download infra credentials
-        uses: aragon/github-templates/steps/credential-retrieval@7eb535980e228a80c9b80b1781362f7da8d41db2 # https://github.com/aragon/github-templates/commit/a36dc232323f483a457ae3ef46028f3a4ef9f2e6
+        uses: aragon/github-templates/steps/credential-retrieval@4992848afd79e5feb5fa4a688674d13e9ed47c22 # https://github.com/aragon/github-templates/commit/4992848afd79e5feb5fa4a688674d13e9ed47c22
         with:
           op-token: "${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}"
           op-vault: "${{ inputs.vault-prefix }}_infra"
@@ -95,7 +95,7 @@ jobs:
         working-directory: ${{ inputs.workspace }}
 
       - name: Setup env file secrets
-        uses: aragon/github-templates/steps/credential-retrieval@7eb535980e228a80c9b80b1781362f7da8d41db2 # https://github.com/aragon/github-templates/commit/a36dc232323f483a457ae3ef46028f3a4ef9f2e6
+        uses: aragon/github-templates/steps/credential-retrieval@4992848afd79e5feb5fa4a688674d13e9ed47c22 # https://github.com/aragon/github-templates/commit/4992848afd79e5feb5fa4a688674d13e9ed47c22
         with:
           op-token: "${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}"
           op-vault: "${{ inputs.vault-prefix }}_${{ inputs.env }}"
@@ -187,10 +187,36 @@ jobs:
           done
           pnpm vercel deploy --prebuilt ${{ env.VERCEL_ARGS }} ${{ inputs.env == 'production' && '--skip-domain' || '' }} "${runtime_args[@]}" --yes --token=${{ env.VERCEL_TOKEN }} --scope ${{ env.VERCEL_SCOPE }} > deployment-url.txt
 
+      # `vercel deploy` writes progress to stderr and the URL to stdout — take the last line so an
+      # extra line can never turn the output into a malformed multi-line entry, and stop here if
+      # there is no URL at all rather than aliasing an empty one below.
       - name: Set output
         id: set-deployment-url
-        run: echo "deploymentUrl=$(cat deployment-url.txt)" >> $GITHUB_OUTPUT
+        run: |
+          url=$(tail -n 1 deployment-url.txt)
+          if [ -z "$url" ]; then
+            echo "::error::vercel deploy printed no deployment URL" >&2
+            exit 1
+          fi
+          echo "deploymentUrl=$url" >> "$GITHUB_OUTPUT"
 
       - name: Set deployment alias
         if: inputs.domain != ''
         run: pnpm vercel alias ${{ steps.set-deployment-url.outputs.deploymentUrl }} ${{ inputs.domain }} --token=${{ env.VERCEL_TOKEN }} --scope ${{ env.VERCEL_SCOPE }}
+
+  # The runner drops a job output whose value contains a masked substring ("Skip output ... since it
+  # may contain secret"), so a successful deploy can still hand callers an empty URL — a broken PR
+  # comment and an E2E run against nothing, both under a green check. Fail the deploy instead.
+  verify-output:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the deployment URL reached the workflow output
+        env:
+          DEPLOYMENT_URL: ${{ needs.deploy.outputs.deploymentUrl }}
+        run: |
+          if [ -z "$DEPLOYMENT_URL" ]; then
+            echo "::error::The deployment succeeded but its URL did not survive into the workflow output. Check the deploy log for mask warnings: a value from the 1Password vault that also appears in the URL scrubs it away." >&2
+            exit 1
+          fi
+          echo "Deployment URL: $DEPLOYMENT_URL"


### PR DESCRIPTION
# Description

Preview deployments have been landing nowhere since 12 Aug: the PR comment reads `🚀 Preview Deployment: [View Here]()`, an empty link that GitHub resolves back to the PR itself, and the E2E job runs against an empty base URL. The deploy itself is fine — its URL never reaches the jobs that consume it.

The dependabot bump in c07a8ec2 repinned `credential-retrieval` to a version whose `alltofile` mode masks every value it writes to `apps/app/.env`. `kv_app_preview` holds `SENTRY_PROJECT`, whose value `app-next` is also the Vercel project name and therefore a substring of every deployment hostname. Masking is job-wide, so `vercel deploy` reported `https://***-8j08cu55t-aragon-app.vercel.app` and the runner dropped the output: `Skip output 'deploymentUrl' since it may contain secret` ([deploy log](https://github.com/aragon/app/actions/runs/31628282442/job/94425319449)). Staging and production alias a fixed domain and pass fixed URLs to E2E, so only previews were affected.

## Changes

- **Repin `credential-retrieval` to 4992848** (aragon/github-templates#10, merged), which leaves values too short to be secrets unmasked and warns naming the vault item instead. Both pins also carry the right commit link again — the bump left the old SHA in the trailing comment.
- **`verify-output` job** — fails the shared deploy when `deploymentUrl` does not reach the workflow output. Callers gate on `needs.deploy.result == 'success'`, so they now skip instead of commenting a dead link or testing nothing.
- **`Set output` reads the last line and rejects an empty URL** — the alias step in the same job would otherwise run `vercel alias` with no argument, and a second stdout line would produce a malformed multi-line output entry.

Verified on this PR's own preview run: both URLs are back in the comment (app `app-next-nujz52s9h`, assistant `assistant-96j9n2ebq`), and `verify-output` passed for the app and the assistant deploy alike.

Follow-up outside CI: `SENTRY_PROJECT` is config, not a credential, and belongs in `pnpm run setup <env>` rather than `kv_app_preview`. The length floor keeps it harmless either way.

## Type of Change

- None (CI-only change, no changeset)

## Developer Checklist:

- [x] Covered by unit tests (`lib/gha.test.js` in the companion PR; this side is workflow YAML)
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github's UI reflect my intended changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
