### PR TITLE
fix(APP-986): Final objection plugin polish

### DIFF
--- a/.changeset/fresh-alchemix-objections.md
+++ b/.changeset/fresh-alchemix-objections.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Polish Alchemix objection voting and refresh its recorded state after vote indexing.

--- a/apps/app/src/daos/alchemix/components/alchemixSubmitVote/components/alchemixObjectionVote.test.tsx
+++ b/apps/app/src/daos/alchemix/components/alchemixSubmitVote/components/alchemixObjectionVote.test.tsx
@@ -1,5 +1,5 @@
 import { GukModulesProvider } from '@aragon/gov-ui-kit';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import * as useWalletAccountHook from '@/modules/application/hooks/useWalletAccount';
 import { GovernanceDialogId } from '@/modules/governance/constants/governanceDialogId';
@@ -259,5 +259,38 @@ describe('<AlchemixObjectionVote /> component', () => {
                 name: /tokenSubmitVote.options.no/,
             }),
         ).toHaveTextContent(/tokenSubmitVote.options.approveNoDescription/);
+    });
+
+    it('refetches objection status on confirmation and again after indexing', async () => {
+        const open = jest.fn();
+        const { refetch } = mockObjectionStatus();
+        useDialogContextSpy.mockReturnValue(generateDialogContext({ open }));
+
+        render(createTestComponent());
+
+        await userEvent.click(
+            screen.getByRole('button', {
+                name: /tokenSubmitVote.buttons.vote/,
+            }),
+        );
+        await userEvent.click(
+            screen.getByRole('radio', {
+                name: /tokenSubmitVote.options.no/,
+            }),
+        );
+        await userEvent.click(
+            screen.getByRole('button', {
+                name: /tokenSubmitVote.buttons.submit/,
+            }),
+        );
+
+        const params = open.mock.calls[0][1].params as IVoteDialogParams;
+
+        act(() => params.onSuccess?.());
+        expect(refetch).toHaveBeenCalledTimes(1);
+        expect(params.onIndexed).toEqual(expect.any(Function));
+
+        act(() => params.onIndexed?.());
+        expect(refetch).toHaveBeenCalledTimes(2);
     });
 });

--- a/apps/app/src/daos/alchemix/components/alchemixSubmitVote/components/alchemixObjectionVote.test.tsx
+++ b/apps/app/src/daos/alchemix/components/alchemixSubmitVote/components/alchemixObjectionVote.test.tsx
@@ -169,7 +169,7 @@ describe('<AlchemixObjectionVote /> component', () => {
         expect(container).toBeEmptyDOMElement();
     });
 
