### PR TITLE
fix(APP-1095): Keep XMAQUINA DAO header below navigation

### DIFF
--- a/.changeset/app-1095-xmaquina-header-layering.md
+++ b/.changeset/app-1095-xmaquina-header-layering.md
@@ -1,0 +1,5 @@
+---
+"@aragon/app": patch
+---
+
+Keep XMAQUINA DAO header content below the navigation bar

--- a/apps/app/src/daos/xmaquina/components/xmaquinaPageHeader/xmaquinaPageHeader.tsx
+++ b/apps/app/src/daos/xmaquina/components/xmaquinaPageHeader/xmaquinaPageHeader.tsx
@@ -31,7 +31,7 @@ export const XmaquinaPageHeader: React.FC<IXmaquinaPageHeaderProps> = (
     return (
         <header
             className={classNames(
-                'relative flex flex-col justify-between overflow-hidden md:h-114',
+                'relative isolate flex flex-col justify-between overflow-hidden md:h-114',
                 twkEverett.className,
                 className,
             )}


### PR DESCRIPTION
# Description

Fixes [APP-1095](https://linear.app/aragon/issue/APP-1095/xmaquina-dao-header-layering-issue).

The sticky DAO navigation and the XMAQUINA action content both use `z-10`. Because the XMAQUINA header did not establish a stacking context, its later-rendered descendants competed with the navbar in the root stacking context and painted above it. Adding `isolate` makes the header an atomic stacking context: action text and icons retain their internal layering while the navbar layers above the complete header.

This also adds the required `@aragon/app` patch changeset.

## Type of Change

- [x] Patch: Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality in a preview or locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisfied
- [x] Confirmed there are no new warnings on automated tests
- [x] Merged and published any dependent changes in downstream modules
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the Files Changed in Github’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] (For User Stories only) Tested in a preview or locally that all Acceptance Criteria are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project

## Verification

- `pnpm type-check`
- `biome check apps/app/src/daos/xmaquina/components/xmaquinaPageHeader/xmaquinaPageHeader.tsx`
- `pnpm validate:changesets`
- `pnpm changeset status --since origin/main`
- `git diff --check origin/main...HEAD`

All commands pass. No new test cases were added, as requested. Manual browser smoke testing and console inspection remain for the preview deployment, so this PR is draft.

## Explicit non-changes and risk

- No shared navbar z-index changes
- No changes to the action components' internal z-indexes
- No test changes
- No `.gitignore` changes
- Low risk: `isolate` changes only the XMAQUINA header's stacking-context boundary and does not affect layout

## Learning decision

No durable rule update: the existing Cryptex custom header already demonstrates the isolated stacking-context pattern.