### PR TITLE
Release @aragon/app@1.37.1

### DIFF
--- a/.changeset/app-1004-assistant-chat-design-iteration.md
+++ b/.changeset/app-1004-assistant-chat-design-iteration.md
@@ -1,6 +1,0 @@
----
-"@aragon/assistant-chat": minor
-"@aragon/app": patch
----
-
-Iterate the support assistant on design feedback: the panel header carries the Aragon mark and names the request being drafted or created, the ticket card leads with the ticket title instead of a "Review your request" label, spent drafts collapse into a quiet line, past requests move from the greeting into their own view reached from under the composer, and the mail escape hatch becomes a footnote there. The transcript opens with a time divider, and the navigation trigger withdraws while the panel is open — the panel collapses through its own chevron.

--- a/.changeset/app-1004-assistant-chat-polish.md
+++ b/.changeset/app-1004-assistant-chat-polish.md
@@ -1,5 +1,0 @@
----
-"@aragon/assistant-chat": patch
----
-
-Send the name and type of an attachment with the conversation (never its bytes), so the assistant can say where a file arrived. The panel header now carries the exact height of the app's navigation bar, so the two bottom borders meet in a line rather than a step, and every control in the widget points at the cursor.

--- a/.changeset/app-1012-unknown-plugins.md
+++ b/.changeset/app-1012-unknown-plugins.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Handle plugins with an unresolved interface type consistently: they are now dropped from the plugin list everywhere instead of only from process lookups, so they no longer surface as unselectable entries. The permissions view and contract versions keep showing them, since those describe what is installed on-chain. Contract updates also no longer offer plugins whose interface type cannot be matched to a known repository, which previously crashed the update dialog

--- a/.changeset/fresh-alchemix-objections.md
+++ b/.changeset/fresh-alchemix-objections.md
@@ -1,5 +1,0 @@
----
-"@aragon/app": patch
----
-
-Polish Alchemix objection voting and refresh its recorded state after vote indexing.

--- a/.github/workflows/app-release-pr-finalize.yml
+++ b/.github/workflows/app-release-pr-finalize.yml
@@ -160,7 +160,7 @@ jobs:
         uses: ./.github/actions/gh-ensure-release
         with:
           tag: ${{ steps.release-tag.outputs.name }}
-          title: Release ${{ steps.release-tag.outputs.name }}
+          title: ${{ steps.release-tag.outputs.name }}
           notes_path: ${{ steps.notes.outputs.path }}
           token: ${{ steps.secrets.outputs.ARABOT_PAT }}
 

--- a/.github/workflows/assistant-release-pr-finalize.yml
+++ b/.github/workflows/assistant-release-pr-finalize.yml
@@ -147,6 +147,6 @@ jobs:
         uses: ./.github/actions/gh-ensure-release
         with:
           tag: ${{ steps.release-tag.outputs.name }}
-          title: Release ${{ steps.release-tag.outputs.name }}
+          title: ${{ steps.release-tag.outputs.name }}
           notes_path: ${{ steps.notes.outputs.path }}
           token: ${{ steps.secrets.outputs.ARABOT_PAT }}

--- a/apps/app/CHANGELOG.md
+++ b/apps/app/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @aragon/app
 