-    it('only enables No and submits a regular objection vote', async () => {
+    it('presents the objection restriction once, only enables No, and submits a regular objection vote', async () => {
         const open = jest.fn();
         useDialogContextSpy.mockReturnValue(generateDialogContext({ open }));
 
@@ -181,21 +181,42 @@ describe('<AlchemixObjectionVote /> component', () => {
             }),
         );
 
-        expect(
-            screen.getByRole('radio', { name: /tokenSubmitVote.options.yes/ }),
-        ).toBeDisabled();
-        expect(
-            screen.getByRole('radio', {
-                name: /tokenSubmitVote.options.abstain/,
-            }),
-        ).toBeDisabled();
-        expect(
-            screen.getAllByText(/alchemixSubmitVote.options.objectionOnly/),
-        ).toHaveLength(2);
-
-        await userEvent.click(
-            screen.getByRole('radio', { name: /tokenSubmitVote.options.no/ }),
+        const question = screen.getByText(/tokenSubmitVote.options.label/);
+        const objectionHelpText = screen.getAllByText(
+            /alchemixSubmitVote.options.objectionOnly/,
         );
+        const yesOption = screen.getByRole('radio', {
+            name: /tokenSubmitVote.options.yes/,
+        });
+        const abstainOption = screen.getByRole('radio', {
+            name: /tokenSubmitVote.options.abstain/,
+        });
+        const noOption = screen.getByRole('radio', {
+            name: /tokenSubmitVote.options.no/,
+        });
+        const objectionHelp = objectionHelpText[0];
+
+        expect(objectionHelpText).toHaveLength(1);
+        expect(question.closest('label')).toContainElement(objectionHelp);
+        expect(
+            question.compareDocumentPosition(objectionHelp) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+        expect(
+            objectionHelp.compareDocumentPosition(yesOption) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+        expect(yesOption).toHaveTextContent(
+            /tokenSubmitVote.options.vetoYesDescription/,
+        );
+        expect(noOption).toHaveTextContent(
+            /tokenSubmitVote.options.vetoNoDescription/,
+        );
+        expect(yesOption).toBeDisabled();
+        expect(abstainOption).toBeDisabled();
+        expect(noOption).toBeEnabled();
+
+        await userEvent.click(noOption);
         await userEvent.click(
             screen.getByRole('button', {
                 name: /tokenSubmitVote.buttons.submit/,
@@ -217,5 +238,26 @@ describe('<AlchemixObjectionVote /> component', () => {
         expect(
             (open.mock.calls[0][1].params as IVoteDialogParams).vote,
         ).not.toHaveProperty('voteType');
+    });
+
+    it('uses the standard approve descriptions in approve mode', async () => {
+        render(createTestComponent());
+
+        await userEvent.click(
+            screen.getByRole('button', {
+                name: /tokenSubmitVote.buttons.vote/,
+            }),
+        );
+
+        expect(
+            screen.getByRole('radio', {
+                name: /tokenSubmitVote.options.yes/,
+            }),
+        ).toHaveTextContent(/tokenSubmitVote.options.approveYesDescription/);
+        expect(
+            screen.getByRole('radio', {
+                name: /tokenSubmitVote.options.no/,
+            }),
+        ).toHaveTextContent(/tokenSubmitVote.options.approveNoDescription/);
     });
 });

--- a/apps/app/src/daos/alchemix/components/alchemixSubmitVote/components/alchemixObjectionVote.tsx
+++ b/apps/app/src/daos/alchemix/components/alchemixSubmitVote/components/alchemixObjectionVote.tsx
@@ -103,6 +103,7 @@ export const AlchemixObjectionVote: React.FC<IAlchemixObjectionVoteProps> = (
             isVeto,
             plugin,
             onSuccess: handleVoteSuccess,
+            onIndexed: refetch,
         };
 
         open(GovernanceDialogId.VOTE, { params });

--- a/apps/app/src/daos/alchemix/components/alchemixSubmitVote/components/alchemixObjectionVote.tsx
+++ b/apps/app/src/daos/alchemix/components/alchemixSubmitVote/components/alchemixObjectionVote.tsx
@@ -33,6 +33,11 @@ export interface IAlchemixObjectionVoteProps {
     isVeto?: boolean;
 }
 
+const disabledOptions: IDisabledVotingOption[] = [
+    { value: VoteOption.YES.toString() },
+    { value: VoteOption.ABSTAIN.toString() },
+];
+
 export const AlchemixObjectionVote: React.FC<IAlchemixObjectionVoteProps> = (
     props,
 ) => {
@@ -73,15 +78,6 @@ export const AlchemixObjectionVote: React.FC<IAlchemixObjectionVoteProps> = (
         proposal,
         onSuccess: () => setShowOptions(true),
     });
-
-    // Only "No" can be submitted during the objection phase, every other option is disabled with the reason.
-    const disabledOptions: IDisabledVotingOption[] = [
-        VoteOption.YES,
-        VoteOption.ABSTAIN,
-    ].map((option) => ({
-        value: option.toString(),
-        reason: t('app.daos.alchemix.alchemixSubmitVote.options.objectionOnly'),
-    }));
 
     const openTransactionDialog = () => {
         if (plugin == null) {
@@ -176,6 +172,9 @@ export const AlchemixObjectionVote: React.FC<IAlchemixObjectionVoteProps> = (
                 <Card className="border border-neutral-100 p-6 shadow-neutral-sm">
                     <TokenVotingOptions
                         disabledOptions={disabledOptions}
+                        helpText={t(
+                            'app.daos.alchemix.alchemixSubmitVote.options.objectionOnly',
+                        )}
                         isVeto={isVeto}
                         onChange={setSelectedOption}
                         value={selectedOption}

--- a/apps/app/src/daos/alchemix/constants/domains/alchemixTest.ts
+++ b/apps/app/src/daos/alchemix/constants/domains/alchemixTest.ts
@@ -1,4 +1,4 @@
 export const alchemixTest = {
-    id: 'ethereum-sepolia-0x1F0D1ab1ebbBFeeaD2cc5566dBCb2e7403b42499',
+    id: 'base-mainnet-0x32d627b081e0f4fF28474820f20128049DA55360',
     name: 'alchemixTest',
 };

--- a/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.test.tsx
+++ b/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.test.tsx
@@ -1,0 +1,137 @@
+import { GukModulesProvider } from '@aragon/gov-ui-kit';
+import type * as ReactQuery from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import { act, type ReactNode } from 'react';
+import * as useWalletAccountHook from '@/modules/application/hooks/useWalletAccount';
+import * as DaoService from '@/shared/api/daoService';
+import type { IDialogLocation } from '@/shared/components/dialogProvider';
+import {
+    type ITransactionDialogProps,
+    TransactionDialog,
+} from '@/shared/components/transactionDialog';
+import {
+    generateDao,
+    generateDaoPlugin,
+    generateReactQueryResultSuccess,
+} from '@/shared/testUtils';
+import { GovernanceServiceKey } from '../../api/governanceService';
+import { generateProposal } from '../../testUtils';
+import { type IVoteDialogParams, VoteDialog } from './voteDialog';
+
+jest.mock('@tanstack/react-query', () => {
+    const actual = jest.requireActual<typeof ReactQuery>(
+        '@tanstack/react-query',
+    );
+    return {
+        ...actual,
+        useQueryClient: jest.fn(),
+    };
+});
+
+jest.mock('@/shared/components/transactionDialog', () => {
+    const actual = jest.requireActual<
+        typeof import('@/shared/components/transactionDialog')
+    >('@/shared/components/transactionDialog');
+    return {
+        ...actual,
+        TransactionDialog: jest.fn((props: { children: ReactNode }) => (
+            <div data-testid="transaction-dialog">{props.children}</div>
+        )),
+    };
+});
+
+jest.mock('next/navigation', () => ({
+    useRouter: jest.fn(() => ({ refresh: jest.fn() })),
+}));
+
+describe('<VoteDialog />', () => {
+    const useWalletAccountSpy = jest.spyOn(
+        useWalletAccountHook,
+        'useWalletAccount',
+    );
+    const useDaoSpy = jest.spyOn(DaoService, 'useDao');
+    const invalidateQueries = jest.fn();
+
+    beforeEach(() => {
+        useWalletAccountSpy.mockReturnValue({
+            address: '0x1111111111111111111111111111111111111111',
+            chainId: 1,
+            isConnecting: false,
+            isReconnecting: false,
+        });
+        useDaoSpy.mockReturnValue(
+            generateReactQueryResultSuccess({ data: generateDao() }),
+        );
+        (useQueryClient as jest.Mock).mockReturnValue({ invalidateQueries });
+    });
+
+    afterEach(() => {
+        useWalletAccountSpy.mockReset();
+        useDaoSpy.mockReset();
+        invalidateQueries.mockReset();
+        (TransactionDialog as jest.Mock).mockClear();
+    });
+
+    const generateDialogLocation = (
+        params?: Partial<IVoteDialogParams>,
+    ): IDialogLocation<IVoteDialogParams> => ({
+        id: 'test',
+        params: {
+            daoId: 'test-dao',
+            plugin: generateDaoPlugin(),
+            proposal: generateProposal(),
+            vote: { label: 'yes', value: 1 },
+            ...params,
+        },
+    });
+
+    const createTestComponent = (
+        location: IDialogLocation<IVoteDialogParams>,
+    ) => (
+        <GukModulesProvider>
+            <VoteDialog location={location} />
+        </GukModulesProvider>
+    );
+
+    it('preserves vote-list invalidation and notifies the caller after indexing', () => {
+        const onIndexed = jest.fn();
+        const onSuccess = jest.fn();
+        const location = generateDialogLocation({ onIndexed, onSuccess });
+
+        render(createTestComponent(location));
+
+        const transactionDialogProps = (TransactionDialog as jest.Mock).mock
+            .calls[0][0] as ITransactionDialogProps;
+
+        expect(transactionDialogProps.onSuccess).toBe(onSuccess);
+
+        act(() => {
+            transactionDialogProps.onIndexed?.({ slug: undefined });
+        });
+
+        expect(invalidateQueries).toHaveBeenCalledWith({
+            queryKey: [GovernanceServiceKey.VOTE_LIST],
+        });
+        expect(onIndexed).toHaveBeenCalledTimes(1);
+        expect(invalidateQueries.mock.invocationCallOrder[0]).toBeLessThan(
+            onIndexed.mock.invocationCallOrder[0],
+        );
+    });
+
+    it('keeps indexing behavior unchanged when the caller omits the callback', () => {
+        const location = generateDialogLocation();
+
+        render(createTestComponent(location));
+
+        const transactionDialogProps = (TransactionDialog as jest.Mock).mock
+            .calls[0][0] as ITransactionDialogProps;
+
+        expect(() => {
+            act(() => {
+                transactionDialogProps.onIndexed?.({ slug: undefined });
+            });
+        }).not.toThrow();
+        expect(invalidateQueries).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
+++ b/apps/app/src/modules/governance/dialogs/voteDialog/voteDialog.tsx
@@ -70,6 +70,10 @@ export interface IVoteDialogParams<
      * Callback called when the vote transaction has been included in a block.
      */
     onSuccess?: () => void;
+    /**
+     * Callback called when the vote transaction has been indexed.
+     */
+    onIndexed?: () => void;
 }
 
 export interface IVoteDialogProps
@@ -89,8 +93,16 @@ export const VoteDialog: React.FC<IVoteDialogProps> = (props) => {
     const { address } = useWalletAccount();
     invariant(address != null, 'VoteDialog: user must be connected.');
 
-    const { vote, proposal, isVeto, daoId, plugin, target, onSuccess } =
-        location.params;
+    const {
+        vote,
+        proposal,
+        isVeto,
+        daoId,
+        plugin,
+        target,
+        onSuccess,
+        onIndexed,
+    } = location.params;
 
     const queryClient = useQueryClient();
     const { data: dao } = useDao({ urlParams: { id: daoId } });
@@ -107,10 +119,12 @@ export const VoteDialog: React.FC<IVoteDialogProps> = (props) => {
 
     // Refresh the vote lists as soon as the vote is indexed so that the submit-vote controls reflect the new vote
     // without waiting for a route refresh or window focus.
-    const handleIndexed = () =>
-        queryClient.invalidateQueries({
+    const handleIndexed = () => {
+        void queryClient.invalidateQueries({
             queryKey: [GovernanceServiceKey.VOTE_LIST],
         });
+        onIndexed?.();
+    };
 
     // Fallback to the parent plugin to display the slug of the parent proposal (if exists)
     const pluginAddress = plugin.parentPlugin ?? plugin.address;

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.test.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.test.tsx
@@ -1,0 +1,124 @@
+import { GukModulesProvider } from '@aragon/gov-ui-kit';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { VoteOption } from '@/plugins/tokenPlugin/types';
+import {
+    type ITokenVotingOptionsProps,
+    TokenVotingOptions,
+} from './tokenVotingOptions';
+
+describe('<TokenVotingOptions /> component', () => {
+    const createTestComponent = (props?: Partial<ITokenVotingOptionsProps>) => {
+        const completeProps: ITokenVotingOptionsProps = {
+            onChange: jest.fn(),
+            ...props,
+        };
+
+        return (
+            <GukModulesProvider>
+                <TokenVotingOptions {...completeProps} />
+            </GukModulesProvider>
+        );
+    };
+
+    it('renders optional help text between the question and voting options', () => {
+        const helpText = 'Only No can be selected.';
+        render(createTestComponent({ helpText }));
+
+        const question = screen.getByText(/tokenSubmitVote.options.label/);
+        const help = screen.getByText(helpText);
+        const yesOption = screen.getByRole('radio', {
+            name: /tokenSubmitVote.options.yes/,
+        });
+
+        expect(question.closest('label')).toContainElement(help);
+        expect(question.compareDocumentPosition(help)).toBe(
+            Node.DOCUMENT_POSITION_FOLLOWING,
+        );
+        expect(
+            help.compareDocumentPosition(yesOption) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+    });
+
+    it('does not add help text markup when the prop is omitted', () => {
+        render(createTestComponent());
+
+        const question = screen.getByText(/tokenSubmitVote.options.label/);
+
+        expect(question.closest('label')).toHaveTextContent(
+            /^app\.plugins\.token\.tokenSubmitVote\.options\.label/,
+        );
+        expect(question.closest('label')?.children).toHaveLength(1);
+    });
+
+    it('keeps normal copy when individual options are disabled without reasons', () => {
+        render(
+            createTestComponent({
+                disabledOptions: [
+                    { value: VoteOption.YES.toString() },
+                    { value: VoteOption.ABSTAIN.toString() },
+                ],
+            }),
+        );
+
+        const yesOption = screen.getByRole('radio', {
+            name: /tokenSubmitVote.options.yes/,
+        });
+        const abstainOption = screen.getByRole('radio', {
+            name: /tokenSubmitVote.options.abstain/,
+        });
+        const noOption = screen.getByRole('radio', {
+            name: /tokenSubmitVote.options.no/,
+        });
+
+        expect(yesOption).toHaveTextContent(
+            /tokenSubmitVote.options.approveYesDescription/,
+        );
+        expect(abstainOption).toHaveTextContent(
+            /tokenSubmitVote.options.abstain/,
+        );
+        expect(noOption).toHaveTextContent(
+            /tokenSubmitVote.options.approveNoDescription/,
+        );
+        expect(yesOption).toBeDisabled();
+        expect(abstainOption).toBeDisabled();
+        expect(noOption).toBeEnabled();
+    });
+
+    it('preserves veto copy and disables every option when requested', () => {
+        render(createTestComponent({ disableOptions: true, isVeto: true }));
+
+        const options = screen.getAllByRole('radio');
+
+        expect(options).toHaveLength(3);
+        options.forEach((option) => expect(option).toBeDisabled());
+        expect(options[0]).toHaveTextContent(
+            /tokenSubmitVote.options.vetoYesDescription/,
+        );
+        expect(options[2]).toHaveTextContent(
+            /tokenSubmitVote.options.vetoNoDescription/,
+        );
+    });
+
+    it('preserves the selected value and change callback', async () => {
+        const onChange = jest.fn();
+        render(
+            createTestComponent({
+                onChange,
+                value: VoteOption.YES.toString(),
+            }),
+        );
+
+        const yesOption = screen.getByRole('radio', {
+            name: /tokenSubmitVote.options.yes/,
+        });
+        const noOption = screen.getByRole('radio', {
+            name: /tokenSubmitVote.options.no/,
+        });
+
+        expect(yesOption).toHaveAttribute('aria-checked', 'true');
+        await userEvent.click(noOption);
+        expect(onChange).toHaveBeenCalledWith(VoteOption.NO.toString());
+    });
+});

--- a/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.tsx
+++ b/apps/app/src/plugins/tokenPlugin/components/tokenSubmitVote/components/tokenVotingOptions.tsx
@@ -17,6 +17,10 @@ export interface ITokenVotingOptionsProps {
      */
     onChange: (value?: string) => void;
     /**
+     * Help text displayed beneath the voting question.
+     */
+    helpText?: string;
+    /**
      * Disables the options when set to true.
      */
     disableOptions?: boolean;
@@ -44,6 +48,7 @@ export const TokenVotingOptions: React.FC<ITokenVotingOptionsProps> = (
         isVeto,
         value: selectedValue,
         onChange,
+        helpText,
         disableOptions,
         disabledOptions,
     } = props;
@@ -77,6 +82,7 @@ export const TokenVotingOptions: React.FC<ITokenVotingOptionsProps> = (
 
     return (
         <InputContainer
+            helpText={helpText}
             id={id}
             label={t('app.plugins.token.tokenSubmitVote.options.label', {
                 label: isVeto


### PR DESCRIPTION
# Description

Two changes:
- The copy was repetitive on the objection plugin saying "You can only vote No" twice. Moved this to a new help text field and it looks good.
<img width="1254" height="489" alt="image" src="https://github.com/user-attachments/assets/3299dc55-7df3-47e7-a2b6-5361208c9445" />
- The indexing of an objection wasn't refreshing the voting terminal so people couldn't tell if tx went through. Trying to object again was of course a failed tx.

## Type of Change

<!--- Please delete the options that are not relevant. -->

- [ ] Major: Breaking change (change that would cause existing functionality to not work as expected)
- [ ] Minor: Feature (non-breaking change which adds new functionality)
- [ ] Patch: Enhancement (non-breaking change to an existing feature)
- [ ] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [ ] Manually smoke tested the functionality in a preview or locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Merged and published any dependent changes in downstream modules
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
