### PR TITLE
feat(APP-1059): Render SPP permission rules

### DIFF
--- a/.changeset/silly-rules-smile.md
+++ b/.changeset/silly-rules-smile.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Render normalized SPP rule conditions in permission details and preserve backend-enriched DAO actors as DAO nodes in the permissions graph.

--- a/apps/app/src/assets/locales/en.json
+++ b/apps/app/src/assets/locales/en.json
@@ -3684,6 +3684,17 @@
         "true": "True",
         "false": "False"
       },
+      "sppRuleConditionSlot": {
+        "description": "The SPP rule condition combines these rules to determine whether the permission is granted.",
+        "rule": "Rule",
+        "type": "Type",
+        "operation": "Operation",
+        "value": "Value",
+        "permissionId": "Permission ID",
+        "ruleIndexes": "Rule references",
+        "conditionAddress": "Condition address",
+        "noRules": "No rules returned"
+      },
       "daoPolicyDetailsPage": {
         "error": {
           "action": "Explore settings",

--- a/apps/app/src/modules/settings/components/permissionCondition/permissionCondition.tsx
+++ b/apps/app/src/modules/settings/components/permissionCondition/permissionCondition.tsx
@@ -8,12 +8,14 @@ import { UnrecognizedConditionSlot } from '../unrecognizedConditionSlot';
 
 export interface IPermissionConditionProps {
     chainId?: number;
+    daoId?: string;
     network?: Network;
     row: IDaoPermission;
 }
 
 export const PermissionCondition: React.FC<IPermissionConditionProps> = ({
     chainId,
+    daoId,
     network,
     row,
 }) => {
@@ -23,6 +25,7 @@ export const PermissionCondition: React.FC<IPermissionConditionProps> = ({
         <PluginSingleComponent
             chainId={chainId}
             conditionAddress={address}
+            daoId={daoId}
             Fallback={UnrecognizedConditionSlot}
             network={network}
             pluginAddress={row.whoAddress}

--- a/apps/app/src/modules/settings/components/permissionsGraph/permissionDetailContent.tsx
+++ b/apps/app/src/modules/settings/components/permissionsGraph/permissionDetailContent.tsx
@@ -18,6 +18,7 @@ interface IPermissionDetailEntity {
 export interface IPermissionDetailContentProps {
     chainId?: number;
     className?: string;
+    daoId?: string;
     network?: IDao['network'];
     row: IDaoPermission;
     who?: IPermissionDetailEntity;
@@ -42,7 +43,7 @@ const toDetailsEntity = (
 
 export const PermissionDetailContent: React.FC<
     IPermissionDetailContentProps
-> = ({ chainId, className, network, row, who, where }) => {
+> = ({ chainId, className, daoId, network, row, who, where }) => {
     const { t } = useTranslations();
     const [activeTab, setActiveTab] =
         useState<PermissionDetailsTab>('permission');
@@ -95,6 +96,7 @@ export const PermissionDetailContent: React.FC<
             ) : (
                 <PermissionCondition
                     chainId={chainId}
+                    daoId={daoId}
                     network={network}
                     row={row}
                 />

--- a/apps/app/src/modules/settings/components/permissionsGraph/permissionDetailPanel.tsx
+++ b/apps/app/src/modules/settings/components/permissionsGraph/permissionDetailPanel.tsx
@@ -9,6 +9,7 @@ import { useDraggablePanel } from './useDraggablePanel';
 
 export interface IPermissionDetailPanelProps {
     chainId?: number;
+    daoId?: string;
     edge: IPermissionGraphEdge;
     network?: IDao['network'];
     nodes: IPermissionGraph['nodes'];
@@ -17,6 +18,7 @@ export interface IPermissionDetailPanelProps {
 
 export const PermissionDetailPanel: React.FC<IPermissionDetailPanelProps> = ({
     chainId,
+    daoId,
     edge,
     network,
     nodes,
@@ -66,6 +68,7 @@ export const PermissionDetailPanel: React.FC<IPermissionDetailPanelProps> = ({
             <PermissionDetailContent
                 chainId={chainId}
                 className="flex flex-col gap-4 overflow-auto p-4"
+                daoId={daoId}
                 network={network}
                 row={row}
                 where={where}

--- a/apps/app/src/modules/settings/components/permissionsGraph/permissionsGraph.tsx
+++ b/apps/app/src/modules/settings/components/permissionsGraph/permissionsGraph.tsx
@@ -147,6 +147,7 @@ export const PermissionsGraph: React.FC<IPermissionsGraphProps> = (props) => {
             {selectedEdge != null && (
                 <PermissionDetailPanel
                     chainId={networkDefinitions[dao.network].id}
+                    daoId={dao.id}
                     edge={selectedEdge}
                     network={dao.network}
                     nodes={graph.nodes}

--- a/apps/app/src/modules/settings/components/permissionsList/permissionsList.tsx
+++ b/apps/app/src/modules/settings/components/permissionsList/permissionsList.tsx
@@ -16,6 +16,7 @@ export interface IPermissionsListProps {
     accountRefs: IPermissionAccountRef[];
     daoPlugins?: IFilterComponentPlugin<IDaoPlugin>[];
     chainId?: number;
+    daoId?: string;
     isLoading: boolean;
     expandedRows: string[];
     onExpandedRowsChange: (rows: string[]) => void;
@@ -33,6 +34,7 @@ export const PermissionsList: React.FC<IPermissionsListProps> = (props) => {
         accountRefs,
         daoPlugins,
         chainId,
+        daoId,
         isLoading,
         expandedRows,
         onExpandedRowsChange,
@@ -84,6 +86,7 @@ export const PermissionsList: React.FC<IPermissionsListProps> = (props) => {
                     <PermissionsListRow
                         accounts={accountRefs}
                         chainId={chainId}
+                        daoId={daoId}
                         daoPlugins={daoPlugins}
                         key={getPermissionRowKey(row)}
                         network={row.network}

--- a/apps/app/src/modules/settings/components/permissionsList/permissionsListRow.tsx
+++ b/apps/app/src/modules/settings/components/permissionsList/permissionsListRow.tsx
@@ -21,6 +21,7 @@ export interface IPermissionsListRowProps {
     daoPlugins?: IFilterComponentPlugin<IDaoPlugin>[];
     accounts: IPermissionAccountRef[];
     chainId?: number;
+    daoId?: string;
     network?: Network;
 }
 
@@ -29,7 +30,8 @@ type PermissionCardTab = 'details' | 'condition';
 export const PermissionsListRow: React.FC<IPermissionsListRowProps> = (
     props,
 ) => {
-    const { row, rowKey, daoPlugins, accounts, chainId, network } = props;
+    const { row, rowKey, daoPlugins, accounts, chainId, daoId, network } =
+        props;
     const { t } = useTranslations();
     const [activeTab, setActiveTab] = useState<PermissionCardTab>('details');
     const resolveOptions = { daoPlugins, accounts };
@@ -100,6 +102,7 @@ export const PermissionsListRow: React.FC<IPermissionsListRowProps> = (
                 ) : (
                     <PermissionCondition
                         chainId={chainId}
+                        daoId={daoId}
                         network={network}
                         row={row}
                     />
@@ -147,6 +150,7 @@ export const PermissionsListRow: React.FC<IPermissionsListRowProps> = (
                                     </p>
                                     <PermissionCondition
                                         chainId={chainId}
+                                        daoId={daoId}
                                         network={network}
                                         row={row}
                                     />

--- a/apps/app/src/modules/settings/components/sppRuleConditionSlot/index.ts
+++ b/apps/app/src/modules/settings/components/sppRuleConditionSlot/index.ts
@@ -1,0 +1,1 @@
+export { SppRuleConditionSlot } from './sppRuleConditionSlot';

--- a/apps/app/src/modules/settings/components/sppRuleConditionSlot/sppRuleConditionSlot.test.tsx
+++ b/apps/app/src/modules/settings/components/sppRuleConditionSlot/sppRuleConditionSlot.test.tsx
@@ -1,10 +1,24 @@
 import { GukModulesProvider } from '@aragon/gov-ui-kit';
 import { render, screen } from '@testing-library/react';
-import type { IDaoPermissionCondition } from '@/shared/api/daoService';
+import * as useSppGuardModule from '@/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation';
+import {
+    type IDaoPermissionCondition,
+    type IDaoPlugin,
+    PluginInterfaceType,
+} from '@/shared/api/daoService';
+import * as useDaoPluginsModule from '@/shared/hooks/useDaoPlugins';
 import { SppRuleConditionSlot } from './sppRuleConditionSlot';
 
+jest.mock('@/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation');
+jest.mock('@/shared/hooks/useDaoPlugins');
+
 describe('<SppRuleConditionSlot /> component', () => {
-    const createTestComponent = (props?: Partial<IDaoPermissionCondition>) => (
+    const createTestComponent = (
+        props?: Partial<IDaoPermissionCondition> & {
+            conditionAddress?: string;
+            daoId?: string;
+        },
+    ) => (
         <GukModulesProvider>
             <SppRuleConditionSlot conditionType="spp-rule" {...props} />
         </GukModulesProvider>
@@ -49,5 +63,42 @@ describe('<SppRuleConditionSlot /> component', () => {
         expect(
             screen.getByText(/sppRuleConditionSlot.noRules/),
         ).toBeInTheDocument();
+    });
+
+    it('reuses the friendly proposal-creation eligibility when the SPP process resolves', () => {
+        const conditionAddress = '0xC0Ffee254729296a45a3885639AC7E10F9d54979';
+        const sppProcess = {
+            address: '0xSppProcess',
+            interfaceType: PluginInterfaceType.SPP,
+            proposalCreationConditionAddress: conditionAddress,
+            settings: { stages: [] },
+        } as unknown as IDaoPlugin;
+
+        (useDaoPluginsModule.useDaoPlugins as jest.Mock).mockReturnValue([
+            { meta: sppProcess },
+        ]);
+        (
+            useSppGuardModule.useSppPermissionCheckProposalCreation as jest.Mock
+        ).mockReturnValue({
+            hasPermission: false,
+            isLoading: false,
+            isRestricted: true,
+            settings: [
+                [
+                    {
+                        term: 'Friendly term',
+                        definition: 'Friendly definition',
+                    },
+                ],
+            ],
+        });
+
+        render(createTestComponent({ conditionAddress, daoId: 'dao-test' }));
+
+        expect(screen.getByText('Friendly term')).toBeInTheDocument();
+        expect(screen.getByText('Friendly definition')).toBeInTheDocument();
+        expect(
+            screen.queryByText(/sppRuleConditionSlot.description/),
+        ).not.toBeInTheDocument();
     });
 });

--- a/apps/app/src/modules/settings/components/sppRuleConditionSlot/sppRuleConditionSlot.test.tsx
+++ b/apps/app/src/modules/settings/components/sppRuleConditionSlot/sppRuleConditionSlot.test.tsx
@@ -1,0 +1,53 @@
+import { GukModulesProvider } from '@aragon/gov-ui-kit';
+import { render, screen } from '@testing-library/react';
+import type { IDaoPermissionCondition } from '@/shared/api/daoService';
+import { SppRuleConditionSlot } from './sppRuleConditionSlot';
+
+describe('<SppRuleConditionSlot /> component', () => {
+    const createTestComponent = (props?: Partial<IDaoPermissionCondition>) => (
+        <GukModulesProvider>
+            <SppRuleConditionSlot conditionType="spp-rule" {...props} />
+        </GukModulesProvider>
+    );
+
+    it('renders every normalized SPP rule field', () => {
+        render(
+            createTestComponent({
+                rules: [
+                    {
+                        type: 'condition',
+                        operation: 'return',
+                        value: '1234',
+                        permissionId: '0xpermission',
+                        ruleIndexes: [1, 2],
+                        conditionAddress:
+                            '0xC0Ffee254729296a45a3885639AC7E10F9d54979',
+                    },
+                ],
+            }),
+        );
+
+        expect(
+            screen.getByText(/sppRuleConditionSlot.description/),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText((content) =>
+                content.startsWith('app.settings.sppRuleConditionSlot.rule '),
+            ),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Condition')).toBeInTheDocument();
+        expect(screen.getByText('Return')).toBeInTheDocument();
+        expect(screen.getByText('1234')).toBeInTheDocument();
+        expect(screen.getByText('0xpermission')).toBeInTheDocument();
+        expect(screen.getByText('1, 2')).toBeInTheDocument();
+        expect(screen.getByText('0xC0Ff…4979')).toBeInTheDocument();
+    });
+
+    it('renders an explicit empty state when the backend returns no rules', () => {
+        render(createTestComponent({ rules: [] }));
+
+        expect(
+            screen.getByText(/sppRuleConditionSlot.noRules/),
+        ).toBeInTheDocument();
+    });
+});

--- a/apps/app/src/modules/settings/components/sppRuleConditionSlot/sppRuleConditionSlot.tsx
+++ b/apps/app/src/modules/settings/components/sppRuleConditionSlot/sppRuleConditionSlot.tsx
@@ -1,11 +1,77 @@
 'use client';
 
 import { addressUtils, DefinitionList } from '@aragon/gov-ui-kit';
-import type { IDaoPermissionCondition } from '@/shared/api/daoService';
+import { PermissionsDefinitionList } from '@/modules/governance/components/permissionsDefinitionList';
+import { useSppPermissionCheckProposalCreation } from '@/plugins/sppPlugin/hooks/useSppPermissionCheckProposalCreation';
+import type { ISppPluginSettings } from '@/plugins/sppPlugin/types';
+import {
+    type IDaoPermissionCondition,
+    type IDaoPlugin,
+    PluginInterfaceType,
+} from '@/shared/api/daoService';
 import { useTranslations } from '@/shared/components/translationsProvider';
+import { useDaoPlugins } from '@/shared/hooks/useDaoPlugins';
 import { stringUtils } from '@/shared/utils/stringUtils';
 
-export const SppRuleConditionSlot: React.FC<IDaoPermissionCondition> = ({
+interface ISppRuleConditionSlotProps extends IDaoPermissionCondition {
+    /** ID of the DAO the permission belongs to, used to resolve the SPP process. */
+    daoId?: string;
+    /** The rule condition contract address, which equals an SPP process proposal-creation condition. */
+    conditionAddress?: string;
+}
+
+/**
+ * Finds the SPP process plugin whose proposal-creation condition matches a
+ * rule-condition address. Backend enrichment keys `spp-rule` conditions by
+ * `plugin.proposalCreationConditionAddress`, so this is the same correlation
+ * used to attach the normalized rules in the first place.
+ */
+const findSppProcess = (
+    plugins: IDaoPlugin[] | undefined,
+    conditionAddress?: string,
+): IDaoPlugin | undefined => {
+    if (conditionAddress == null) {
+        return undefined;
+    }
+
+    return plugins?.find(
+        (plugin) =>
+            plugin.interfaceType === PluginInterfaceType.SPP &&
+            plugin.proposalCreationConditionAddress != null &&
+            addressUtils.isAddressEqual(
+                plugin.proposalCreationConditionAddress,
+                conditionAddress,
+            ),
+    );
+};
+
+/**
+ * Reuses the friendly proposal-creation eligibility presenter shown on process
+ * details. Runs wallet-free by setting `useConnectedUserInfo: false`; only
+ * `settings`, `isRestricted`, and `isLoading` are read (guards ignore
+ * `hasPermission` here).
+ */
+const SppFriendlyCondition: React.FC<{
+    daoId: string;
+    plugin: IDaoPlugin<ISppPluginSettings>;
+}> = ({ daoId, plugin }) => {
+    const { isLoading, isRestricted, settings } =
+        useSppPermissionCheckProposalCreation({
+            plugin,
+            daoId,
+            useConnectedUserInfo: false,
+        });
+
+    return (
+        <PermissionsDefinitionList
+            isLoading={isLoading}
+            isRestricted={isRestricted}
+            settings={settings}
+        />
+    );
+};
+
+const DecodedRules: React.FC<{ rules: IDaoPermissionCondition['rules'] }> = ({
     rules,
 }) => {
     const { t } = useTranslations();
@@ -91,5 +157,60 @@ export const SppRuleConditionSlot: React.FC<IDaoPermissionCondition> = ({
                 </ol>
             )}
         </div>
+    );
+};
+
+interface ISppProcessResolverProps {
+    conditionType: string;
+    conditionAddress?: string;
+    daoId: string;
+    rules?: IDaoPermissionCondition['rules'];
+}
+
+const SppProcessResolver: React.FC<ISppProcessResolverProps> = ({
+    daoId,
+    conditionAddress,
+    rules,
+}) => {
+    const plugins = useDaoPlugins({
+        daoId,
+        includeSubPlugins: true,
+        includeLinkedAccounts: true,
+        includeUnsupported: true,
+    });
+
+    const sppProcess = findSppProcess(
+        plugins?.map((plugin) => plugin.meta),
+        conditionAddress,
+    );
+
+    if (sppProcess != null) {
+        // Filtered to interfaceType SPP above, so its settings are the SPP
+        // plugin settings the proposal-creation guard reads.
+        const plugin = sppProcess as IDaoPlugin<ISppPluginSettings>;
+        return <SppFriendlyCondition daoId={daoId} plugin={plugin} />;
+    }
+
+    return <DecodedRules rules={rules} />;
+};
+
+export const SppRuleConditionSlot: React.FC<ISppRuleConditionSlotProps> = (
+    props,
+) => {
+    const { conditionType, daoId, conditionAddress, rules } = props;
+
+    // Resolving the process runs plugin queries, so only mount the resolver
+    // when a DAO is available. Without one, fall back to the decoded rules.
+    if (daoId == null) {
+        return <DecodedRules rules={rules} />;
+    }
+
+    return (
+        <SppProcessResolver
+            conditionAddress={conditionAddress}
+            conditionType={conditionType}
+            daoId={daoId}
+            rules={rules}
+        />
     );
 };

--- a/apps/app/src/modules/settings/components/sppRuleConditionSlot/sppRuleConditionSlot.tsx
+++ b/apps/app/src/modules/settings/components/sppRuleConditionSlot/sppRuleConditionSlot.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { addressUtils, DefinitionList } from '@aragon/gov-ui-kit';
+import type { IDaoPermissionCondition } from '@/shared/api/daoService';
+import { useTranslations } from '@/shared/components/translationsProvider';
+import { stringUtils } from '@/shared/utils/stringUtils';
+
+export const SppRuleConditionSlot: React.FC<IDaoPermissionCondition> = ({
+    rules,
+}) => {
+    const { t } = useTranslations();
+
+    return (
+        <div className="flex flex-col gap-3">
+            <p className="text-neutral-500">
+                {t('app.settings.sppRuleConditionSlot.description')}
+            </p>
+            {rules == null || rules.length === 0 ? (
+                <p className="text-neutral-400">
+                    {t('app.settings.sppRuleConditionSlot.noRules')}
+                </p>
+            ) : (
+                <ol className="flex flex-col gap-4">
+                    {rules.map((rule, index) => (
+                        <li
+                            className="flex flex-col gap-2"
+                            key={`${rule.permissionId}-${index}`}
+                        >
+                            <p className="font-medium text-neutral-800">
+                                {t('app.settings.sppRuleConditionSlot.rule')}{' '}
+                                {index + 1}
+                            </p>
+                            <DefinitionList.Container>
+                                <DefinitionList.Item
+                                    term={t(
+                                        'app.settings.sppRuleConditionSlot.type',
+                                    )}
+                                >
+                                    {stringUtils.toPascalCase(rule.type)}
+                                </DefinitionList.Item>
+                                <DefinitionList.Item
+                                    term={t(
+                                        'app.settings.sppRuleConditionSlot.operation',
+                                    )}
+                                >
+                                    {stringUtils.toPascalCase(rule.operation)}
+                                </DefinitionList.Item>
+                                <DefinitionList.Item
+                                    term={t(
+                                        'app.settings.sppRuleConditionSlot.value',
+                                    )}
+                                >
+                                    <span className="break-all">
+                                        {rule.value}
+                                    </span>
+                                </DefinitionList.Item>
+                                <DefinitionList.Item
+                                    copyValue={rule.permissionId}
+                                    term={t(
+                                        'app.settings.sppRuleConditionSlot.permissionId',
+                                    )}
+                                >
+                                    <span className="break-all">
+                                        {rule.permissionId}
+                                    </span>
+                                </DefinitionList.Item>
+                                {rule.ruleIndexes != null && (
+                                    <DefinitionList.Item
+                                        term={t(
+                                            'app.settings.sppRuleConditionSlot.ruleIndexes',
+                                        )}
+                                    >
+                                        {rule.ruleIndexes.join(', ')}
+                                    </DefinitionList.Item>
+                                )}
+                                {rule.conditionAddress != null && (
+                                    <DefinitionList.Item
+                                        copyValue={rule.conditionAddress}
+                                        term={t(
+                                            'app.settings.sppRuleConditionSlot.conditionAddress',
+                                        )}
+                                    >
+                                        {addressUtils.truncateAddress(
+                                            rule.conditionAddress,
+                                        )}
+                                    </DefinitionList.Item>
+                                )}
+                            </DefinitionList.Container>
+                        </li>
+                    ))}
+                </ol>
+            )}
+        </div>
+    );
+};

--- a/apps/app/src/modules/settings/initConditionRegistry.test.ts
+++ b/apps/app/src/modules/settings/initConditionRegistry.test.ts
@@ -3,6 +3,7 @@ import { pluginRegistryUtils } from '@/shared/utils/pluginRegistryUtils';
 import { ExecuteSelectorConditionSlot } from './components/executeSelectorConditionSlot';
 import { MembershipConditionSlot } from './components/membershipConditionSlot';
 import { NoConditionSlot } from './components/noConditionSlot';
+import { SppRuleConditionSlot } from './components/sppRuleConditionSlot';
 import { UnrecognizedConditionSlot } from './components/unrecognizedConditionSlot';
 import { VotingPowerConditionSlot } from './components/votingPowerConditionSlot';
 import { initialiseConditionRegistry } from './initConditionRegistry';
@@ -19,6 +20,7 @@ describe('initialiseConditionRegistry', () => {
             component: ExecuteSelectorConditionSlot,
         },
         { pluginId: 'membership', component: MembershipConditionSlot },
+        { pluginId: 'spp-rule', component: SppRuleConditionSlot },
         { pluginId: 'unknown', component: UnrecognizedConditionSlot },
         { pluginId: 'none', component: NoConditionSlot },
     ])('resolves the $pluginId condition component from the slot', ({

--- a/apps/app/src/modules/settings/initConditionRegistry.ts
+++ b/apps/app/src/modules/settings/initConditionRegistry.ts
@@ -4,6 +4,7 @@ import { pluginRegistryUtils } from '@/shared/utils/pluginRegistryUtils';
 import { ExecuteSelectorConditionSlot } from './components/executeSelectorConditionSlot';
 import { MembershipConditionSlot } from './components/membershipConditionSlot';
 import { NoConditionSlot } from './components/noConditionSlot';
+import { SppRuleConditionSlot } from './components/sppRuleConditionSlot';
 import { UnrecognizedConditionSlot } from './components/unrecognizedConditionSlot';
 import { VotingPowerConditionSlot } from './components/votingPowerConditionSlot';
 import { NO_CONDITION, UNKNOWN_CONDITION } from './utils/conditionTypeUtils';
@@ -34,6 +35,11 @@ export const initialiseConditionRegistry = () => {
             slotId: SettingsSlotId.SETTINGS_PERMISSION_CONDITION,
             pluginId: 'membership',
             component: MembershipConditionSlot,
+        })
+        .registerSlotComponent({
+            slotId: SettingsSlotId.SETTINGS_PERMISSION_CONDITION,
+            pluginId: 'spp-rule',
+            component: SppRuleConditionSlot,
         })
         .registerSlotComponent({
             slotId: SettingsSlotId.SETTINGS_PERMISSION_CONDITION,

--- a/apps/app/src/modules/settings/pages/daoPermissionsPage/daoPermissionsPageClient.test.tsx
+++ b/apps/app/src/modules/settings/pages/daoPermissionsPage/daoPermissionsPageClient.test.tsx
@@ -217,7 +217,7 @@ describe('<DaoPermissionsPageClient /> component', () => {
         );
     });
 
-    it('hides the list expand control below the desktop breakpoint', () => {
+    it('renders the list expand control below the list, not in the view toolbar', () => {
         mockFilterParamValues = { permissionsview: 'list' };
 
         render(
@@ -226,10 +226,13 @@ describe('<DaoPermissionsPageClient /> component', () => {
             </GukModulesProvider>,
         );
 
-        expect(screen.getByRole('button', { name: 'Expand all' })).toHaveClass(
-            'hidden',
-            'md:inline-flex',
-        );
+        // Rendered bottom-right of the list, not hidden on desktop like the
+        // old toolbar control.
+        const expandButton = screen.getByRole('button', {
+            name: 'Expand all',
+        });
+        expect(expandButton).toBeInTheDocument();
+        expect(expandButton).not.toHaveClass('hidden');
     });
 
     it('shows noisy permission groups when hide switches are off', () => {

--- a/apps/app/src/modules/settings/pages/daoPermissionsPage/daoPermissionsPageClient.tsx
+++ b/apps/app/src/modules/settings/pages/daoPermissionsPage/daoPermissionsPageClient.tsx
@@ -229,23 +229,6 @@ export const DaoPermissionsPageClient: React.FC<
                                         value={PermissionsView.GRAPH}
                                     />
                                 </ToggleGroup>
-                                {showExpandAll && (
-                                    <Button
-                                        className="hidden md:inline-flex"
-                                        onClick={handleToggleAll}
-                                        responsiveSize={{ md: 'md' }}
-                                        size="sm"
-                                        variant="tertiary"
-                                    >
-                                        {allExpanded
-                                            ? t(
-                                                  'app.settings.permissionsList.collapseAll',
-                                              )
-                                            : t(
-                                                  'app.settings.permissionsList.expandAll',
-                                              )}
-                                    </Button>
-                                )}
                             </div>
                             <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-neutral-700 text-sm md:justify-end">
                                 <div className="flex items-center gap-1">
@@ -292,6 +275,7 @@ export const DaoPermissionsPageClient: React.FC<
                             <PermissionsList
                                 accountRefs={accountRefs}
                                 chainId={chainId}
+                                daoId={daoId}
                                 daoPlugins={daoPlugins}
                                 expandedRows={expandedRows}
                                 isLoading={isLoading}
@@ -307,6 +291,24 @@ export const DaoPermissionsPageClient: React.FC<
                                 isLoading={isLoading}
                                 rows={filteredRows}
                             />
+                        )}
+                        {isListView && showExpandAll && (
+                            <div className="flex justify-end">
+                                <Button
+                                    onClick={handleToggleAll}
+                                    responsiveSize={{ md: 'md' }}
+                                    size="sm"
+                                    variant="tertiary"
+                                >
+                                    {allExpanded
+                                        ? t(
+                                              'app.settings.permissionsList.collapseAll',
+                                          )
+                                        : t(
+                                              'app.settings.permissionsList.expandAll',
+                                          )}
+                                </Button>
+                            </div>
                         )}
                     </div>
                 </Page.Main>

--- a/apps/app/src/modules/settings/utils/buildPermissionGraph/buildPermissionGraph.test.ts
+++ b/apps/app/src/modules/settings/utils/buildPermissionGraph/buildPermissionGraph.test.ts
@@ -129,6 +129,35 @@ describe('buildPermissionGraph', () => {
         );
     });
 
+    it('preserves an enriched external DAO as a linked DAO node', () => {
+        const externalDaoAddress = '0x2222222222222222222222222222222222222222';
+        const graph = buildPermissionGraph({
+            rows: [
+                buildRow({
+                    whoAddress: externalDaoAddress,
+                    who: {
+                        address: externalDaoAddress,
+                        avatarSrc: 'https://external-dao.png',
+                        label: 'External DAO',
+                        layer: 'dao',
+                    },
+                }),
+            ],
+            dao,
+            accountRefs,
+        });
+
+        expect(
+            graph.nodes.find(
+                (node) => node.id === externalDaoAddress.toLowerCase(),
+            ),
+        ).toMatchObject({
+            kind: 'linkedDao',
+            label: 'External DAO',
+            avatarSrc: 'https://external-dao.png',
+        });
+    });
+
     it.each([
         {
             name: 'uses backend entity metadata without installed plugin lookup',

--- a/apps/app/src/modules/settings/utils/buildPermissionGraph/buildPermissionGraph.ts
+++ b/apps/app/src/modules/settings/utils/buildPermissionGraph/buildPermissionGraph.ts
@@ -78,6 +78,18 @@ const resolveNode = (
         };
     }
 
+    if (enrichedEntity?.layer === 'dao') {
+        return {
+            id,
+            kind: 'linkedDao',
+            label:
+                enrichedEntity.label ??
+                addressUtils.truncateAddress(enrichedEntity.address),
+            avatarSrc: enrichedEntity.avatarSrc,
+            address,
+        };
+    }
+
     const entity = permissionEntityUtils.resolvePermissionEntity(address, {
         daoPlugins,
         accounts: accountRefs,

--- a/apps/app/src/modules/settings/utils/conditionTypeUtils/conditionTypeUtils.test.ts
+++ b/apps/app/src/modules/settings/utils/conditionTypeUtils/conditionTypeUtils.test.ts
@@ -56,6 +56,11 @@ describe('conditionType Utils', () => {
                 expected: 'ExecuteSelector',
             },
             {
+                description: 'maps spp-rule to SppRule',
+                conditionType: 'spp-rule',
+                expected: 'SPP rule',
+            },
+            {
                 description: 'maps "none" to the empty placeholder',
                 conditionType: 'none',
                 expected: '-',

--- a/apps/app/src/modules/settings/utils/conditionTypeUtils/conditionTypeUtils.ts
+++ b/apps/app/src/modules/settings/utils/conditionTypeUtils/conditionTypeUtils.ts
@@ -36,6 +36,7 @@ const UNKNOWN_LABEL = 'Unrecognized condition';
 const CONDITION_LABELS: Record<string, string> = {
     'voting-power': 'VotingPower',
     'execute-selector': 'ExecuteSelector',
+    'spp-rule': 'SPP rule',
 };
 
 /**

--- a/apps/app/src/shared/api/daoService/domain/daoPermission.ts
+++ b/apps/app/src/shared/api/daoService/domain/daoPermission.ts
@@ -6,6 +6,35 @@ import type {
     PermissionEntityStatus,
 } from './enum';
 
+export interface ISppConditionRule {
+    type:
+        | 'block-number'
+        | 'timestamp'
+        | 'condition'
+        | 'logic'
+        | 'value'
+        | 'unknown';
+    operation:
+        | 'none'
+        | 'eq'
+        | 'neq'
+        | 'gt'
+        | 'lt'
+        | 'gte'
+        | 'lte'
+        | 'return'
+        | 'not'
+        | 'and'
+        | 'or'
+        | 'xor'
+        | 'if-else'
+        | 'unknown';
+    value: string;
+    permissionId: string;
+    ruleIndexes?: number[];
+    conditionAddress?: string;
+}
+
 /**
  * Backend-enriched condition payload for a permission. Fields vary by
  * condition type (voting-power, membership, execute-selector, or unknown).
@@ -40,6 +69,10 @@ export interface IDaoPermissionCondition {
      * Untrusted backend payload, narrowed by the execute-selector slot.
      */
     targets?: unknown;
+    /**
+     * Normalized rules returned for SPP rule conditions.
+     */
+    rules?: ISppConditionRule[];
 }
 
 /**

--- a/apps/app/src/shared/api/daoService/domain/index.ts
+++ b/apps/app/src/shared/api/daoService/domain/index.ts
@@ -5,6 +5,7 @@ export type {
     IDaoPermission,
     IDaoPermissionCondition,
     IPermissionEntityRef,
+    ISppConditionRule,
 } from './daoPermission';
 export type { IDaoPlugin } from './daoPlugin';
 export {


### PR DESCRIPTION
# Description

Render normalized SPP rule conditions in permission details and preserve backend-enriched external DAO actors as DAO nodes in the permissions graph.

This is the frontend slice of [APP-1059](https://linear.app/aragon/issue/APP-1059/expand-graph-view-support-for-additional-dao-conditions-and-addresses). It depends on [aragon/app-backend#1527](https://github.com/aragon/app-backend/pull/1527) returning `conditionType: "spp-rule"` with normalized `rules` data.

## Type of Change

- [x] Patch: Enhancement (non-breaking change to an existing feature)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project