+## 1.37.1
+
+### Patch Changes
+
+- [#1303](https://github.com/aragon/app/pull/1303) [`acb5001`](https://github.com/aragon/app/commit/acb5001b3153ca47e34e4c718ffd070bf7b25e20) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Iterate the support assistant on design feedback: the panel header carries the Aragon mark and names the request being drafted or created, the ticket card leads with the ticket title instead of a "Review your request" label, spent drafts collapse into a quiet line, past requests move from the greeting into their own view reached from under the composer, and the mail escape hatch becomes a footnote there. The transcript opens with a time divider, and the navigation trigger withdraws while the panel is open — the panel collapses through its own chevron.
+
+- [#1312](https://github.com/aragon/app/pull/1312) [`a718058`](https://github.com/aragon/app/commit/a71805829ce8c79367c51d2b08673b18824aa922) Thanks [@harryburger](https://github.com/harryburger)! - Handle plugins with an unresolved interface type consistently: they are now dropped from the plugin list everywhere instead of only from process lookups, so they no longer surface as unselectable entries. The permissions view and contract versions keep showing them, since those describe what is installed on-chain. Contract updates also no longer offer plugins whose interface type cannot be matched to a known repository, which previously crashed the update dialog
+
+- [#1322](https://github.com/aragon/app/pull/1322) [`4399ebc`](https://github.com/aragon/app/commit/4399ebcea692d9ce3c3fbded3539deb88eb204c3) Thanks [@evanaronson](https://github.com/evanaronson)! - Polish Alchemix objection voting and refresh its recorded state after vote indexing.
+
+- Updated dependencies [[`acb5001`](https://github.com/aragon/app/commit/acb5001b3153ca47e34e4c718ffd070bf7b25e20), [`acb5001`](https://github.com/aragon/app/commit/acb5001b3153ca47e34e4c718ffd070bf7b25e20)]:
+    - @aragon/assistant-chat@0.4.0
+
 ## 1.37.0
 
 ### Minor Changes

--- a/apps/app/e2e/setup/wallet.setup.ts
+++ b/apps/app/e2e/setup/wallet.setup.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
+import type { Page } from '@playwright/test';
 import { defineWalletSetup } from '@synthetixio/synpress';
-import { getExtensionId, MetaMask } from '@synthetixio/synpress/playwright';
+import { getExtensionId } from '@synthetixio/synpress/playwright';
 import dotenv from 'dotenv';
 import { WALLET_SETUP_CACHE_KEY } from './walletCacheKey.mjs';
 
@@ -15,36 +16,115 @@ if (!SEED_PHRASE || !PASSWORD) {
     );
 }
 
-const walletSetup = defineWalletSetup(PASSWORD, async (context, walletPage) => {
-    const extensionId = await getExtensionId(context, 'MetaMask');
-    const metamask = new MetaMask(context, walletPage, PASSWORD, extensionId);
+const SRP_ATTEMPTS = 3;
+const TOGGLE_ATTEMPTS = 3;
 
-    await metamask.importWallet(SEED_PHRASE);
+/**
+ * Imports the wallet through the MetaMask onboarding flow (same steps as
+ * synpress's MetaMask.importWallet, inlined to make the SRP entry retryable).
+ *
+ * MetaMask splits the typed phrase into per-word inputs and re-renders while
+ * typing, which occasionally drops words and leaves the Continue button
+ * disabled — so the phrase is retyped from scratch until it validates.
+ */
+const importWalletOnboarding = async (walletPage: Page) => {
+    await walletPage.getByTestId('onboarding-import-wallet').click();
+    await walletPage.getByTestId('onboarding-import-with-srp-button').click();
 
-    const homeUrl = `chrome-extension://${extensionId}/home.html`;
+    const confirmButton = walletPage.getByTestId('import-srp-confirm');
 
-    // MetaMask extension pages render asynchronously after navigation;
-    // no DOM event reliably signals readiness, so brief pauses are required.
-    await walletPage.goto(homeUrl);
-    await walletPage.waitForTimeout(2000);
+    for (let attempt = 1; attempt <= SRP_ATTEMPTS; attempt++) {
+        await walletPage
+            .getByTestId('srp-input-import__srp-note')
+            .type(SEED_PHRASE, { delay: 25 });
 
-    // MetaMask may show a lock screen if the session expired during import.
-    const lockInput = walletPage.locator('[data-testid="unlock-password"]');
-    if (await lockInput.isVisible().catch(() => false)) {
-        await lockInput.fill(PASSWORD);
-        await walletPage.locator('[data-testid="unlock-submit"]').click();
-        await walletPage.waitForTimeout(2000);
+        // Poll instead of waitFor: the button is present but disabled, and
+        // whether it ever enables depends on the typed phrase being complete.
+        const deadline = Date.now() + 5000;
+        let enabled = false;
+        while (!enabled && Date.now() < deadline) {
+            enabled = await confirmButton.isEnabled();
+            if (!enabled) {
+                await walletPage.waitForTimeout(250);
+            }
+        }
+        if (enabled) {
+            break;
+        }
+        if (attempt === SRP_ATTEMPTS) {
+            throw new Error(
+                'MetaMask did not accept the secret recovery phrase (Continue stayed disabled)',
+            );
+        }
+        await walletPage.getByText('Clear all').click();
+        await walletPage.waitForTimeout(500);
     }
 
-    const openWalletBtn = walletPage.locator(
-        '[data-testid="onboarding-complete-done"]',
-    );
-    if (await openWalletBtn.isVisible().catch(() => false)) {
-        await openWalletBtn.click();
-        await walletPage.waitForTimeout(3000);
-    }
+    await confirmButton.click();
 
-    // Enable test networks in Advanced settings.
+    await walletPage
+        .locator('[data-testid="create-password-new-input"]')
+        .type(PASSWORD, { delay: 20 });
+    await walletPage
+        .locator('[data-testid="create-password-confirm-input"]')
+        .type(PASSWORD, { delay: 20 });
+    await walletPage.locator('[data-testid="create-password-terms"]').click();
+    await walletPage.locator('[data-testid="create-password-submit"]').click();
+
+    // The post-password screens vary between runs (metametrics opt-in,
+    // completion page, or a lock screen when the session expires mid-flow).
+    // Handle whichever appears until the UI settles instead of assuming a
+    // fixed order.
+    const isVisible = (selector: string) =>
+        walletPage
+            .locator(selector)
+            .isVisible()
+            .catch(() => false);
+
+    const deadline = Date.now() + 60_000;
+    let quietChecks = 0;
+    let disabledDoneChecks = 0;
+    while (quietChecks < 5 && Date.now() < deadline) {
+        if (await isVisible('#metametrics-opt-in')) {
+            await walletPage.locator('#metametrics-opt-in').click();
+            await walletPage
+                .locator('[data-testid="metametrics-i-agree"]')
+                .click();
+            quietChecks = 0;
+        } else if (await isVisible('[data-testid="unlock-password"]')) {
+            await walletPage
+                .locator('[data-testid="unlock-password"]')
+                .fill(PASSWORD);
+            await walletPage.locator('[data-testid="unlock-submit"]').click();
+            quietChecks = 0;
+        } else if (
+            await isVisible('[data-testid="onboarding-complete-done"]')
+        ) {
+            const doneButton = walletPage.locator(
+                '[data-testid="onboarding-complete-done"]',
+            );
+            if (await doneButton.isEnabled().catch(() => false)) {
+                await doneButton.click();
+                disabledDoneChecks = 0;
+            } else if (++disabledDoneChecks >= 10) {
+                // The "Open wallet" button can stay disabled while the "Pin the
+                // extension" tooltip is shown; reloading home.html gets past it.
+                break;
+            }
+            quietChecks = 0;
+        } else {
+            quietChecks++;
+        }
+        await walletPage.waitForTimeout(1000);
+    }
+};
+
+/**
+ * Enables the "Show test networks" toggle in Advanced settings. The click
+ * occasionally does not register in CI, so it is retried until the toggle
+ * actually flips.
+ */
+const enableTestNetworks = async (walletPage: Page, homeUrl: string) => {
     await walletPage.goto(`${homeUrl}#settings/advanced`);
     await walletPage.waitForTimeout(2000);
 
@@ -55,17 +135,76 @@ const walletSetup = defineWalletSetup(PASSWORD, async (context, walletPage) => {
         .click();
     await walletPage.waitForTimeout(1000);
 
-    // MetaMask toggle — CSS class selector is version-dependent.
+    // MetaMask reuses this testid for both the "Show conversion on test networks"
+    // and "Show test networks" rows; :not(.show-fiat-on-testnets-toggle) picks the latter.
     const offToggle = walletPage.locator(
         '[data-testid="advanced-setting-show-testnet-conversion"] label.toggle-button--off:not(.show-fiat-on-testnets-toggle)',
     );
-    if ((await offToggle.count()) > 0) {
+    const onToggle = walletPage.locator(
+        '[data-testid="advanced-setting-show-testnet-conversion"] label.toggle-button--on:not(.show-fiat-on-testnets-toggle)',
+    );
+
+    for (let attempt = 1; attempt <= TOGGLE_ATTEMPTS; attempt++) {
+        if ((await offToggle.count()) === 0) {
+            return;
+        }
         await offToggle.click();
+        const flipped = await onToggle
+            .waitFor({ state: 'visible', timeout: 5000 })
+            .then(() => true)
+            .catch(() => false);
+        if (flipped) {
+            return;
+        }
+    }
+
+    throw new Error(
+        'Failed to enable the "Show test networks" toggle in MetaMask Advanced settings',
+    );
+};
+
+const walletSetup = defineWalletSetup(PASSWORD, async (context, walletPage) => {
+    try {
+        await importWalletOnboarding(walletPage);
+
+        const extensionId = await getExtensionId(context, 'MetaMask');
+        const homeUrl = `chrome-extension://${extensionId}/home.html`;
+
+        // MetaMask extension pages render asynchronously after navigation;
+        // no DOM event reliably signals readiness, so brief pauses are required.
+        await walletPage.goto(homeUrl);
+        await walletPage.waitForTimeout(2000);
+
+        // MetaMask may show a lock screen if the session expired during import.
+        const lockInput = walletPage.locator('[data-testid="unlock-password"]');
+        if (await lockInput.isVisible().catch(() => false)) {
+            await lockInput.fill(PASSWORD);
+            await walletPage.locator('[data-testid="unlock-submit"]').click();
+            await walletPage.waitForTimeout(2000);
+        }
+
+        const openWalletBtn = walletPage.locator(
+            '[data-testid="onboarding-complete-done"]',
+        );
+        if (
+            (await openWalletBtn.isVisible().catch(() => false)) &&
+            (await openWalletBtn.isEnabled().catch(() => false))
+        ) {
+            await openWalletBtn.click();
+            await walletPage.waitForTimeout(3000);
+        }
+
+        await enableTestNetworks(walletPage, homeUrl);
+    } catch (error) {
+        // The cache-creation step uploads no Playwright traces; a screenshot in
+        // e2e/test-results/ lands in the CI artifact and shows what MetaMask displayed.
         await walletPage
-            .locator(
-                '[data-testid="advanced-setting-show-testnet-conversion"] label.toggle-button--on:not(.show-fiat-on-testnets-toggle)',
-            )
-            .waitFor({ state: 'visible', timeout: 5000 });
+            .screenshot({
+                path: 'e2e/test-results/wallet-setup-failure.png',
+                fullPage: true,
+            })
+            .catch(() => undefined);
+        throw error;
     }
 });
 

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/app",
-    "version": "1.37.0",
+    "version": "1.37.1",
     "description": "Human-centered DAO infrastructure",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",

--- a/packages/assistant-chat/CHANGELOG.md
+++ b/packages/assistant-chat/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aragon/assistant-chat
 
+## 0.4.0
+
+### Minor Changes
+
+- [#1303](https://github.com/aragon/app/pull/1303) [`acb5001`](https://github.com/aragon/app/commit/acb5001b3153ca47e34e4c718ffd070bf7b25e20) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Iterate the support assistant on design feedback: the panel header carries the Aragon mark and names the request being drafted or created, the ticket card leads with the ticket title instead of a "Review your request" label, spent drafts collapse into a quiet line, past requests move from the greeting into their own view reached from under the composer, and the mail escape hatch becomes a footnote there. The transcript opens with a time divider, and the navigation trigger withdraws while the panel is open — the panel collapses through its own chevron.
+
+### Patch Changes
+
+- [#1303](https://github.com/aragon/app/pull/1303) [`acb5001`](https://github.com/aragon/app/commit/acb5001b3153ca47e34e4c718ffd070bf7b25e20) Thanks [@tyhonchik](https://github.com/tyhonchik)! - Send the name and type of an attachment with the conversation (never its bytes), so the assistant can say where a file arrived. The panel header now carries the exact height of the app's navigation bar, so the two bottom borders meet in a line rather than a step, and every control in the widget points at the cursor.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/assistant-chat/package.json
+++ b/packages/assistant-chat/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aragon/assistant-chat",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Support-chat widget for the Aragon App, backed by the Aragon assistant service",
     "author": "Aragon Association",
     "homepage": "https://github.com/aragon/app#readme",


### PR DESCRIPTION
## ⚠️ Open tickets
- [APP-1004: AI assistant iteration based on feedback](https://linear.app/aragon/issue/APP-1004/ai-assistant-iteration-based-on-feedback) — QA

## Features
- [APP-1004: AI assistant iteration based on feedback](https://linear.app/aragon/issue/APP-1004/ai-assistant-iteration-based-on-feedback) ([#1303](https://github.com/aragon/app/pull/1303))
- [APP-1035: Transaction basic action does not init amount properly when asset is not in DAO](https://linear.app/aragon/issue/APP-1035/transaction-basic-action-does-not-init-amount-properly-when-asset-is) ([#1312](https://github.com/aragon/app/pull/1312))

## Fixes
- [APP-986: Support the Alchemix objection plugin](https://linear.app/aragon/issue/APP-986/support-the-alchemix-objection-plugin) ([#1322](https://github.com/aragon/app/pull/1322))
- fix(release): harden the e2e wallet setup, drop the Release prefix from GitHub Release titles
- fix(ci): restore the preview deployment URL and fail loudly when it is lost ([#1320](https://github.com/aragon/app/pull/1320))

## Other Changes
- [APP-1028: Automated release improvements based on July 31 retro](https://linear.app/aragon/issue/APP-1028/automated-release-improvements-based-on-july-31-retro) ([#1318](https://github.com/aragon/app/pull/1318))
- chore: Bump dorny/paths-filter from 3.0.2 to 4.0.3 ([#1315](https://github.com/aragon/app/pull/1315))
- chore: Bump aragon/github-templates/steps/credential-retrieval ([#1316](https://github.com/aragon/app/pull/1316))



<!-- slack_ts: 1787073631.043299 -->
